### PR TITLE
Fix zeroed state variables on disk.

### DIFF
--- a/src/wh_nvm_flash.c
+++ b/src/wh_nvm_flash.c
@@ -19,7 +19,9 @@ enum {
     NF_COPY_OBJECT_BUFFER_LEN = 8 * WHFU_BYTES_PER_UNIT,
 };
 
-/* MSB's  of state variables */
+/* MSW of state variables (nfState) must be set to this pattern when written
+ * to flash to prevent hardware on certain chipsets from confusing zero values
+ * with erased flash */
 static const whFlashUnit BASE_STATE = 0x1234567800000000ull;
 
 /* On-flash layout of the state of an Object or Directory*/

--- a/src/wh_nvm_flash.c
+++ b/src/wh_nvm_flash.c
@@ -389,7 +389,7 @@ static int nfPartition_ProgramStart(whNvmFlashContext* context,
 static int nfPartition_ProgramCount(whNvmFlashContext* context,
         int partition, uint32_t count)
 {
-    whFlashUnit unit = BASE_STATE + count;
+    whFlashUnit unit = BASE_STATE | count;
 
     if ((context == NULL) || (context->cb == NULL)) {
         return WH_ERROR_BADARGS;

--- a/src/wh_nvm_flash.c
+++ b/src/wh_nvm_flash.c
@@ -19,6 +19,9 @@ enum {
     NF_COPY_OBJECT_BUFFER_LEN = 8 * WHFU_BYTES_PER_UNIT,
 };
 
+/* MSB's  of state variables */
+static const whFlashUnit BASE_STATE = 0x1234567800000000ull;
+
 /* On-flash layout of the state of an Object or Directory*/
 typedef struct {
     whFlashUnit epoch;   /* Not Erased: counter */
@@ -344,7 +347,7 @@ static int nfPartition_ReadMemDirectory(whNvmFlashContext* context, int partitio
 static int nfPartition_ProgramEpoch(whNvmFlashContext* context,
         int partition, uint32_t epoch)
 {
-    whFlashUnit unit = epoch;
+    whFlashUnit unit = BASE_STATE | epoch;
 
     if ((context == NULL) || (context->cb == NULL)) {
         return WH_ERROR_BADARGS;
@@ -362,7 +365,7 @@ static int nfPartition_ProgramEpoch(whNvmFlashContext* context,
 static int nfPartition_ProgramStart(whNvmFlashContext* context,
         int partition, uint32_t start)
 {
-    whFlashUnit unit = start;
+    whFlashUnit unit = BASE_STATE | start;
 
     if ((context == NULL) || (context->cb == NULL)) {
         return WH_ERROR_BADARGS;
@@ -380,7 +383,7 @@ static int nfPartition_ProgramStart(whNvmFlashContext* context,
 static int nfPartition_ProgramCount(whNvmFlashContext* context,
         int partition, uint32_t count)
 {
-    whFlashUnit unit = count;
+    whFlashUnit unit = BASE_STATE + count;
 
     if ((context == NULL) || (context->cb == NULL)) {
         return WH_ERROR_BADARGS;
@@ -458,8 +461,8 @@ static int nfObject_ProgramBegin(whNvmFlashContext* context, int partition,
 {
     int rc = 0;
     uint32_t object_offset = 0;
-    whFlashUnit state_epoch = epoch;
-    whFlashUnit state_start = start;
+    whFlashUnit state_epoch = BASE_STATE | epoch;
+    whFlashUnit state_start = BASE_STATE | start;
 
     if (    (context == NULL) ||
             (context->cb == NULL) ||
@@ -523,7 +526,7 @@ static int nfObject_ProgramFinish(whNvmFlashContext* context, int partition,
         int object_index, uint32_t byte_count)
 {
     uint32_t object_offset = 0;
-    whFlashUnit state_count = WHFU_BYTES2UNITS(byte_count);
+    whFlashUnit state_count = BASE_STATE | WHFU_BYTES2UNITS(byte_count);
 
     if ((context == NULL) || (context->cb == NULL)) {
         return WH_ERROR_BADARGS;

--- a/test/wh_config.h
+++ b/test/wh_config.h
@@ -1,7 +1,7 @@
 #ifndef WH_CONFIG_H_
 #define WH_CONFIG_H_
 
-//#define WH_CFG_TEST_VERBOSE
+#define WH_CFG_TEST_VERBOSE
 #define WH_CFG_TEST_POSIX
 
 #endif /* WH_CONFIG_H_*/

--- a/test/wh_test_nvm_flash.c
+++ b/test/wh_test_nvm_flash.c
@@ -245,17 +245,25 @@ int whTest_NvmFlashCfg(whNvmFlashConfig* cfg)
 #if defined(WH_CFG_TEST_VERBOSE)
     _ShowAvailable(cb, context);
     _ShowList(cb, context);
+#endif
+
     /* Ensure reclamation doesn't destroy active objects */
     {
         whNvmMetadata metaBuf = {0};
         unsigned char dataBuf[256];
 
+        printf("--Read IDs after reclaim\n");
         for (size_t i=0; i<sizeof(ids)/sizeof(ids[0]); i++) {
-            WH_TEST_ASSERT(0 == cb->Read(context, ids[i], 0, sizeof(dataBuf), dataBuf));
-           WH_TEST_ASSERT(0 == cb->GetMetadata(context, ids[i], &metaBuf));
+            if ((ret = cb->Read(context, ids[i], 0, sizeof(dataBuf), dataBuf)) != 0) {
+                WH_ERROR_PRINT("Read after reclaim returned %d\n", ret);
+                goto cleanup;
+            }
+            if ((ret = cb->GetMetadata(context, ids[i], &metaBuf)) != 0) {
+                WH_ERROR_PRINT("GetMetadata after reclaim returned %d\n", ret);
+                goto cleanup;
+            }
         }
     }
-#endif
 
     /* Destroy 1 object */
     printf("--Destroy 1 object\n");

--- a/test/wh_test_nvm_flash.c
+++ b/test/wh_test_nvm_flash.c
@@ -245,6 +245,16 @@ int whTest_NvmFlashCfg(whNvmFlashConfig* cfg)
 #if defined(WH_CFG_TEST_VERBOSE)
     _ShowAvailable(cb, context);
     _ShowList(cb, context);
+    /* Ensure reclamation doesn't destroy active objects */
+    {
+        whNvmMetadata metaBuf = {0};
+        unsigned char dataBuf[256];
+
+        for (size_t i=0; i<sizeof(ids)/sizeof(ids[0]); i++) {
+            WH_TEST_ASSERT(0 == cb->Read(context, ids[i], 0, sizeof(dataBuf), dataBuf));
+           WH_TEST_ASSERT(0 == cb->GetMetadata(context, ids[i], &metaBuf));
+        }
+    }
 #endif
 
     /* Destroy 1 object */
@@ -296,7 +306,7 @@ int whTest_NvmFlash_RamSim(void)
         .size       = 1024 * 1024, /* 1MB  Flash */
         .sectorSize = 4096,        /* 4KB  Sector Size */
         .pageSize   = 8,           /* 8B   Page Size */
-        .erasedByte = ~(uint8_t)0,
+        .erasedByte = (uint8_t)0,
     }};
 
     /* NVM Configuration using PosixSim HAL Flash */

--- a/test/wh_test_nvm_flash.c
+++ b/test/wh_test_nvm_flash.c
@@ -254,12 +254,13 @@ int whTest_NvmFlashCfg(whNvmFlashConfig* cfg)
 
         printf("--Read IDs after reclaim\n");
         for (size_t i=0; i<sizeof(ids)/sizeof(ids[0]); i++) {
-            if ((ret = cb->Read(context, ids[i], 0, sizeof(dataBuf), dataBuf)) != 0) {
-                WH_ERROR_PRINT("Read after reclaim returned %d\n", ret);
-                goto cleanup;
-            }
             if ((ret = cb->GetMetadata(context, ids[i], &metaBuf)) != 0) {
                 WH_ERROR_PRINT("GetMetadata after reclaim returned %d\n", ret);
+                goto cleanup;
+            }
+
+            if ((ret = cb->Read(context, ids[i], 0, metaBuf.len, dataBuf)) != 0) {
+                WH_ERROR_PRINT("Read after reclaim returned %d\n", ret);
                 goto cleanup;
             }
         }


### PR DESCRIPTION
Sets non-zero values in the unused upper bytes of the state variables on the NVM when using nvm_flash subsystem.  This corrects the case when the base NVM uses 0's for Erased AND the EraseVerify/BlankCheck does NOT distinguish, such as the Infineon Tricore.