### PR TITLE
Flash ramsim uninitialized writeLock fix

### DIFF
--- a/src/wh_flash_ramsim.c
+++ b/src/wh_flash_ramsim.c
@@ -34,11 +34,12 @@ int whFlashRamsim_Init(void* context, const void* config)
         return WH_ERROR_BADARGS;
     }
 
-    ctx->size       = cfg->size;
-    ctx->sectorSize = cfg->sectorSize;
-    ctx->pageSize   = cfg->pageSize;
-    ctx->memory     = (uint8_t*)malloc(ctx->size);
-    ctx->erasedByte = cfg->erasedByte;
+    ctx->size        = cfg->size;
+    ctx->sectorSize  = cfg->sectorSize;
+    ctx->pageSize    = cfg->pageSize;
+    ctx->memory      = (uint8_t*)malloc(ctx->size);
+    ctx->erasedByte  = cfg->erasedByte;
+    ctx->writeLocked = 0;
 
     if (!ctx->memory) {
         return WH_ERROR_BADARGS;

--- a/test/Makefile
+++ b/test/Makefile
@@ -41,6 +41,12 @@ CFLAGS += $(DBGFLAGS)
 LDFLAGS += $(DBGFLAGS)
 endif
 
+# Add address sanitizer option
+ifeq ($(ASAN),1)
+CFLAGS += -fsanitize=address
+LDFLAGS += -fsanitize=address
+endif
+
 # wolfHSM-specific defines
 CFLAGS += -DWH_CONFIG
 


### PR DESCRIPTION
Not the bug we are looking for sadly, but a quick fix: I realized the flash ramsim didn't initialize `ctx->writeLock`, leading to UB that shows up occasionally so want to fix. 

- Fix uninitialized `ctx->writeLock` in flash ramsim
- Add tests for writeLock functionality
- Add `ASAN` makefile option