### PR TITLE
Server-side crypto callback support

### DIFF
--- a/src/wh_server.c
+++ b/src/wh_server.c
@@ -70,15 +70,19 @@ int wh_Server_Init(whServerContext* server, whServerConfig* config)
     server->crypto->devId = config->devId;
     if (config->cryptocb != NULL) {
         /* register the crypto callback with wolSSL */
-        rc = wc_CryptoCb_RegisterDevice(config->devId, config->cryptocb, NULL);
+        rc = wc_CryptoCb_RegisterDevice(server->crypto->devId,
+                                        config->cryptocb,
+                                        NULL);
         if (rc != 0) {
             (void)wh_Server_Cleanup(server);
             return WH_ERROR_ABORTED;
         }
     }
-#endif /* WOLF_CRYPTO_CB */
+#else
+    server->crypto->devId = INVALID_DEVID;
+#endif
 
-    rc = wc_InitRng_ex(server->crypto->rng, NULL, config->devId);
+    rc = wc_InitRng_ex(server->crypto->rng, NULL, server->crypto->devId);
     if (rc != 0) {
         (void)wh_Server_Cleanup(server);
         return WH_ERROR_ABORTED;

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -228,7 +228,7 @@ static int hsmLoadKeyCurve25519(whServerContext* server, curve25519_key* key, ui
     return ret;
 }
 
-int _wh_Server_HandleCryptoRequest(whServerContext* server,
+int wh_Server_HandleCryptoRequest(whServerContext* server,
     uint16_t action, uint8_t* data, uint16_t* size)
 {
     int ret = 0;
@@ -250,7 +250,7 @@ int _wh_Server_HandleCryptoRequest(whServerContext* server,
         case WC_PK_TYPE_CURVE25519_KEYGEN:
             /* init private key */
             ret = wc_curve25519_init_ex(server->crypto->curve25519Private, NULL,
-                INVALID_DEVID);
+                server->crypto->devId);
             /* make the key */
             if (ret == 0) {
                 ret = wc_curve25519_make_key(server->crypto->rng,
@@ -277,10 +277,10 @@ int _wh_Server_HandleCryptoRequest(whServerContext* server,
             out = (uint8_t*)(&packet->pkCurve25519Res + 1);
             /* init ecc key */
             ret = wc_curve25519_init_ex(server->crypto->curve25519Private, NULL,
-                INVALID_DEVID);
+                server->crypto->devId);
             if (ret == 0) {
                 ret = wc_curve25519_init_ex(server->crypto->curve25519Public,
-                    NULL, INVALID_DEVID);
+                    NULL, server->crypto->devId);
             }
             /* load the private key */
             if (ret == 0) {

--- a/wolfhsm/wh_server.h
+++ b/wolfhsm/wh_server.h
@@ -15,6 +15,7 @@
 #include "wolfssl/wolfcrypt/settings.h"
 #include "wolfssl/wolfcrypt/random.h"
 #include "wolfssl/wolfcrypt/curve25519.h"
+#include "wolfssl/wolfcrypt/cryptocb.h"
 
 typedef struct CacheSlot {
     uint8_t commited;
@@ -23,6 +24,7 @@ typedef struct CacheSlot {
 } CacheSlot;
 
 typedef struct {
+    int devId;
     curve25519_key curve25519Private[1];
     curve25519_key curve25519Public[1];
     WC_RNG rng[1];
@@ -39,6 +41,10 @@ typedef struct whServerContext_t {
 typedef struct whServerConfig_t {
     whCommServerConfig* comm_config;
     whNvmConfig* nvm_config;
+#if defined WOLF_CRYPTO_CB /* TODO: should we be relying on wolfSSL defines? */
+    int devId;
+    CryptoDevCallbackFunc cryptocb;
+#endif
 } whServerConfig;
 
 /* Initialize the nvm, crypto, and comms, components.

--- a/wolfhsm/wh_server.h
+++ b/wolfhsm/wh_server.h
@@ -7,6 +7,7 @@
  */
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "wolfhsm/wh_common.h"
 #include "wolfhsm/wh_comm.h"
@@ -30,8 +31,15 @@ typedef struct {
     WC_RNG rng[1];
 } crypto_context;
 
+typedef struct {
+    bool wcInitFlag: 1;
+    bool wcRngInitFlag: 1;
+    bool wcDevIdInitFlag: 1;
+} whServerFlags;
+
 /* Context structure to maintain the state of an HSM server */
 typedef struct whServerContext_t {
+    whServerFlags flags;
     whCommServer comm[1];
     whNvmContext nvm[1];
     crypto_context crypto[1];

--- a/wolfhsm/wh_server_crypto.h
+++ b/wolfhsm/wh_server_crypto.h
@@ -1,6 +1,10 @@
 #ifndef WOLFHSM_WH_SERVER_CRYPTO_H
 #define WOLFHSM_WH_SERVER_CRYPTO_H
+
 #include "wolfhsm/wh_server.h"
-int _wh_Server_HandleCryptoRequest(whServerContext* server,
+
+int wh_Server_HandleCryptoRequest(whServerContext* server,
     uint16_t action, uint8_t* data, uint16_t* size);
+
+
 #endif


### PR DESCRIPTION
- Adds support for server-side crypto callbacks
- Some formatting/housekeeping cleanups

Tested full stack on tricore and it works for current crypto tests on `main` (e.g. RNG and Curve25519) !
 (` hardware crypto <--> server cryptocb <--> wolfHSM server (HSM) <--| IPC comms |--> wolfHSM client (tricore)`)