### PR TITLE
Update to comm/message handling and enumerations.  Example handlings

### DIFF
--- a/src/wh_comm.c
+++ b/src/wh_comm.c
@@ -30,8 +30,8 @@ int wh_CommClient_Init(whCommClient* context, const whCommClientConfig* config)
                 config->transport_config);
     }
     if (rc == 0) {
-        context->hdr = (whHeader*)(&context->packet[0]);
-        context->data = (void*)(&context->packet[WOLFHSM_COMM_HEADER_LEN]);
+        context->hdr = (whCommHeader*)(&context->packet[0]);
+        context->data = (void*)(&context->packet[WM_COMM_HEADER_LEN]);
         context->initialized = 1;
     }
     return rc;
@@ -41,7 +41,7 @@ int wh_CommClient_Init(whCommClient* context, const whCommClientConfig* config)
  * sequence number will be incremented on transport success.
  */
 int wh_CommClient_SendRequest(whCommClient* context,
-        uint16_t magic, uint16_t type, uint16_t *out_seq,
+        uint16_t magic, uint16_t kind, uint16_t *out_seq,
         uint16_t data_size, const void* data)
 {
     int rc = WH_ERROR_NOTREADY;
@@ -56,7 +56,7 @@ int wh_CommClient_SendRequest(whCommClient* context,
         (context->transport_cb->Send != NULL)) {
 
         context->hdr->magic = magic;
-        context->hdr->type = wh_Translate16(magic, type);
+        context->hdr->kind = wh_Translate16(magic, kind);
         context->hdr->seq = wh_Translate16(magic, context->seq + 1);
         if ((data != NULL) && (data_size != 0)) {
             memcpy(context->data, data, data_size);
@@ -76,12 +76,12 @@ int wh_CommClient_SendRequest(whCommClient* context,
  * of the buffer.
  */
 int wh_CommClient_RecvResponse(whCommClient* context,
-        uint16_t* out_magic, uint16_t* out_type, uint16_t* out_seq,
+        uint16_t* out_magic, uint16_t* out_kind, uint16_t* out_seq,
         uint16_t* out_size, void* data)
 {
     int rc = WH_ERROR_NOTREADY;
     uint16_t magic = 0;
-    uint16_t type = 0;
+    uint16_t kind = 0;
     uint16_t seq = 0;
     uint16_t size = sizeof(context->packet);
 
@@ -101,13 +101,13 @@ int wh_CommClient_RecvResponse(whCommClient* context,
             if (size >= sizeof(*context->hdr)) {
                 size -= sizeof(*context->hdr);
                 magic = context->hdr->magic;
-                type = wh_Translate16(magic, context->hdr->type);
+                kind = wh_Translate16(magic, context->hdr->kind);
                 seq = wh_Translate16(magic, context->hdr->seq);
                 if ((data != NULL) && (size != 0)) {
                     memcpy(data, context->data, size);
                 }
                 if (out_magic != NULL) *out_magic = magic;
-                if (out_type != NULL) *out_type = type;
+                if (out_kind != NULL) *out_kind = kind;
                 if (out_seq != NULL) *out_seq = seq;
                 if (out_size != NULL) *out_size = size;
             } else {
@@ -160,20 +160,20 @@ int wh_CommServer_Init(whCommServer* context, const whCommServerConfig* config)
                 config->transport_config);
     }
     if (rc == 0) {
-        context->hdr = (whHeader*)(&context->packet[0]);
-        context->data = (void*)(&context->packet[WOLFHSM_COMM_HEADER_LEN]);
+        context->hdr = (whCommHeader*)(&context->packet[0]);
+        context->data = (void*)(&context->packet[WM_COMM_HEADER_LEN]);
         context->initialized = 1;
     }
     return rc;
 }
 
 int wh_CommServer_RecvRequest(whCommServer* context,
-        uint16_t* out_magic, uint16_t* out_type, uint16_t* out_seq,
+        uint16_t* out_magic, uint16_t* out_kind, uint16_t* out_seq,
         uint16_t* out_size, void* data)
 {
     int rc = WH_ERROR_NOTREADY;
     uint16_t magic = 0;
-    uint16_t type = 0;
+    uint16_t kind = 0;
     uint16_t seq = 0;
     uint16_t size = sizeof(context->packet);
 
@@ -194,14 +194,14 @@ int wh_CommServer_RecvRequest(whCommServer* context,
 
                 size -= sizeof(*context->hdr);
                 magic = context->hdr->magic;
-                type = wh_Translate16(magic, context->hdr->type);
+                kind = wh_Translate16(magic, context->hdr->kind);
                 seq = wh_Translate16(magic, context->hdr->seq);
 
                 if ((data != NULL) && (size != 0)) {
                     memcpy(data, context->data, size);
                 }
                 if (out_magic != NULL) *out_magic = magic;
-                if (out_type != NULL) *out_type = type;
+                if (out_kind != NULL) *out_kind = kind;
                 if (out_seq != NULL) *out_seq = seq;
                 if (out_size != NULL) *out_size = size;
             } else {
@@ -214,7 +214,7 @@ int wh_CommServer_RecvRequest(whCommServer* context,
 }
 
 int wh_CommServer_SendResponse(whCommServer* context,
-        uint16_t magic, uint16_t type, uint16_t seq,
+        uint16_t magic, uint16_t kind, uint16_t seq,
         uint16_t data_size, const void* data)
 {
     int rc = WH_ERROR_NOTREADY;
@@ -228,7 +228,7 @@ int wh_CommServer_SendResponse(whCommServer* context,
         (context->transport_cb->Send != NULL)) {
 
         context->hdr->magic = magic;
-        context->hdr->type = wh_Translate16(magic, type);
+        context->hdr->kind = wh_Translate16(magic, kind);
         context->hdr->seq = wh_Translate16(magic, seq);
         if ((data != NULL) && (data_size != 0)) {
             memcpy(context->data, data, data_size);

--- a/wolfhsm/wh_client.h
+++ b/wolfhsm/wh_client.h
@@ -56,7 +56,7 @@ struct whClientContext_t {
     int inited;
     whCommClient comm[1];
     uint16_t last_req_id;
-    uint16_t last_type;
+    uint16_t last_req_kind;
 #if 0
     whNvmClient* nvm;
     whKeyClient* key;
@@ -96,6 +96,13 @@ typedef struct whClientConfig_t whClientConfig;
 
 int wh_Client_Init(whClient* c, const whClientConfig* config);
 int wh_Client_Cleanup(whClient* c);
+
+int wh_Client_SendRequest(whClient* c,
+        uint16_t group, uint16_t action,
+        uint16_t data_size, const void* data);
+int wh_Client_RecvResponse(whClient *c,
+        uint16_t *out_group, uint16_t *out_action,
+        uint16_t *out_size, void* data);
 
 int wh_Client_EchoRequest(whClient* c, uint16_t size, const void* data);
 int wh_Client_EchoResponse(whClient* c, uint16_t *out_size, void* data);

--- a/wolfhsm/wh_comm.h
+++ b/wolfhsm/wh_comm.h
@@ -1,26 +1,21 @@
 /*
- * wolfhsm/comm.h
+ * wolfhsm/wh_comm.h
  *
  * Library to provide client to server requests and server to client responses.
  * Fundamentally, communications are reliable, bidirectional, and packet-based
  * with a fixed MTU.  Packets are delivered in-order without any intrinsic
  * queuing nor OOB support.  Transports deliver complete packets up to the MTU
- * size and provide the number of bytes received as metadata.
+ * size and provide the number of bytes received.
  *
  * Note: Multibyte data will be passed in native order, which means clients and
  * servers must be the SAME endianess or will be required to translate data
- * elements in messages.
- *
- * Provided exmaple transports are:
- *  - shared memory (transport_shm)
- *  - UNIX domain socket (transport_unix)
- *  - TCP streaming socket (transport_tcp)
+ * elements in messages.  Translate helper functions are provided here and used
+ * to interpret header fields.
  *
  * All functions return an integer value with 0 meaning success and !=0 an error
- * enumerated either within wolfssl/wolfcrypt/error-crypt.h or in the function
- * comments.  Unless otherwise noted, all functions are non-blocking and each
- * may update the context state or perform other bookkeeping actions as
- * necessary.
+ * enumerated either within wolfhsm/wh_error.h.  Unless otherwise noted, all
+ * functions are non-blocking and each may update the context state or perform
+ * other bookkeeping actions as necessary.
  */
 
 #ifndef WOLFHSM_WH_COMM_H_
@@ -35,9 +30,9 @@
  * DATA_LEN bytes.
  */
 enum {
-    WOLFHSM_COMM_HEADER_LEN = 8,
-    WOLFHSM_COMM_DATA_LEN = 1280,
-    WOLFHSM_COMM_MTU = (WOLFHSM_COMM_HEADER_LEN + WOLFHSM_COMM_DATA_LEN)
+    WM_COMM_HEADER_LEN = 8,    /* whCommHeader */
+    WH_COMM_DATA_LEN = 1280,
+    WH_COMM_MTU = (WM_COMM_HEADER_LEN + WH_COMM_DATA_LEN)
 };
 
 /* Support for endian and version differences */
@@ -58,14 +53,26 @@ enum {
 /* Header for a packet, request or response. On-the-wire format */
 typedef struct {
     uint16_t magic;     /* Endian marker with version */
-    uint16_t type;      /* Type of packet.  Enumerated in message.h */
+    uint16_t kind;      /* Kind of packet.  Enumerated in message.h */
     uint16_t seq;       /* Sequence number. Incremented on request, copied for
                          * response. */
     uint16_t aux;       /* Session identifier for request or error indicator
                          * for response. */
-} whHeader;
+} whCommHeader;
 /* static_assert(sizeof_whHeader == WOLFHSM_COMM_HEADER_LEN,
-                 "Size of whHeader doesn't match WOLFHSM_COMM_HEADER_LEN") */
+                 "Size of whCommHeader doesn't match WOLFHSM_COMM_HEADER_LEN") */
+
+enum {
+    WH_COMM_AUX_REQ_NORMAL      = 0x0000, /* Normal request. No session */
+    /* Request Aux values 1-0xFFFE are session ids */
+    WH_COMM_AUX_REQ_NORESP      = 0xFFFF, /* Async request without response*/
+
+    WH_COMM_AUX_RESP_OK         = 0x0000, /* Response is valid */
+    WH_COMM_AUX_RESP_ERROR      = 0x0001, /* Request failed with error */
+    WH_COMM_AUX_RESP_FATAL      = 0xFFFE, /* Server condition is fatal */
+    WH_COMM_AUX_RESP_UNSUPP     = 0xFFFF, /* Request is not supported */
+};
+
 
 static inline uint8_t wh_Translate8(uint16_t magic, uint8_t val)
 {
@@ -120,8 +127,8 @@ typedef struct {
     uint16_t reqid;
     uint16_t seq;
     uint16_t size;
-    uint8_t packet[WOLFHSM_COMM_MTU];
-    whHeader* hdr;
+    uint8_t packet[WH_COMM_MTU];
+    whCommHeader* hdr;
     uint8_t* data;
     uint32_t client_id;
     uint32_t server_id;
@@ -139,14 +146,14 @@ int wh_CommClient_Init(whCommClient* context, const whCommClientConfig* config);
  * transport will update the sequence number on success.
  */
 int wh_CommClient_SendRequest(whCommClient* context,
-        uint16_t magic, uint16_t type, uint16_t* out_seq,
+        uint16_t magic, uint16_t kind, uint16_t* out_seq,
         uint16_t data_size, const void* data);
 
 /* If a response packet has been buffered, get the header and copy the data out
  * of the buffer.
  */
 int wh_CommClient_RecvResponse(whCommClient* context,
-        uint16_t* out_magic, uint16_t* out_type, uint16_t* out_seq,
+        uint16_t* out_magic, uint16_t* out_kind, uint16_t* out_seq,
         uint16_t* out_size, void* data);
 
 /* Inform the server that no further communications are necessary and any
@@ -170,8 +177,8 @@ typedef struct {
     void* transport_context;
     const whTransportServerCb* transport_cb;
     uint16_t reqid;
-    uint8_t packet[WOLFHSM_COMM_MTU];
-    whHeader* hdr;
+    uint8_t packet[WH_COMM_MTU];
+    whCommHeader* hdr;
     uint8_t* data;
     uint32_t client_id;
     uint32_t server_id;
@@ -188,7 +195,7 @@ int wh_CommServer_Init(whCommServer* context, const whCommServerConfig* config);
  * of the buffer.
  */
 int wh_CommServer_RecvRequest(whCommServer* context,
-        uint16_t* out_magic, uint16_t* out_type, uint16_t* out_seq,
+        uint16_t* out_magic, uint16_t* out_kind, uint16_t* out_seq,
         uint16_t* out_size, void* buffer);
 
 /* Upon completion of the request, send the response packet using the same seq
@@ -196,7 +203,7 @@ int wh_CommServer_RecvRequest(whCommServer* context,
  * used for asynchronous notifications, such as keep-alive or close.
  */
 int wh_CommServer_SendResponse(whCommServer* context,
-        uint16_t magic, uint16_t type, uint16_t seq,
+        uint16_t magic, uint16_t kind, uint16_t seq,
         uint16_t data_size, const void* data);
 
 int wh_CommServer_Cleanup(whCommServer* context);

--- a/wolfhsm/wh_message.h
+++ b/wolfhsm/wh_message.h
@@ -1,44 +1,40 @@
 /*
- * wolfhsm/message.h
+ * wolfhsm/wh_message.h
  *
- * Basic message structure assuming a reliable comm transport with metadata
- * support of 16-bit type.
+ * Message groups and actions for dispatch and handling based on a 16-bit kind.
  */
 
 #ifndef WOLFHSM_WH_MESSAGE_H_
 #define WOLFHSM_WH_MESSAGE_H_
 
-/* Message type and groups */
+/* Message groups and kind */
 enum {
-    WOLFHSM_MESSAGE_TYPE_MASK           = 0xFF, /* 256 total types */
-    WOLFHSM_MESSAGE_TYPE_NONE           = 0x00, /* No message type */
+    WH_MESSAGE_KIND_NONE            = 0x0000, /* No message kind. Invalid */
 
-    WOLFHSM_MESSAGE_AUX_REQ_NORMAL      = 0x00, /* Normal request */
-    WOLFHSM_MESSAGE_AUX_REQ_NORESP      = 0x01, /* Request without response*/
-    WOLFHSM_MESSAGE_AUX_REQ_SESSION     = 0x02, /* Request within session*/
+    WH_MESSAGE_GROUP_MASK           = 0xFF00, /* 255 groups */
+    WH_MESSAGE_GROUP_NONE           = 0x0000, /* No group.  Invalid. */
 
-    WOLFHSM_MESSAGE_AUX_RESP_OK         = 0x00, /* Response is valid */
-    WOLFHSM_MESSAFE_AUX_RESP_ERROR      = 0x01, /* Request failed with error */
-    WOLFHSM_MESSAGE_AUX_RESP_UNSUPP     = 0xFF, /* Request is not supported */
-    WOLFHSM_MESSAGE_AUX_RESP_FATAL      = 0xFE, /* Server condition is fatal */
+    WH_MESSAGE_GROUP_COMM           = 0x0100, /* Messages used for comms */
+    WH_MESSAGE_GROUP_NVM            = 0x0200, /* NVM functions */
+    WH_MESSAGE_GROUP_KEY            = 0x0300, /* Key/counter management */
+    WH_MESSAGE_GROUP_CRYPTO         = 0x0400, /* wolfCrypt CryptoCb */
+    WH_MESSAGE_GROUP_IMAGE          = 0x0500, /* Image/boot management */
+    WH_MESSAGE_GROUP_PKCS11         = 0x0600, /* PKCS11 protocol */
+    WH_MESSAGE_GROUP_SHE            = 0x0700, /* SHE protocol */
+    WH_MESSAGE_GROUP_CUSTOM         = 0x1000, /* User-specified features */
 
-    WOLFHSM_MESSAGE_GROUP_MASK          = 0xE0, /* 32 entries per group */
-    WOLFHSM_MESSAGE_GROUP_COMM          = 0x00, /* Messages used for comms */
-    WOLFHSM_MESSAGE_GROUP_NVM           = 0x20, /* NVM functions */
-    WOLFHSM_MESSAGE_GROUP_KEY           = 0x40, /* Key/counter management */
-    WOLFHSM_MESSAGE_GROUP_CRYPTO        = 0x60, /* wolfCrypt CryptoCb */
-    WOLFHSM_MESSAGE_GROUP_IMAGE         = 0x80, /* Image/boot management */
-    WOLFHSM_MESSAGE_GROUP_PKCS11        = 0xA0, /* PKCS11 protocol */
-    WOLFHSM_MESSAGE_GROUP_SHE           = 0xC0, /* SHE protocol */
-    WOLFHSM_MESSAGE_GROUP_CUSTOM        = 0xE0, /* User-specified features */
+    WH_MESSAGE_ACTION_MASK         = 0x00FF, /* 255 subtypes per group*/
+    WH_MESSAGE_ACTION_NONE         = 0x0000, /* No action. Invalid. */
 };
 
-typedef struct {
-    int return_code;
-} whMessage_ErrorResponse;
+/* Construct the message kind based on group and action */
+#define WH_MESSAGE_KIND(_G, _S) (   ((_G) & WH_MESSAGE_GROUP_MASK) |      \
+                                    ((_S) & WH_MESSAGE_ACTION_MASK))
 
-int whMessage_GetErrorResponse(uint16_t magic,
-        const void* data,
-        int *out_return_code);
+/* Extract the group from the message kind */
+#define WH_MESSAGE_GROUP(_K)        ((_K) & WH_MESSAGE_GROUP_MASK)
+
+/* Extract the action from the message kind */
+#define WH_MESSAGE_ACTION(_K)      ((_K) & WH_MESSAGE_ACTION_MASK)
 
 #endif /* WOLFHSM_WH_MESSAGE_H_ */

--- a/wolfhsm/wh_message_comm.h
+++ b/wolfhsm/wh_message_comm.h
@@ -1,5 +1,7 @@
 /*
- * wolfhsm/message_comm.h
+ * wolfhsm/wh_message_comm.h
+ *
+ * Comm component message action enumerations and definitions.
  *
  */
 
@@ -8,16 +10,36 @@
 
 #include <stdint.h>
 
-#include "wolfhsm/wh_message.h"
-
+/* Comm component message kinds */
 enum {
-    WOLFHSM_MESSAGE_TYPE_COMM_NONE      = WOLFHSM_MESSAGE_GROUP_COMM + 0x00,
-    WOLFHSM_MESSAGE_TYPE_COMM_INIT      = WOLFHSM_MESSAGE_GROUP_COMM + 0x01,
-    WOLFHSM_MESSAGE_TYPE_COMM_KEEPALIVE = WOLFHSM_MESSAGE_GROUP_COMM + 0x02,
-    WOLFHSM_MESSAGE_TYPE_COMM_CLOSE     = WOLFHSM_MESSAGE_GROUP_COMM + 0x03,
-    WOLFHSM_MESSAGE_TYPE_COMM_INFO      = WOLFHSM_MESSAGE_GROUP_COMM + 0x04,
-    WOLFHSM_MESSAGE_TYPE_COMM_ECHO      = WOLFHSM_MESSAGE_GROUP_COMM + 0x05,
+    WH_MESSAGE_COMM_ACTION_NONE      = 0x00,
+    WH_MESSAGE_COMM_ACTION_INIT      = 0x01,
+    WH_MESSAGE_COMM_ACTION_KEEPALIVE = 0x02,
+    WH_MESSAGE_COMM_ACTION_CLOSE     = 0x03,
+    WH_MESSAGE_COMM_ACTION_INFO      = 0x04,
+    WH_MESSAGE_COMM_ACTION_ECHO      = 0x05,
 };
+
+
+/* Generic error response message. */
+typedef struct {
+    int return_code;
+} whMessageComm_ErrorResponse;
+
+int wh_MessageComm_GetErrorResponse(uint16_t magic,
+        const void* data,
+        int *out_return_code);
+
+
+/* Generic len/data message that does not require data translation */
+typedef struct {
+    uint16_t len;
+    uint8_t data[WH_COMM_DATA_LEN - sizeof(uint16_t)];
+} whMessageCommLenData;
+
+int wh_MessageComm_TranslateLenData(uint16_t magic,
+        const whMessageCommLenData* src,
+        whMessageCommLenData* dest);
 
 typedef struct {
     uint32_t client_id;
@@ -36,17 +58,6 @@ typedef struct {
 int wh_MessageComm_TranslateInitRequest(uint16_t magic,
         const whMessageCommInitRequest* src,
         whMessageCommInitRequest* dest);
-
-/* Generic len/data message that does not require data translation */
-typedef struct {
-    uint16_t len;
-    uint8_t data[WOLFHSM_COMM_DATA_LEN - sizeof(uint16_t)];
-} whMessageCommLenData;
-
-int wh_MessageComm_TranslateLenData(uint16_t magic,
-        const whMessageCommLenData* src,
-        whMessageCommLenData* dest);
-
 
 /* Info request/response data */
 enum {


### PR DESCRIPTION
Update to expand message handling groups and actions.  Changed name of message type to message kind.  Changed message groups to no longer care about upper level kind enumeration and only deal with locally enumerated actions.

wh_comm provides 16-bit "kind" in whCommHeader to specify the type of the packet.  wh_message splits the kind into a "group" (loosely related to the server component doing the work) and "action" (specific action the client is asking the server to perform).

wh_client sends the request (header and data) in native format (no byte swapping) to the server.  wh_server interprets the first header field (magic) to understand if the client is in a different endianness and swaps the header fields to local.  wh_server then invokes the corresponding group handler with the action, data, and size.

The server handler then translates the specific message using custom struct conversion functions (declared in wh_message_XXX.h) if necessary.  The handler performs the requested action to generate a response packet.  The handler translates the response packet if necessary and sends the response back to the client.

The aux field is now defined to be used for future async and session handling, currently not populated.