### PR TITLE
Added readback/self-checking NVM tests to whTest_ClientServerSequential

### DIFF
--- a/test/wh_test_clientserver.c
+++ b/test/wh_test_clientserver.c
@@ -34,25 +34,25 @@
 
 
 /* Dummy callback that loopback-copies client data */
-static int _customServerCb(whServerContext*               server,
+static int _customServerCb(whServerContext*                 server,
                            const whMessageCustomCb_Request* req,
                            whMessageCustomCb_Response*      resp)
 {
     uint8_t* serverPtr = NULL;
     uint8_t* clientPtr = NULL;
-    size_t copySz = 0;
+    size_t   copySz    = 0;
 
     if (req->type == WH_MESSAGE_CUSTOM_CB_TYPE_DMA64) {
         clientPtr = (uint8_t*)((uintptr_t)req->data.dma64.client_addr);
         serverPtr = (uint8_t*)((uintptr_t)req->data.dma64.server_addr);
         resp->data.dma64.client_sz = req->data.dma64.server_sz;
-        copySz = req->data.dma64.server_sz;
+        copySz                     = req->data.dma64.server_sz;
     }
     else if (req->type == WH_MESSAGE_CUSTOM_CB_TYPE_DMA32) {
         clientPtr = (uint8_t*)((uintptr_t)req->data.dma32.client_addr);
         serverPtr = (uint8_t*)((uintptr_t)req->data.dma32.server_addr);
         resp->data.dma32.client_sz = req->data.dma32.server_sz;
-        copySz = req->data.dma32.server_sz;
+        copySz                     = req->data.dma32.server_sz;
     }
 
     memcpy(clientPtr, serverPtr, copySz);
@@ -64,11 +64,11 @@ static int _customServerCb(whServerContext*               server,
  * already initialized */
 static int _testCallbacks(whServerContext* server, whClientContext* client)
 {
-    size_t                   counter;
-    whMessageCustomCb_Request  req  = {0};
-    whMessageCustomCb_Response resp = {0};
-    uint16_t                 outId   = 0;
-    int                      respErr = 0;
+    size_t                     counter;
+    whMessageCustomCb_Request  req     = {0};
+    whMessageCustomCb_Response resp    = {0};
+    uint16_t                   outId   = 0;
+    int                        respErr = 0;
 
     const char input[] = "The answer to the ultimate question of life, the "
                          "universe and everything is 42";
@@ -78,9 +78,11 @@ static int _testCallbacks(whServerContext* server, whClientContext* client)
         req.id = counter;
 
         /* Check that the callback shows as unregistered */
-        WH_TEST_RETURN_ON_FAIL(wh_Client_CustomCheckRegisteredRequest(client, req.id));
+        WH_TEST_RETURN_ON_FAIL(
+            wh_Client_CustomCheckRegisteredRequest(client, req.id));
         WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
-        WH_TEST_RETURN_ON_FAIL(wh_Client_CustomCbCheckRegisteredResponse(client, &outId, &respErr));
+        WH_TEST_RETURN_ON_FAIL(wh_Client_CustomCbCheckRegisteredResponse(
+            client, &outId, &respErr));
         WH_TEST_ASSERT_RETURN(outId == req.id);
         WH_TEST_ASSERT_RETURN(respErr == WH_ERROR_NOHANDLER);
 
@@ -95,9 +97,11 @@ static int _testCallbacks(whServerContext* server, whClientContext* client)
             wh_Server_RegisterCustomCb(server, counter, _customServerCb));
 
         /* Check that the callback now shows as registered */
-        WH_TEST_RETURN_ON_FAIL(wh_Client_CustomCheckRegisteredRequest(client, req.id));
+        WH_TEST_RETURN_ON_FAIL(
+            wh_Client_CustomCheckRegisteredRequest(client, req.id));
         WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
-        WH_TEST_RETURN_ON_FAIL(wh_Client_CustomCbCheckRegisteredResponse(client, &outId, &respErr));
+        WH_TEST_RETURN_ON_FAIL(wh_Client_CustomCbCheckRegisteredResponse(
+            client, &outId, &respErr));
         WH_TEST_ASSERT_RETURN(outId == req.id);
         WH_TEST_ASSERT_RETURN(respErr == WH_ERROR_OK);
 
@@ -150,8 +154,8 @@ int whTest_ClientServerSequential(void)
     }};
 
     /* Client configuration/contexts */
-    whTransportClientCb         tccb[1]   = {WH_TRANSPORT_MEM_CLIENT_CB};
-    whTransportMemClientContext tmcc[1]   = {0};
+    whTransportClientCb         tccb[1]    = {WH_TRANSPORT_MEM_CLIENT_CB};
+    whTransportMemClientContext tmcc[1]    = {0};
     whCommClientConfig          cc_conf[1] = {{
                  .transport_cb      = tccb,
                  .transport_context = (void*)tmcc,
@@ -162,12 +166,12 @@ int whTest_ClientServerSequential(void)
     whClientContext client[1] = {0};
 
     whClientConfig c_conf[1] = {{
-       .comm = cc_conf,
+        .comm = cc_conf,
     }};
 
     /* Server configuration/contexts */
-    whTransportServerCb         tscb[1]   = {WH_TRANSPORT_MEM_SERVER_CB};
-    whTransportMemServerContext tmsc[1]   = {0};
+    whTransportServerCb         tscb[1]    = {WH_TRANSPORT_MEM_SERVER_CB};
+    whTransportMemServerContext tmsc[1]    = {0};
     whCommServerConfig          cs_conf[1] = {{
                  .transport_cb      = tscb,
                  .transport_context = (void*)tmsc,
@@ -176,41 +180,41 @@ int whTest_ClientServerSequential(void)
     }};
 
     /* RamSim Flash state and configuration */
-    whFlashRamsimCtx fc[1] = {0};
+    whFlashRamsimCtx fc[1]      = {0};
     whFlashRamsimCfg fc_conf[1] = {{
         .size       = 1024 * 1024, /* 1MB  Flash */
         .sectorSize = 128 * 1024,  /* 128KB  Sector Size */
         .pageSize   = 8,           /* 8B   Page Size */
         .erasedByte = ~(uint8_t)0,
     }};
-    const whFlashCb  fcb[1]          = {WH_FLASH_RAMSIM_CB};
+    const whFlashCb  fcb[1]     = {WH_FLASH_RAMSIM_CB};
 
     /* NVM Flash Configuration using RamSim HAL Flash */
-    whNvmFlashConfig nf_conf[1] = {{
-        .cb      = fcb,
-        .context = fc,
-        .config  = fc_conf,
+    whNvmFlashConfig  nf_conf[1] = {{
+         .cb      = fcb,
+         .context = fc,
+         .config  = fc_conf,
     }};
-    whNvmFlashContext nfc[1] = {0};
-    whNvmCb nfcb[1] = {WH_NVM_FLASH_CB};
+    whNvmFlashContext nfc[1]     = {0};
+    whNvmCb           nfcb[1]    = {WH_NVM_FLASH_CB};
 
-    whNvmConfig n_conf[1] = {{
-            .cb = nfcb,
-            .context = nfc,
-            .config = nf_conf,
+    whNvmConfig  n_conf[1] = {{
+         .cb      = nfcb,
+         .context = nfc,
+         .config  = nf_conf,
     }};
-    whNvmContext nvm[1] = {{0}};
+    whNvmContext nvm[1]    = {{0}};
 
     crypto_context crypto[1] = {{
-            .devId = INVALID_DEVID,
+        .devId = INVALID_DEVID,
     }};
 
-    whServerConfig                  s_conf[1] = {{
-       .comm_config = cs_conf,
-       .nvm = nvm,
-       .crypto = crypto,
+    whServerConfig  s_conf[1] = {{
+         .comm_config = cs_conf,
+         .nvm         = nvm,
+         .crypto      = crypto,
     }};
-    whServerContext                server[1] = {0};
+    whServerContext server[1] = {0};
 
     WH_TEST_RETURN_ON_FAIL(wolfCrypt_Init());
     WH_TEST_RETURN_ON_FAIL(wc_InitRng_ex(crypto->rng, NULL, crypto->devId));
@@ -220,23 +224,23 @@ int whTest_ClientServerSequential(void)
     WH_TEST_RETURN_ON_FAIL(wh_Client_Init(client, c_conf));
     WH_TEST_RETURN_ON_FAIL(wh_Server_Init(server, s_conf));
 
-    int counter = 1;
-    char recv_buffer[WH_COMM_MTU] = {0};
-    char send_buffer[WH_COMM_MTU] = {0};
-    uint16_t send_len = 0;
-    uint16_t recv_len = 0;
+    int      counter                  = 1;
+    char     recv_buffer[WH_COMM_MTU] = {0};
+    char     send_buffer[WH_COMM_MTU] = {0};
+    uint16_t send_len                 = 0;
+    uint16_t recv_len                 = 0;
 
-    int32_t server_rc = 0;
-    uint32_t client_id = 0;
-    uint32_t server_id = 0;
-    uint32_t avail_size = 0;
-    uint32_t reclaim_size = 0;
-    whNvmId avail_objects = 0;
-    whNvmId reclaim_objects = 0;
+    int32_t  server_rc       = 0;
+    uint32_t client_id       = 0;
+    uint32_t server_id       = 0;
+    uint32_t avail_size      = 0;
+    uint32_t reclaim_size    = 0;
+    whNvmId  avail_objects   = 0;
+    whNvmId  reclaim_objects = 0;
 
     /* Check that the server side is ready to recv */
     WH_TEST_ASSERT_RETURN(WH_ERROR_NOTREADY ==
-            wh_Server_HandleRequestMessage(server));
+                          wh_Server_HandleRequestMessage(server));
 
     for (counter = 0; counter < REPEAT_COUNT; counter++) {
 
@@ -249,18 +253,17 @@ int whTest_ClientServerSequential(void)
         WH_TEST_RETURN_ON_FAIL(
             wh_Client_EchoRequest(client, send_len, send_buffer));
 #if defined(WH_CFG_TEST_VERBOSE)
-        printf("Client EchoRequest:%d, len:%d, %.*s\n",
-               ret, send_len, send_len, send_buffer);
+        printf("Client EchoRequest:%d, len:%d, %.*s\n", ret, send_len, send_len,
+               send_buffer);
 #endif
 
         if (counter == 0) {
-            WH_TEST_ASSERT_RETURN(WH_ERROR_NOTREADY ==
-                                  wh_Client_EchoResponse(
-                                      client, &recv_len, recv_buffer));
+            WH_TEST_ASSERT_RETURN(
+                WH_ERROR_NOTREADY ==
+                wh_Client_EchoResponse(client, &recv_len, recv_buffer));
         }
 
-        WH_TEST_RETURN_ON_FAIL(
-            wh_Server_HandleRequestMessage(server));
+        WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
 
 #if defined(WH_CFG_TEST_VERBOSE)
         printf("Server HandleRequestMessage:%d\n", ret);
@@ -270,279 +273,343 @@ int whTest_ClientServerSequential(void)
             wh_Client_EchoResponse(client, &recv_len, recv_buffer));
 
 #if defined(WH_CFG_TEST_VERBOSE)
-        printf("Client EchoResponse:%d, len:%d, %.*s, expected:%.*s\n",
-            ret, recv_len, recv_len, recv_buffer, send_len, send_buffer);
+        printf("Client EchoResponse:%d, len:%d, %.*s, expected:%.*s\n", ret,
+               recv_len, recv_len, recv_buffer, send_len, send_buffer);
 #endif
-        WH_TEST_ASSERT_RETURN( recv_len == send_len);
-        WH_TEST_ASSERT_RETURN( strncmp(recv_buffer, send_buffer, recv_len) == 0);
+        WH_TEST_ASSERT_RETURN(recv_len == send_len);
+        WH_TEST_ASSERT_RETURN(strncmp(recv_buffer, send_buffer, recv_len) == 0);
     }
 
     /* Perform NVM tests */
+    WH_TEST_RETURN_ON_FAIL(wh_Client_NvmInitRequest(client));
+    WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
     WH_TEST_RETURN_ON_FAIL(
-            wh_Client_NvmInitRequest(client));
-    WH_TEST_RETURN_ON_FAIL(
-            wh_Server_HandleRequestMessage(server));
-    WH_TEST_RETURN_ON_FAIL(
-            wh_Client_NvmInitResponse(client, &server_rc, &client_id, &server_id));
+        wh_Client_NvmInitResponse(client, &server_rc, &client_id, &server_id));
 
 #if defined(WH_CFG_TEST_VERBOSE)
-        printf("Client NvmInitResponse:%d, server_rc:%d, clientid:%d serverid:%d\n",
-            ret, server_rc, client_id, server_id);
+    printf("Client NvmInitResponse:%d, server_rc:%d, clientid:%d serverid:%d\n",
+           ret, server_rc, client_id, server_id);
 #endif
+    WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
 
-    WH_TEST_RETURN_ON_FAIL(
-            wh_Client_NvmGetAvailableRequest(client));
-    WH_TEST_RETURN_ON_FAIL(
-            wh_Server_HandleRequestMessage(server));
-    WH_TEST_RETURN_ON_FAIL(
-            wh_Client_NvmGetAvailableResponse(client, &server_rc,
-                    &avail_size, &avail_objects,
-                    &reclaim_size, &reclaim_objects));
+
+    WH_TEST_RETURN_ON_FAIL(wh_Client_NvmGetAvailableRequest(client));
+    WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
+    WH_TEST_RETURN_ON_FAIL(wh_Client_NvmGetAvailableResponse(
+        client, &server_rc, &avail_size, &avail_objects, &reclaim_size,
+        &reclaim_objects));
 #if defined(WH_CFG_TEST_VERBOSE)
-        printf("Client NvmGetAvailableResponse:%d, server_rc:%d avail_size:%d avail_objects:%d, reclaim_size:%d reclaim_objects:%d\n",
-            ret, server_rc, avail_size, avail_objects, reclaim_size, reclaim_objects);
+    printf("Client NvmGetAvailableResponse:%d, server_rc:%d avail_size:%d "
+           "avail_objects:%d, reclaim_size:%d reclaim_objects:%d\n",
+           ret, server_rc, avail_size, avail_objects, reclaim_size,
+           reclaim_objects);
 #endif
+    WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
+    WH_TEST_ASSERT_RETURN(avail_objects == NF_OBJECT_COUNT);
 
-    for (counter = 0; counter < 5; counter ++) {
-        whNvmId id = counter + 20;
-        whNvmAccess access = WOLFHSM_NVM_ACCESS_ANY;
-        whNvmFlags flags = WOLFHSM_NVM_FLAGS_ANY;
-        whNvmSize label_len = 0;
-        char label[WOLFHSM_NVM_LABEL_LEN] = {0};
-        whNvmSize len = 0;
 
-        whNvmId gid = 0;
-        whNvmAccess gaccess = 0;
-        whNvmFlags gflags = 0;
-        char glabel[WOLFHSM_NVM_LABEL_LEN] = {0};
-        whNvmSize glen = 0;
+    for (counter = 0; counter < 5; counter++) {
+        whNvmId     id                           = counter + 20;
+        whNvmAccess access                       = WOLFHSM_NVM_ACCESS_ANY;
+        whNvmFlags  flags                        = WOLFHSM_NVM_FLAGS_ANY;
+        whNvmSize   label_len                    = 0;
+        char        label[WOLFHSM_NVM_LABEL_LEN] = {0};
+        whNvmSize   len                          = 0;
 
-        whNvmSize rlen = 0;
+        whNvmId     gid                           = 0;
+        whNvmAccess gaccess                       = 0;
+        whNvmFlags  gflags                        = 0;
+        char        glabel[WOLFHSM_NVM_LABEL_LEN] = {0};
+        whNvmSize   glen                          = 0;
+        whNvmSize   rlen                          = 0;
+
+        whNvmId lastAvailObjects = 0;
 
         label_len = snprintf(label, sizeof(label), "Label:%d", id);
-        len = snprintf(send_buffer, sizeof(send_buffer), "Data:%d Counter:%d", id, counter);
+        len = snprintf(send_buffer, sizeof(send_buffer), "Data:%d Counter:%d",
+                       id, counter);
 
 #if defined(WH_CFG_TEST_VERBOSE)
-        printf("Client NvmAddObjectRequest:%d, id:%u, access:0x%x, flags:0x%x, len:%u label:%s\nData:%s\n",
-            ret, id, access, flags, len, label, send_buffer);
+        printf("Client NvmAddObjectRequest:%d, id:%u, access:0x%x, flags:0x%x, "
+               "len:%u label:%s\nData:%s\n",
+               ret, id, access, flags, len, label, send_buffer);
 #endif
 
-        WH_TEST_RETURN_ON_FAIL(
-                wh_Client_NvmAddObjectRequest(client,
-                        id, access, flags,
-                        label_len, (uint8_t*)label,
-                        len, (uint8_t*)send_buffer));
-        WH_TEST_RETURN_ON_FAIL(
-                wh_Server_HandleRequestMessage(server));
-        WH_TEST_RETURN_ON_FAIL(
-                wh_Client_NvmAddObjectResponse(client, &server_rc));
-        #if defined(WH_CFG_TEST_VERBOSE)
-                printf("Client NvmAddObjectResponse:%d, server_rc:%d\n",
-                    ret, server_rc);
-        #endif
+        lastAvailObjects = avail_objects;
 
+        WH_TEST_RETURN_ON_FAIL(wh_Client_NvmAddObjectRequest(
+            client, id, access, flags, label_len, (uint8_t*)label, len,
+            (uint8_t*)send_buffer));
+        WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
         WH_TEST_RETURN_ON_FAIL(
-                wh_Client_NvmGetAvailableRequest(client));
-        WH_TEST_RETURN_ON_FAIL(
-                wh_Server_HandleRequestMessage(server));
-        WH_TEST_RETURN_ON_FAIL(
-                wh_Client_NvmGetAvailableResponse(client, &server_rc,
-                        &avail_size, &avail_objects,
-                        &reclaim_size, &reclaim_objects));
-        #if defined(WH_CFG_TEST_VERBOSE)
-                printf("Client NvmGetAvailableResponse:%d, server_rc:%d, avail_size:%d avail_objects:%d, reclaim_size:%d reclaim_objects:%d\n",
-                    ret, server_rc, avail_size, avail_objects, reclaim_size, reclaim_objects);
-        #endif
+            wh_Client_NvmAddObjectResponse(client, &server_rc));
+#if defined(WH_CFG_TEST_VERBOSE)
+        printf("Client NvmAddObjectResponse:%d, server_rc:%d\n", ret,
+               server_rc);
+#endif
+        WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
 
-        WH_TEST_RETURN_ON_FAIL(
-                wh_Client_NvmGetMetadataRequest(client, id));
-        WH_TEST_RETURN_ON_FAIL(
-                wh_Server_HandleRequestMessage(server));
-        WH_TEST_RETURN_ON_FAIL(
-                wh_Client_NvmGetMetadataResponse(client, &server_rc,
-                        &gid, &gaccess, &gflags,
-                        &glen,
-                        sizeof(glabel), (uint8_t*)glabel));
-        #if defined(WH_CFG_TEST_VERBOSE)
-                printf("Client NvmGetMetadataResponse:%d, id:%u, access:0x%x, flags:0x%x, len:%u label:%s\n",
-            ret, gid, gaccess, gflags, glen, glabel);
-        #endif
+        WH_TEST_RETURN_ON_FAIL(wh_Client_NvmGetAvailableRequest(client));
+        WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
+        WH_TEST_RETURN_ON_FAIL(wh_Client_NvmGetAvailableResponse(
+            client, &server_rc, &avail_size, &avail_objects, &reclaim_size,
+            &reclaim_objects));
+#if defined(WH_CFG_TEST_VERBOSE)
+        printf("Client NvmGetAvailableResponse:%d, server_rc:%d, avail_size:%d "
+               "avail_objects:%d, reclaim_size:%d reclaim_objects:%d\n",
+               ret, server_rc, avail_size, avail_objects, reclaim_size,
+               reclaim_objects);
+#endif
 
-        WH_TEST_RETURN_ON_FAIL(
-                wh_Client_NvmReadRequest(client, id, 0, glen));
-        WH_TEST_RETURN_ON_FAIL(
-                wh_Server_HandleRequestMessage(server));
-        WH_TEST_RETURN_ON_FAIL(
-                wh_Client_NvmReadResponse(client, &server_rc,
-                        &rlen, (uint8_t*)recv_buffer));
-        #if defined(WH_CFG_TEST_VERBOSE)
-                printf("Client NvmReadResponse:%d, server_rc:%d id:%u, len:%u data:%s\n",
+        /* Check that available objects decreased by one */
+        WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
+        WH_TEST_ASSERT_RETURN(lastAvailObjects - 1 == avail_objects);
+
+        WH_TEST_RETURN_ON_FAIL(wh_Client_NvmGetMetadataRequest(client, id));
+        WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
+        WH_TEST_RETURN_ON_FAIL(wh_Client_NvmGetMetadataResponse(
+            client, &server_rc, &gid, &gaccess, &gflags, &glen, sizeof(glabel),
+            (uint8_t*)glabel));
+#if defined(WH_CFG_TEST_VERBOSE)
+        printf("Client NvmGetMetadataResponse:%d, id:%u, access:0x%x, "
+               "flags:0x%x, len:%u label:%s\n",
+               ret, gid, gaccess, gflags, glen, glabel);
+#endif
+
+        /* Ensure metadata matches that of the object we just wrote */
+        WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
+        WH_TEST_ASSERT_RETURN(gid == id);
+
+        memset(recv_buffer, 0, sizeof(recv_buffer));
+        WH_TEST_RETURN_ON_FAIL(wh_Client_NvmReadRequest(client, id, 0, glen));
+        WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
+        WH_TEST_RETURN_ON_FAIL(wh_Client_NvmReadResponse(
+            client, &server_rc, &rlen, (uint8_t*)recv_buffer));
+#if defined(WH_CFG_TEST_VERBOSE)
+        printf(
+            "Client NvmReadResponse:%d, server_rc:%d id:%u, len:%u data:%s\n",
             ret, server_rc, gid, rlen, recv_buffer);
-        #endif
+#endif
+
+        /* Ensure data and size of response object matches that of the written
+         * object */
+        WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
+        WH_TEST_ASSERT_RETURN(rlen == len);
+        WH_TEST_ASSERT_RETURN(0 == memcmp(send_buffer, recv_buffer, len));
     }
 
     whNvmAccess list_access = WOLFHSM_NVM_ACCESS_ANY;
-    whNvmFlags list_flags = WOLFHSM_NVM_FLAGS_ANY;
-    whNvmId list_id = 0;
-    whNvmId list_count = 0;
+    whNvmFlags  list_flags  = WOLFHSM_NVM_FLAGS_ANY;
+    whNvmId     list_id     = 0;
+    whNvmId     list_count  = 0;
     do {
-    WH_TEST_RETURN_ON_FAIL(
+        WH_TEST_RETURN_ON_FAIL(
             wh_Client_NvmListRequest(client, list_access, list_flags, list_id));
-    WH_TEST_RETURN_ON_FAIL(
-            wh_Server_HandleRequestMessage(server));
-    WH_TEST_RETURN_ON_FAIL(
-            wh_Client_NvmListResponse(client, &server_rc,
-                    &list_count, &list_id));
-    #if defined(WH_CFG_TEST_VERBOSE)
-            printf("Client NvmListResponse:%d, server_rc:%d count:%u id:%u\n",
-        ret, server_rc, list_count, list_id);
-    #endif
+        WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
+        WH_TEST_RETURN_ON_FAIL(wh_Client_NvmListResponse(
+            client, &server_rc, &list_count, &list_id));
+#if defined(WH_CFG_TEST_VERBOSE)
+        printf("Client NvmListResponse:%d, server_rc:%d count:%u id:%u\n", ret,
+               server_rc, list_count, list_id);
+#endif
 
-        if(list_count > 0) {
+        if (list_count > 0) {
+            /* ensure list_id contains ID of object written, and list_count
+             * shows remaining items in list */
+            WH_TEST_ASSERT_RETURN(list_id == 20 + (5 - list_count));
+
             WH_TEST_RETURN_ON_FAIL(
-                    wh_Client_NvmDestroyObjectsRequest(client, 1, &list_id));
+                wh_Client_NvmDestroyObjectsRequest(client, 1, &list_id));
+            WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
             WH_TEST_RETURN_ON_FAIL(
-                    wh_Server_HandleRequestMessage(server));
+                wh_Client_NvmDestroyObjectsResponse(client, &server_rc));
+#if defined(WH_CFG_TEST_VERBOSE)
+            printf("Client NvmDestroyObjectsResponse:%d, server_rc:%d for "
+                   "id:%u with count:%u\n",
+                   ret, server_rc, list_id, list_count);
+#endif
+            WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
+
+            /* Ensure object was destroyed and no longer exists */
             WH_TEST_RETURN_ON_FAIL(
-                    wh_Client_NvmDestroyObjectsResponse(client, &server_rc));
-            #if defined(WH_CFG_TEST_VERBOSE)
-                    printf("Client NvmDestroyObjectsResponse:%d, server_rc:%d for id:%u with count:%u\n",
-                ret, server_rc, list_id, list_count);
-            #endif
+                wh_Client_NvmGetMetadataRequest(client, list_id));
+            WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
+            WH_TEST_RETURN_ON_FAIL(wh_Client_NvmGetMetadataResponse(
+                client, &server_rc, NULL, NULL, NULL, NULL, 0, NULL));
+            WH_TEST_ASSERT_RETURN(WH_ERROR_NOTFOUND == server_rc);
+
+#if defined(WH_CFG_TEST_VERBOSE)
+            printf("Client NvmListResponse:%d, server_rc:%d count:%u id:%u\n",
+                   ret, server_rc, list_count, list_id);
+#endif
+
             list_id = 0;
         }
     } while (list_count > 0);
 
-    for (counter = 0; counter < 5; counter ++) {
+
+    WH_TEST_RETURN_ON_FAIL(wh_Client_NvmGetAvailableRequest(client));
+    WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
+    WH_TEST_RETURN_ON_FAIL(wh_Client_NvmGetAvailableResponse(
+        client, &server_rc, &avail_size, &avail_objects, &reclaim_size,
+        &reclaim_objects));
+    WH_TEST_ASSERT_RETURN(avail_objects == NF_OBJECT_COUNT);
+
+    for (counter = 0; counter < 5; counter++) {
         whNvmMetadata meta = {
-                .id = counter + 40,
-                .access = WOLFHSM_NVM_ACCESS_ANY,
-                .flags = WOLFHSM_NVM_FLAGS_ANY,
-                .len = 0,
-                .label = {0},
+            .id     = counter + 40,
+            .access = WOLFHSM_NVM_ACCESS_ANY,
+            .flags  = WOLFHSM_NVM_FLAGS_ANY,
+            .len    = 0,
+            .label  = {0},
         };
         whNvmSize len = 0;
 
-        whNvmId gid = 0;
-        whNvmAccess gaccess = 0;
-        whNvmFlags gflags = 0;
-        char glabel[WOLFHSM_NVM_LABEL_LEN] = {0};
-        whNvmSize glen = 0;
+        whNvmId     gid                           = 0;
+        whNvmAccess gaccess                       = 0;
+        whNvmFlags  gflags                        = 0;
+        char        glabel[WOLFHSM_NVM_LABEL_LEN] = {0};
+        whNvmSize   glen                          = 0;
+        whNvmSize   rlen                          = 0;
 
-        whNvmSize rlen = 0;
+        whNvmId lastAvailObjects = 0;
 
         snprintf((char*)(meta.label), sizeof(meta.label), "Label:%d", meta.id);
-        len = snprintf(send_buffer, sizeof(send_buffer), "Data:%d Counter:%d", meta.id, counter);
+        len = snprintf(send_buffer, sizeof(send_buffer), "Data:%d Counter:%d",
+                       meta.id, counter);
 
 #if defined(WH_CFG_TEST_VERBOSE)
-        printf("Client NvmAddObjectDmaRequest:%d, id:%u, access:0x%x, flags:0x%x, len:%u label:%s\nData:%s\n",
-            ret, meta.id, meta.access, meta.flags, len, meta.label, send_buffer);
+        printf("Client NvmAddObjectDmaRequest:%d, id:%u, access:0x%x, "
+               "flags:0x%x, len:%u label:%s\nData:%s\n",
+               ret, meta.id, meta.access, meta.flags, len, meta.label,
+               send_buffer);
 #endif
 
+        lastAvailObjects = avail_objects;
+
+        WH_TEST_RETURN_ON_FAIL(wh_Client_NvmAddObjectDmaRequest(
+            client, &meta, len, (uint8_t*)send_buffer));
+        WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
         WH_TEST_RETURN_ON_FAIL(
-                wh_Client_NvmAddObjectDmaRequest(client,
-                        &meta,
-                        len, (uint8_t*)send_buffer));
-        WH_TEST_RETURN_ON_FAIL(
-                wh_Server_HandleRequestMessage(server));
-        WH_TEST_RETURN_ON_FAIL(
-                wh_Client_NvmAddObjectDmaResponse(client, &server_rc));
-        #if defined(WH_CFG_TEST_VERBOSE)
-                printf("Client NvmAddObjectDmaResponse:%d, server_rc:%d, meta.len:%u\n",
-                    ret, server_rc, meta.len);
-        #endif
+            wh_Client_NvmAddObjectDmaResponse(client, &server_rc));
+#if defined(WH_CFG_TEST_VERBOSE)
+        printf("Client NvmAddObjectDmaResponse:%d, server_rc:%d, meta.len:%u\n",
+               ret, server_rc, meta.len);
+#endif
+        WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
+
+        WH_TEST_RETURN_ON_FAIL(wh_Client_NvmGetAvailableRequest(client));
+        WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
+        WH_TEST_RETURN_ON_FAIL(wh_Client_NvmGetAvailableResponse(
+            client, &server_rc, &avail_size, &avail_objects, &reclaim_size,
+            &reclaim_objects));
+#if defined(WH_CFG_TEST_VERBOSE)
+        printf("Client NvmGetAvailableResponse:%d, server_rc:%d, avail_size:%d "
+               "avail_objects:%d, reclaim_size:%d reclaim_objects:%d\n",
+               ret, server_rc, avail_size, avail_objects, reclaim_size,
+               reclaim_objects);
+#endif
+        WH_TEST_ASSERT_RETURN(lastAvailObjects - 1 == avail_objects);
 
         WH_TEST_RETURN_ON_FAIL(
-                wh_Client_NvmGetAvailableRequest(client));
-        WH_TEST_RETURN_ON_FAIL(
-                wh_Server_HandleRequestMessage(server));
-        WH_TEST_RETURN_ON_FAIL(
-                wh_Client_NvmGetAvailableResponse(client, &server_rc,
-                        &avail_size, &avail_objects,
-                        &reclaim_size, &reclaim_objects));
-        #if defined(WH_CFG_TEST_VERBOSE)
-                printf("Client NvmGetAvailableResponse:%d, server_rc:%d, avail_size:%d avail_objects:%d, reclaim_size:%d reclaim_objects:%d\n",
-                    ret, server_rc, avail_size, avail_objects, reclaim_size, reclaim_objects);
-        #endif
+            wh_Client_NvmGetMetadataRequest(client, meta.id));
+        WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
+        WH_TEST_RETURN_ON_FAIL(wh_Client_NvmGetMetadataResponse(
+            client, &server_rc, &gid, &gaccess, &gflags, &glen, sizeof(glabel),
+            (uint8_t*)glabel));
+#if defined(WH_CFG_TEST_VERBOSE)
+        printf("Client NvmGetMetadataResponse:%d, id:%u, access:0x%x, "
+               "flags:0x%x, len:%u label:%s\n",
+               ret, gid, gaccess, gflags, glen, glabel);
+#endif
 
-        WH_TEST_RETURN_ON_FAIL(
-                wh_Client_NvmGetMetadataRequest(client, meta.id));
-        WH_TEST_RETURN_ON_FAIL(
-                wh_Server_HandleRequestMessage(server));
-        WH_TEST_RETURN_ON_FAIL(
-                wh_Client_NvmGetMetadataResponse(client, &server_rc,
-                        &gid, &gaccess, &gflags,
-                        &glen,
-                        sizeof(glabel), (uint8_t*)glabel));
-        #if defined(WH_CFG_TEST_VERBOSE)
-                printf("Client NvmGetMetadataResponse:%d, id:%u, access:0x%x, flags:0x%x, len:%u label:%s\n",
-            ret, gid, gaccess, gflags, glen, glabel);
-        #endif
+        /* Ensure metadata matches that of the object we just wrote */
+        WH_TEST_ASSERT_RETURN(gid == meta.id);
 
+
+        memset(recv_buffer, 0, sizeof(recv_buffer));
+        WH_TEST_RETURN_ON_FAIL(wh_Client_NvmReadDmaRequest(
+            client, meta.id, 0, glen, (uint8_t*)recv_buffer));
+        WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
         WH_TEST_RETURN_ON_FAIL(
-                wh_Client_NvmReadDmaRequest(client, meta.id, 0, glen, (uint8_t*)recv_buffer));
-        WH_TEST_RETURN_ON_FAIL(
-                wh_Server_HandleRequestMessage(server));
-        WH_TEST_RETURN_ON_FAIL(
-                wh_Client_NvmReadDmaResponse(client, &server_rc));
-        #if defined(WH_CFG_TEST_VERBOSE)
-                printf("Client NvmReadDmaResponse:%d, server_rc:%d id:%u, len:%u data:%s\n",
-            ret, server_rc, gid, rlen, recv_buffer);
-        #endif
+            wh_Client_NvmReadDmaResponse(client, &server_rc));
+#if defined(WH_CFG_TEST_VERBOSE)
+        printf("Client NvmReadDmaResponse:%d, server_rc:%d id:%u, len:%u "
+               "data:%s\n",
+               ret, server_rc, gid, rlen, recv_buffer);
+#endif
+
+        /* Ensure data and size of response object matches that of the written
+         * object */
+        WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
+        WH_TEST_ASSERT_RETURN(glen == len);
+        WH_TEST_ASSERT_RETURN(0 == memcmp(send_buffer, recv_buffer, len));
     }
 
     do {
-    WH_TEST_RETURN_ON_FAIL(
+        WH_TEST_RETURN_ON_FAIL(
             wh_Client_NvmListRequest(client, list_access, list_flags, list_id));
-    WH_TEST_RETURN_ON_FAIL(
-            wh_Server_HandleRequestMessage(server));
-    WH_TEST_RETURN_ON_FAIL(
-            wh_Client_NvmListResponse(client, &server_rc,
-                    &list_count, &list_id));
-    #if defined(WH_CFG_TEST_VERBOSE)
-            printf("Client NvmListResponse:%d, server_rc:%d count:%u id:%u\n",
-        ret, server_rc, list_count, list_id);
-    #endif
+        WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
+        WH_TEST_RETURN_ON_FAIL(wh_Client_NvmListResponse(
+            client, &server_rc, &list_count, &list_id));
+#if defined(WH_CFG_TEST_VERBOSE)
+        printf("Client NvmListResponse:%d, server_rc:%d count:%u id:%u\n", ret,
+               server_rc, list_count, list_id);
+#endif
+        WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
 
-        if(list_count > 0) {
+        if (list_count > 0) {
+            /* ensure list_id contains ID of object written, and list_count
+             * shows remaining items in list */
+            WH_TEST_ASSERT_RETURN(list_id == 40 + (5 - list_count));
+
             WH_TEST_RETURN_ON_FAIL(
-                    wh_Client_NvmDestroyObjectsRequest(client, 1, &list_id));
+                wh_Client_NvmDestroyObjectsRequest(client, 1, &list_id));
+            WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
             WH_TEST_RETURN_ON_FAIL(
-                    wh_Server_HandleRequestMessage(server));
+                wh_Client_NvmDestroyObjectsResponse(client, &server_rc));
+            WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
+
+#if defined(WH_CFG_TEST_VERBOSE)
+            printf("Client NvmDestroyObjectsResponse:%d, server_rc:%d for "
+                   "id:%u with count:%u\n",
+                   ret, server_rc, list_id, list_count);
+#endif
+
+            /* Ensure object was destroyed and no longer exists */
             WH_TEST_RETURN_ON_FAIL(
-                    wh_Client_NvmDestroyObjectsResponse(client, &server_rc));
-            #if defined(WH_CFG_TEST_VERBOSE)
-                    printf("Client NvmDestroyObjectsResponse:%d, server_rc:%d for id:%u with count:%u\n",
-                ret, server_rc, list_id, list_count);
-            #endif
+                wh_Client_NvmGetMetadataRequest(client, list_id));
+            WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
+            WH_TEST_RETURN_ON_FAIL(wh_Client_NvmGetMetadataResponse(
+                client, &server_rc, NULL, NULL, NULL, NULL, 0, NULL));
+            WH_TEST_ASSERT_RETURN(WH_ERROR_NOTFOUND == server_rc);
+
             list_id = 0;
         }
     } while (list_count > 0);
 
 
-    WH_TEST_RETURN_ON_FAIL(
-            wh_Client_NvmCleanupRequest(client));
-    WH_TEST_RETURN_ON_FAIL(
-            wh_Server_HandleRequestMessage(server));
-    WH_TEST_RETURN_ON_FAIL(
-            wh_Client_NvmCleanupResponse(client, &server_rc));
-    #if defined(WH_CFG_TEST_VERBOSE)
-            printf("Client NvmCleanupResponse:%d, server_rc:%d\n",
-                ret, server_rc);
-    #endif
+    WH_TEST_RETURN_ON_FAIL(wh_Client_NvmCleanupRequest(client));
+    WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
+    WH_TEST_RETURN_ON_FAIL(wh_Client_NvmCleanupResponse(client, &server_rc));
+#if defined(WH_CFG_TEST_VERBOSE)
+    printf("Client NvmCleanupResponse:%d, server_rc:%d\n", ret, server_rc);
+#endif
+    WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
 
-    WH_TEST_RETURN_ON_FAIL(
-            wh_Client_NvmGetAvailableRequest(client));
-    WH_TEST_RETURN_ON_FAIL(
-            wh_Server_HandleRequestMessage(server));
-    WH_TEST_RETURN_ON_FAIL(
-            wh_Client_NvmGetAvailableResponse(client, &server_rc,
-                    &avail_size, &avail_objects,
-                    &reclaim_size, &reclaim_objects));
-    #if defined(WH_CFG_TEST_VERBOSE)
-            printf("Client NvmGetAvailableResponse:%d, server_rc:%d, avail_size:%d avail_objects:%d, reclaim_size:%d reclaim_objects:%d\n",
-                ret, server_rc, avail_size, avail_objects, reclaim_size, reclaim_objects);
-    #endif
+    WH_TEST_RETURN_ON_FAIL(wh_Client_NvmGetAvailableRequest(client));
+    WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
+    WH_TEST_RETURN_ON_FAIL(wh_Client_NvmGetAvailableResponse(
+        client, &server_rc, &avail_size, &avail_objects, &reclaim_size,
+        &reclaim_objects));
+#if defined(WH_CFG_TEST_VERBOSE)
+    printf("Client NvmGetAvailableResponse:%d, server_rc:%d, avail_size:%d "
+           "avail_objects:%d, reclaim_size:%d reclaim_objects:%d\n",
+           ret, server_rc, avail_size, avail_objects, reclaim_size,
+           reclaim_objects);
+#endif
+    WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
+    WH_TEST_ASSERT_RETURN(avail_objects == NF_OBJECT_COUNT);
 
     /* Test custom registered callbacks */
     WH_TEST_RETURN_ON_FAIL(_testCallbacks(server, client));


### PR DESCRIPTION
Test will now fail if server NVM isn't working as expected from the client perspective.

Note: clang-format caused a lot of whitespace changes so recommend you turn off the whitespace diff when looking at the PR in github (Files changed -> settings button -> check hide whitespace)