### PR TITLE
Quick post-merge fixes

### DIFF
--- a/src/wh_client.c
+++ b/src/wh_client.c
@@ -277,7 +277,7 @@ int wh_Client_CustomCbCheckRegisteredResponse(whClientContext* c, uint16_t* outI
         return WH_ERROR_ABORTED;
     }
 
-    if (resp.err != WH_ERROR_OK && resp.err != WH_ERROR_NO_HANDLER) {
+    if (resp.err != WH_ERROR_OK && resp.err != WH_ERROR_NOHANDLER) {
         /* error codes that aren't related to the query should be fatal */
         return WH_ERROR_ABORTED;
     }

--- a/src/wh_server_customcb.c
+++ b/src/wh_server_customcb.c
@@ -63,7 +63,7 @@ int wh_Server_HandleCustomCbRequest(whServerContext* server, uint16_t magic,
     else {
         /* No callback was registered, populate response error. We must
          * return success to ensure the "error" response is sent  */
-        resp.err = WH_ERROR_NO_HANDLER;
+        resp.err = WH_ERROR_NOHANDLER;
     }
 
     /* tag response with requested callback ID for client-side bookkeeping*/

--- a/test/wh_test_clientserver.c
+++ b/test/wh_test_clientserver.c
@@ -82,13 +82,13 @@ static int _testCallbacks(whServerContext* server, whClientContext* client)
         WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
         WH_TEST_RETURN_ON_FAIL(wh_Client_CustomCbCheckRegisteredResponse(client, &outId, &respErr));
         WH_TEST_ASSERT_RETURN(outId == req.id);
-        WH_TEST_ASSERT_RETURN(respErr == WH_ERROR_NO_HANDLER);
+        WH_TEST_ASSERT_RETURN(respErr == WH_ERROR_NOHANDLER);
 
         /* Test that calling an unregistered callback returns error */
         WH_TEST_RETURN_ON_FAIL(wh_Client_CustomCbRequest(client, &req));
         WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
         WH_TEST_RETURN_ON_FAIL(wh_Client_CustomCbResponse(client, &resp));
-        WH_TEST_ASSERT_RETURN(resp.err == WH_ERROR_NO_HANDLER);
+        WH_TEST_ASSERT_RETURN(resp.err == WH_ERROR_NOHANDLER);
 
         /* Register a custom callback */
         WH_TEST_RETURN_ON_FAIL(

--- a/wolfhsm/wh_client.h
+++ b/wolfhsm/wh_client.h
@@ -186,8 +186,10 @@ int wh_Client_CustomCbResponse(whClientContext* c, whMessageCustomCb_Response *r
 int wh_Client_CustomCheckRegisteredRequest(whClientContext* c, uint32_t id);
 /* Processes a server response to callback query. OutId is set to the ID of the
  * received query. ResponseError is set to WH_ERROR_OK if the callback is
- * registered, and WH_ERROR_NO_HANDLER if not */
+ * registered, and WH_ERROR_NOHANDLER if not */
 int wh_Client_CustomCbCheckRegisteredResponse(whClientContext* c, uint16_t* outId, int* responseError);
+/* Blocking call to check if a callback is registered */
+int wh_Client_CustomCbCheckRegistered(whClientContext* c, uint16_t id, int* responseError);
 
 
 #endif /* WOLFHSM_WH_CLIENT_H_ */

--- a/wolfhsm/wh_error.h
+++ b/wolfhsm/wh_error.h
@@ -26,7 +26,7 @@ enum {
     WH_ERROR_NOSPACE        = -415, /* No available space */
 
     /* Custom-callback status returns */
-    WH_ERROR_NO_HANDLER     = -420, /* No handler registered for action */
+    WH_ERROR_NOHANDLER     = -420, /* No handler registered for action */
 };
 
 #endif /* WOLFHSM_WH_ERROR_H_ */

--- a/wolfhsm/wh_message.h
+++ b/wolfhsm/wh_message.h
@@ -25,7 +25,6 @@ enum {
 
     WH_MESSAGE_ACTION_MASK         = 0x00FF,  /* 255 subtypes per group*/
     WH_MESSAGE_ACTION_NONE         = 0x0000,  /* No action. Invalid. */
-    WH_MESSAGE_ACTION_MAX          = 0x00FF,  /* Max action value */
 };
 
 /* Construct the message kind based on group and action */


### PR DESCRIPTION
Addresses post-merge comments from #14 
- Renamed WH_ERROR_NO_HANDLER to WH_ERROR_NOHANDLER
- Removed WH_ACTION_MAX
- Add prototype for busy wait CheckRegistered to header.