### PR TITLE
server DMA address handling

### DIFF
--- a/src/wh_server.c
+++ b/src/wh_server.c
@@ -63,6 +63,14 @@ int wh_Server_Init(whServerContext* server, whServerConfig* config)
         (void)wh_Server_Cleanup(server);
         return WH_ERROR_ABORTED;
     }
+
+    /* Initialize DMA configuration and callbacks */
+    if (NULL != config->dmaAddrAllowList) {
+        server->dmaAddrAllowList = config->dmaAddrAllowList;
+    }
+    server->dmaCb.cb32 = NULL;
+    server->dmaCb.cb64 = NULL;
+
     return rc;
 }
 

--- a/src/wh_server.c
+++ b/src/wh_server.c
@@ -64,12 +64,12 @@ int wh_Server_Init(whServerContext* server, whServerConfig* config)
         return WH_ERROR_ABORTED;
     }
 
-    /* Initialize DMA configuration and callbacks */
-    if (NULL != config->dmaAddrAllowList) {
-        server->dmaAddrAllowList = config->dmaAddrAllowList;
+    /* Initialize DMA configuration and callbacks, if provided */
+    if (NULL != config->dmaConfig) {
+        server->dma.dmaAddrAllowList = config->dmaConfig->dmaAddrAllowList;
+        server->dma.cb32             = config->dmaConfig->cb32;
+        server->dma.cb64             = config->dmaConfig->cb64;
     }
-    server->dmaCb.cb32 = NULL;
-    server->dmaCb.cb64 = NULL;
 
     return rc;
 }

--- a/src/wh_server_dma.c
+++ b/src/wh_server_dma.c
@@ -7,7 +7,7 @@
  * building a binary tree, etc.) */
 
 
-static int _checkAddrAgainstAllowList(const whDmaAddrList allowList, void* addr,
+static int _checkAddrAgainstAllowList(const whServerDmaAddrList allowList, void* addr,
                                       size_t size)
 {
     uintptr_t startAddr = (uintptr_t)addr;
@@ -26,8 +26,8 @@ static int _checkAddrAgainstAllowList(const whDmaAddrList allowList, void* addr,
     return WH_ERROR_ACCESS;
 }
 
-static int _checkMemOperAgainstAllowList(const whDmaAddrAllowList* allowList,
-                                         whDmaOper oper, void* addr,
+static int _checkMemOperAgainstAllowList(const whServerDmaAddrAllowList* allowList,
+                                         whServerDmaOper oper, void* addr,
                                          size_t size)
 {
     int rc = WH_ERROR_OK;
@@ -48,7 +48,7 @@ static int _checkMemOperAgainstAllowList(const whDmaAddrAllowList* allowList,
     return rc;
 }
 
-int wh_Server_DmaRegisterCb32(whServerContext* server, whDmaClientMem32Cb cb)
+int wh_Server_DmaRegisterCb32(whServerContext* server, whServerDmaClientMem32Cb cb)
 {
     if (NULL == server || NULL == cb) {
         return WH_ERROR_BADARGS;
@@ -59,7 +59,7 @@ int wh_Server_DmaRegisterCb32(whServerContext* server, whDmaClientMem32Cb cb)
     return WH_ERROR_OK;
 }
 
-int wh_Server_DmaRegisterCb64(whServerContext* server, whDmaClientMem64Cb cb)
+int wh_Server_DmaRegisterCb64(whServerContext* server, whServerDmaClientMem64Cb cb)
 {
     if (NULL == server || NULL == cb) {
         return WH_ERROR_BADARGS;
@@ -71,7 +71,7 @@ int wh_Server_DmaRegisterCb64(whServerContext* server, whDmaClientMem64Cb cb)
 }
 
 int wh_Server_DmaRegisterAllowList(whServerContext*          server,
-                                   const whDmaAddrAllowList* allowlist)
+                                   const whServerDmaAddrAllowList* allowlist)
 {
     if (NULL == server || NULL == allowlist) {
         return WH_ERROR_BADARGS;
@@ -86,7 +86,7 @@ int wh_Server_DmaRegisterAllowList(whServerContext*          server,
 int wh_Server_DmaProcessClientAddress32(whServerContext* server,
                                         uint32_t         clientAddr,
                                         void** xformedCliAddr, uint32_t len,
-                                        whDmaOper oper, whDmaFlags flags)
+                                        whServerDmaOper oper, whServerDmaFlags flags)
 {
     int rc = WH_ERROR_OK;
 
@@ -117,7 +117,7 @@ int wh_Server_DmaProcessClientAddress32(whServerContext* server,
 int wh_Server_DmaProcessClientAddress64(whServerContext* server,
                                         uint64_t         clientAddr,
                                         void** xformedCliAddr, uint64_t len,
-                                        whDmaOper oper, whDmaFlags flags)
+                                        whServerDmaOper oper, whServerDmaFlags flags)
 {
     int rc = WH_ERROR_OK;
 
@@ -146,7 +146,7 @@ int wh_Server_DmaProcessClientAddress64(whServerContext* server,
 
 int whServerDma_CopyFromClient32(struct whServerContext_t* server,
                                  void* serverPtr, uint32_t clientAddr,
-                                 size_t len, whDmaFlags flags)
+                                 size_t len, whServerDmaFlags flags)
 {
     int rc = WH_ERROR_OK;
 
@@ -187,7 +187,7 @@ int whServerDma_CopyFromClient32(struct whServerContext_t* server,
 
 int whServerDma_CopyFromClient64(struct whServerContext_t* server,
                                  void* serverPtr, uint64_t clientAddr,
-                                 size_t len, whDmaFlags flags)
+                                 size_t len, whServerDmaFlags flags)
 {
     int rc = WH_ERROR_OK;
 
@@ -227,7 +227,7 @@ int whServerDma_CopyFromClient64(struct whServerContext_t* server,
 
 int whServerDma_CopyToClient32(struct whServerContext_t* server,
                                uint32_t clientAddr, void* serverPtr, size_t len,
-                               whDmaFlags flags)
+                               whServerDmaFlags flags)
 {
     int rc = WH_ERROR_OK;
 
@@ -268,7 +268,7 @@ int whServerDma_CopyToClient32(struct whServerContext_t* server,
 
 int whServerDma_CopyToClient64(struct whServerContext_t* server,
                                uint64_t clientAddr, void* serverPtr, size_t len,
-                               whDmaFlags flags)
+                               whServerDmaFlags flags)
 {
     int rc = WH_ERROR_OK;
 

--- a/src/wh_server_dma.c
+++ b/src/wh_server_dma.c
@@ -48,17 +48,27 @@ static int _checkMemOperAgainstAllowList(const whDmaAddrAllowList* allowList,
     return rc;
 }
 
-int wh_Server_DmaRegisterCb(whServerContext* server, whDmaCb cb)
+int wh_Server_DmaRegisterCb32(whServerContext* server, whDmaClientMem32Cb cb)
 {
-    if (NULL == server) {
+    if (NULL == server || NULL == cb) {
         return WH_ERROR_BADARGS;
     }
 
-    server->dmaCb = cb;
+    server->dma.cb32 = cb;
 
     return WH_ERROR_OK;
 }
 
+int wh_Server_DmaRegisterCb64(whServerContext* server, whDmaClientMem64Cb cb)
+{
+    if (NULL == server || NULL == cb) {
+        return WH_ERROR_BADARGS;
+    }
+
+    server->dma.cb64 = cb;
+
+    return WH_ERROR_OK;
+}
 
 int wh_Server_DmaRegisterAllowList(whServerContext*          server,
                                    const whDmaAddrAllowList* allowlist)
@@ -67,7 +77,7 @@ int wh_Server_DmaRegisterAllowList(whServerContext*          server,
         return WH_ERROR_BADARGS;
     }
 
-    server->dmaAddrAllowList = allowlist;
+    server->dma.dmaAddrAllowList = allowlist;
 
     return WH_ERROR_OK;
 }
@@ -88,15 +98,15 @@ int wh_Server_DmaProcessClientAddress32(whServerContext* server,
     *xformedCliAddr = (void*)((uintptr_t)clientAddr);
 
     /* Perform user-supplied address transformation, cache manipulation, etc */
-    if (NULL != server->dmaCb.cb32) {
-        rc = server->dmaCb.cb32(server, clientAddr, xformedCliAddr, len, oper,
+    if (NULL != server->dma.cb32) {
+        rc = server->dma.cb32(server, clientAddr, xformedCliAddr, len, oper,
                                 flags);
     }
 
     /* if the server has a allowlist registered, check transformed address
      * against it */
-    if (server->dmaAddrAllowList != NULL) {
-        rc = _checkMemOperAgainstAllowList(server->dmaAddrAllowList, oper,
+    if (server->dma.dmaAddrAllowList != NULL) {
+        rc = _checkMemOperAgainstAllowList(server->dma.dmaAddrAllowList, oper,
                                            *xformedCliAddr, len);
     }
 
@@ -119,14 +129,14 @@ int wh_Server_DmaProcessClientAddress64(whServerContext* server,
     *xformedCliAddr = (void*)((uintptr_t)clientAddr);
 
     /* Perform user-supplied address transformation, cache manipulation, etc */
-    if (NULL != server->dmaCb.cb64) {
-        rc = server->dmaCb.cb64(server, clientAddr, xformedCliAddr, len, oper,
+    if (NULL != server->dma.cb64) {
+        rc = server->dma.cb64(server, clientAddr, xformedCliAddr, len, oper,
                                 flags);
     }
 
     /* if the server has a allowlist registered, check address against it */
-    if (server->dmaAddrAllowList != NULL) {
-        rc = _checkMemOperAgainstAllowList(server->dmaAddrAllowList, oper,
+    if (server->dma.dmaAddrAllowList != NULL) {
+        rc = _checkMemOperAgainstAllowList(server->dma.dmaAddrAllowList, oper,
                                            *xformedCliAddr, len);
     }
 
@@ -149,7 +159,7 @@ int whServerDma_CopyFromClient32(struct whServerContext_t* server,
 
     /* Check the server address against the allow list */
     rc = _checkMemOperAgainstAllowList(
-        server->dmaAddrAllowList, WH_DMA_OPER_CLIENT_READ_PRE, serverPtr, len);
+        server->dma.dmaAddrAllowList, WH_DMA_OPER_CLIENT_READ_PRE, serverPtr, len);
     if (rc != WH_ERROR_OK) {
         return rc;
     }
@@ -190,7 +200,7 @@ int whServerDma_CopyFromClient64(struct whServerContext_t* server,
 
     /* Check the server address against the allow list */
     rc = _checkMemOperAgainstAllowList(
-        server->dmaAddrAllowList, WH_DMA_OPER_CLIENT_READ_PRE, serverPtr, len);
+        server->dma.dmaAddrAllowList, WH_DMA_OPER_CLIENT_READ_PRE, serverPtr, len);
     if (rc != WH_ERROR_OK) {
         return rc;
     }
@@ -230,7 +240,7 @@ int whServerDma_CopyToClient32(struct whServerContext_t* server,
 
     /* Check the server address against the allow list */
     rc = _checkMemOperAgainstAllowList(
-        server->dmaAddrAllowList, WH_DMA_OPER_CLIENT_WRITE_PRE, serverPtr, len);
+        server->dma.dmaAddrAllowList, WH_DMA_OPER_CLIENT_WRITE_PRE, serverPtr, len);
     if (rc != WH_ERROR_OK) {
         return rc;
     }
@@ -271,7 +281,7 @@ int whServerDma_CopyToClient64(struct whServerContext_t* server,
 
     /* Check the server address against the allow list */
     rc = _checkMemOperAgainstAllowList(
-        server->dmaAddrAllowList, WH_DMA_OPER_CLIENT_WRITE_PRE, serverPtr, len);
+        server->dma.dmaAddrAllowList, WH_DMA_OPER_CLIENT_WRITE_PRE, serverPtr, len);
     if (rc != WH_ERROR_OK) {
         return rc;
     }

--- a/src/wh_server_dma.c
+++ b/src/wh_server_dma.c
@@ -2,6 +2,52 @@
 #include "wolfhsm/wh_error.h"
 #include "wolfhsm/wh_server_dma.h"
 
+/* TODO: if the Address allowlist ever gets large, we should consider a more
+ * efficient representation (requiring sorted array and binary search, or
+ * building a binary tree, etc.) */
+
+
+static int _checkAddrAgainstAllowList(const whDmaAddrList allowList, void* addr,
+                                      size_t size)
+{
+    uintptr_t startAddr = (uintptr_t)addr;
+    uintptr_t endAddr   = startAddr + size;
+
+    /* Check if the address range is fully within a allowlist entry */
+    for (int i = 0; i < WH_DMA_ADDR_ALLOWLIST_SIZE; i++) {
+        uintptr_t allowlistStartAddr = (uintptr_t)allowList[i].addr;
+        uintptr_t allowlistEndAddr   = allowlistStartAddr + allowList[i].size;
+
+        if (startAddr >= allowlistStartAddr && endAddr <= allowlistEndAddr) {
+            return WH_ERROR_OK;
+        }
+    }
+
+    return WH_ERROR_ACCESS;
+}
+
+static int _checkMemOperAgainstAllowList(const whDmaAddrAllowList* allowList,
+                                         whDmaOper oper, void* addr,
+                                         size_t size)
+{
+    int rc = WH_ERROR_OK;
+
+    /* If a read/write operation is requested, check the transformed address
+     * against the appropriate allowlist
+     *
+     * TODO: do we need to allowlist check on POST in case there are subsequent
+     * memory operations for some reason?
+     */
+    if (oper == WH_DMA_OPER_CLIENT_READ_PRE) {
+        rc = _checkAddrAgainstAllowList(allowList->readList, addr, size);
+    }
+    else if (oper == WH_DMA_OPER_CLIENT_WRITE_PRE) {
+        rc = _checkAddrAgainstAllowList(allowList->writeList, addr, size);
+    }
+
+    return rc;
+}
+
 int wh_Server_DmaRegisterCb(whServerContext* server, whDmaCb cb)
 {
     if (NULL == server) {
@@ -9,6 +55,17 @@ int wh_Server_DmaRegisterCb(whServerContext* server, whDmaCb cb)
     }
 
     server->dmaCb = cb;
+
+    return WH_ERROR_OK;
+}
+
+
+int wh_Server_DmaRegisterAllowList(whServerContext* server, const whDmaAddrAllowList* allowlist) {
+    if (NULL == server || NULL == allowlist) {
+        return WH_ERROR_BADARGS;
+    }
+
+    server->dmaAddrAllowList = allowlist;
 
     return WH_ERROR_OK;
 }
@@ -25,12 +82,21 @@ int wh_Server_DmaProcessClientAddress32(whServerContext* server,
         return WH_ERROR_BADARGS;
     }
 
+    /* Perform user-supplied address transformation, cache manipulation, etc */
     if (NULL != server->dmaCb.cb32) {
         rc =
             server->dmaCb.cb32(server, clientAddr, serverPtr, len, oper, flags);
     }
+    else {
+        /* No callback registered, so just use the address as-is */
+        *serverPtr = (void*)((uintptr_t)clientAddr);
+    }
 
-    /* TODO: other stuff besides invoking client DMA callback? */
+    /* if the server has a allowlist registered, check address against it */
+    if (server->dmaAddrAllowList != NULL) {
+        rc = _checkMemOperAgainstAllowList(server->dmaAddrAllowList, oper,
+                                           *serverPtr, len);
+    }
 
     return rc;
 }
@@ -47,12 +113,141 @@ int wh_Server_DmaProcessClientAddress64(whServerContext* server,
         return WH_ERROR_BADARGS;
     }
 
+    /* Perform user-supplied address transformation, cache manipulation, etc */
     if (NULL != server->dmaCb.cb64) {
         rc =
             server->dmaCb.cb64(server, clientAddr, serverPtr, len, oper, flags);
     }
+    else {
+        /* No callback registered, so just use the address as-is */
+        *serverPtr = (void*)clientAddr;
+    }
 
-    /* TODO: other stuff besides invoking client DMA callback? */
+    /* if the server has a allowlist registered, check address against it */
+    if (server->dmaAddrAllowList != NULL) {
+        rc = _checkMemOperAgainstAllowList(server->dmaAddrAllowList, oper,
+                                           *serverPtr, len);
+    }
 
     return rc;
 }
+
+
+int whServerDma_CopyFromClient32(struct whServerContext_t* server,
+                                 void* serverPtr, uint32_t clientAddr,
+                                 size_t len, whDmaFlags flags)
+{
+    int rc = WH_ERROR_OK;
+
+    /* TODO: should len be checked against UINTxxMax? Should it be size_t? */
+    if (NULL == server || NULL == serverPtr || 0 == len) {
+        return WH_ERROR_BADARGS;
+    }
+
+    rc =
+        wh_Server_DmaProcessClientAddress32(server, clientAddr, &serverPtr, len,
+                                            WH_DMA_OPER_CLIENT_READ_PRE, flags);
+    if (rc != WH_ERROR_OK) {
+        return rc;
+    }
+
+    /* Perform the actual copy */
+    /* TODO should we add a flag to force client word-sized reads? */
+    memcpy(serverPtr, (void*)((uintptr_t)clientAddr), len);
+
+    rc = wh_Server_DmaProcessClientAddress32(server, clientAddr, &serverPtr,
+                                             len, WH_DMA_OPER_CLIENT_READ_POST,
+                                             flags);
+
+    return rc;
+}
+
+
+int whServerDma_CopyFromClient64(struct whServerContext_t* server,
+                                 void* serverPtr, uint64_t clientAddr,
+                                 size_t len, whDmaFlags flags)
+{
+    int rc = WH_ERROR_OK;
+
+    /* TODO: should len be checked against UINTxxMax? Should it be size_t? */
+    if (NULL == server || NULL == serverPtr || 0 == len) {
+        return WH_ERROR_BADARGS;
+    }
+
+    rc =
+        wh_Server_DmaProcessClientAddress64(server, clientAddr, &serverPtr, len,
+                                            WH_DMA_OPER_CLIENT_READ_PRE, flags);
+    if (rc != WH_ERROR_OK) {
+        return rc;
+    }
+
+    /* Perform the actual copy */
+    /* TODO should we add a flag to force client word-sized reads? */
+    memcpy(serverPtr, (void*)((uintptr_t)clientAddr), len);
+
+    rc = wh_Server_DmaProcessClientAddress64(server, clientAddr, &serverPtr,
+                                             len, WH_DMA_OPER_CLIENT_READ_POST,
+                                             flags);
+
+    return rc;
+
+}
+
+int whServerDma_CopyToClient32(struct whServerContext_t* server,
+                               uint32_t clientAddr, void* serverPtr,
+                               size_t len, whDmaFlags flags)
+{
+    int rc = WH_ERROR_OK;
+
+    /* TODO: should len be checked against UINTxxMax? Should it be size_t? */
+    if (NULL == server || NULL == serverPtr || 0 == len) {
+        return WH_ERROR_BADARGS;
+    }
+
+    rc =
+        wh_Server_DmaProcessClientAddress32(server, clientAddr, &serverPtr, len,
+                                            WH_DMA_OPER_CLIENT_WRITE_PRE, flags);
+    if (rc != WH_ERROR_OK) {
+        return rc;
+    }
+
+    /* Perform the actual copy */
+    /* TODO should we add a flag to force client word-sized reads? */
+    memcpy(serverPtr, (void*)((uintptr_t)clientAddr), len);
+
+    rc = wh_Server_DmaProcessClientAddress32(server, clientAddr, &serverPtr,
+                                             len, WH_DMA_OPER_CLIENT_WRITE_POST,
+                                             flags);
+
+    return rc;
+}
+
+
+int whServerDma_CopyToClient64(struct whServerContext_t* server, 
+                               uint64_t clientAddr, void* serverPtr,
+                               size_t len, whDmaFlags flags)
+{
+        int rc = WH_ERROR_OK;
+
+    /* TODO: should len be checked against UINTxxMax? Should it be size_t? */
+    if (NULL == server || NULL == serverPtr || 0 == len) {
+        return WH_ERROR_BADARGS;
+    }
+
+    rc =
+        wh_Server_DmaProcessClientAddress64(server, clientAddr, &serverPtr, len,
+                                            WH_DMA_OPER_CLIENT_WRITE_PRE, flags);
+    if (rc != WH_ERROR_OK) {
+        return rc;
+    }
+
+    /* Perform the actual copy */
+    /* TODO should we add a flag to force client word-sized reads? */
+    memcpy(serverPtr, (void*)((uintptr_t)clientAddr), len);
+
+    rc = wh_Server_DmaProcessClientAddress64(server, clientAddr, &serverPtr,
+                                             len, WH_DMA_OPER_CLIENT_WRITE_POST,
+                                             flags);
+
+    return rc;
+}                            

--- a/src/wh_server_dma.c
+++ b/src/wh_server_dma.c
@@ -1,0 +1,58 @@
+#include "wolfhsm/wh_server.h"
+#include "wolfhsm/wh_error.h"
+#include "wolfhsm/wh_server_dma.h"
+
+int wh_Server_DmaRegisterCb(whServerContext* server, whDmaCb cb)
+{
+    if (NULL == server) {
+        return WH_ERROR_BADARGS;
+    }
+
+    server->dmaCb = cb;
+
+    return WH_ERROR_OK;
+}
+
+
+int wh_Server_DmaProcessClientAddress32(whServerContext* server,
+                                        uint32_t clientAddr, void** serverPtr,
+                                        uint32_t len, whDmaOper oper,
+                                        whDmaFlags flags)
+{
+    int rc = WH_ERROR_OK;
+
+    if (NULL == server) {
+        return WH_ERROR_BADARGS;
+    }
+
+    if (NULL != server->dmaCb.cb32) {
+        rc =
+            server->dmaCb.cb32(server, clientAddr, serverPtr, len, oper, flags);
+    }
+
+    /* TODO: other stuff besides invoking client DMA callback? */
+
+    return rc;
+}
+
+
+int wh_Server_DmaProcessClientAddress64(whServerContext* server,
+                                        uint64_t clientAddr, void** serverPtr,
+                                        uint64_t len, whDmaOper oper,
+                                        whDmaFlags flags)
+{
+    int rc = WH_ERROR_OK;
+
+    if (NULL == server) {
+        return WH_ERROR_BADARGS;
+    }
+
+    if (NULL != server->dmaCb.cb64) {
+        rc =
+            server->dmaCb.cb64(server, clientAddr, serverPtr, len, oper, flags);
+    }
+
+    /* TODO: other stuff besides invoking client DMA callback? */
+
+    return rc;
+}

--- a/src/wh_server_dma.c
+++ b/src/wh_server_dma.c
@@ -13,12 +13,20 @@ static int _checkAddrAgainstAllowList(const whServerDmaAddrList allowList, void*
     uintptr_t startAddr = (uintptr_t)addr;
     uintptr_t endAddr   = startAddr + size;
 
-    /* Check if the address range is fully within a allowlist entry */
-    for (int i = 0; i < WH_DMA_ADDR_ALLOWLIST_SIZE; i++) {
-        uintptr_t allowlistStartAddr = (uintptr_t)allowList[i].addr;
-        uintptr_t allowlistEndAddr   = allowlistStartAddr + allowList[i].size;
+    if (0 == size) {
+        return WH_ERROR_BADARGS;
+    }
 
-        if (startAddr >= allowlistStartAddr && endAddr <= allowlistEndAddr) {
+    /* Check if the address range is fully within a allowlist entry */
+    for (int i = 0; i < WH_DMA_ADDR_ALLOWLIST_COUNT; i++) {
+        uintptr_t allowListStartAddr = (uintptr_t)allowList[i].addr;
+        uintptr_t allowListEndAddr   = allowListStartAddr + allowList[i].size;
+
+        if (0 == allowList[i].size) {
+            continue;
+        }
+
+        if (startAddr >= allowListStartAddr && endAddr <= allowListEndAddr) {
             return WH_ERROR_OK;
         }
     }
@@ -70,7 +78,7 @@ int wh_Server_DmaRegisterCb64(whServerContext* server, whServerDmaClientMem64Cb 
     return WH_ERROR_OK;
 }
 
-int wh_Server_DmaRegisterAllowList(whServerContext*          server,
+int wh_Server_DmaRegisterAllowList(whServerContext*                server,
                                    const whServerDmaAddrAllowList* allowlist)
 {
     if (NULL == server || NULL == allowlist) {
@@ -86,7 +94,8 @@ int wh_Server_DmaRegisterAllowList(whServerContext*          server,
 int wh_Server_DmaProcessClientAddress32(whServerContext* server,
                                         uint32_t         clientAddr,
                                         void** xformedCliAddr, uint32_t len,
-                                        whServerDmaOper oper, whServerDmaFlags flags)
+                                        whServerDmaOper  oper,
+                                        whServerDmaFlags flags)
 {
     int rc = WH_ERROR_OK;
 

--- a/src/wh_server_dma.c
+++ b/src/wh_server_dma.c
@@ -80,7 +80,7 @@ int wh_Server_DmaProcessClientAddress32(whServerContext* server,
 {
     int rc = WH_ERROR_OK;
 
-    if (NULL == server) {
+    if (NULL == server || NULL == xformedCliAddr) {
         return WH_ERROR_BADARGS;
     }
 
@@ -111,7 +111,7 @@ int wh_Server_DmaProcessClientAddress64(whServerContext* server,
 {
     int rc = WH_ERROR_OK;
 
-    if (NULL == server) {
+    if (NULL == server || NULL == xformedCliAddr) {
         return WH_ERROR_BADARGS;
     }
 
@@ -142,7 +142,7 @@ int whServerDma_CopyFromClient32(struct whServerContext_t* server,
 
     void* transformedAddr = NULL;
 
-    /* TODO: should len be checked against UINTxxMax? Should it be size_t? */
+    /* TODO: should len be checked against UINT32Max? Should it be uint32_t? */
     if (NULL == server || NULL == serverPtr || 0 == len) {
         return WH_ERROR_BADARGS;
     }
@@ -183,7 +183,7 @@ int whServerDma_CopyFromClient64(struct whServerContext_t* server,
 
     void* transformedAddr = NULL;
 
-    /* TODO: should len be checked against UINTxxMax? Should it be size_t? */
+    /* TODO: should len be be uint64_t? */
     if (NULL == server || NULL == serverPtr || 0 == len) {
         return WH_ERROR_BADARGS;
     }
@@ -223,7 +223,7 @@ int whServerDma_CopyToClient32(struct whServerContext_t* server,
 
     void* transformedAddr = NULL;
 
-    /* TODO: should len be checked against UINTxxMax? Should it be size_t? */
+    /* TODO: should len be checked against UINT32Max? Should it be uint32_t ? */
     if (NULL == server || NULL == serverPtr || 0 == len) {
         return WH_ERROR_BADARGS;
     }
@@ -264,7 +264,7 @@ int whServerDma_CopyToClient64(struct whServerContext_t* server,
 
     void* transformedAddr = NULL;
 
-    /* TODO: should len be checked against UINTxxMax? Should it be size_t? */
+    /* TODO: should len be uint64_t? */
     if (NULL == server || NULL == serverPtr || 0 == len) {
         return WH_ERROR_BADARGS;
     }

--- a/src/wh_server_dma.c
+++ b/src/wh_server_dma.c
@@ -88,7 +88,9 @@ int wh_Server_DmaCheckMemOperAllowed(const whServerContext* server,
 
 int wh_Server_DmaRegisterCb32(whServerContext* server, whServerDmaClientMem32Cb cb)
 {
-    if (NULL == server || NULL == cb) {
+    /* No NULL check for cb, since it is optional and always NULL checked before
+     * it is called */
+    if (NULL == server) {
         return WH_ERROR_BADARGS;
     }
 
@@ -99,7 +101,9 @@ int wh_Server_DmaRegisterCb32(whServerContext* server, whServerDmaClientMem32Cb 
 
 int wh_Server_DmaRegisterCb64(whServerContext* server, whServerDmaClientMem64Cb cb)
 {
-    if (NULL == server || NULL == cb) {
+    /* No NULL check for cb, since it is optional and always NULL checked before
+     * it is called */
+    if (NULL == server) {
         return WH_ERROR_BADARGS;
     }
 

--- a/src/wh_server_nvm.c
+++ b/src/wh_server_nvm.c
@@ -265,14 +265,14 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
             /* perform platform-specific host address processing */
             resp.rc = wh_Server_DmaProcessClientAddress32(
                 server, req.metadata_hostaddr, &metadata, sizeof(whNvmMetadata),
-                WH_DMA_OPER_CLIENT_READ_PRE, (whDmaFlags){0});
+                WH_DMA_OPER_CLIENT_READ_PRE, (whServerDmaFlags){0});
             if (resp.rc != WH_ERROR_OK) {
                 goto transRespAddObjDma32;
             }
 
             resp.rc = wh_Server_DmaProcessClientAddress32(
                 server, req.data_hostaddr, &data, req.data_len,
-                WH_DMA_OPER_CLIENT_READ_PRE, (whDmaFlags){0});
+                WH_DMA_OPER_CLIENT_READ_PRE, (whServerDmaFlags){0});
             if (resp.rc != WH_ERROR_OK) {
                 goto transRespAddObjDma32;
             }
@@ -289,14 +289,14 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
             /* perform platform-specific host address processing */
             resp.rc = wh_Server_DmaProcessClientAddress32(
                 server, req.metadata_hostaddr, &metadata, sizeof(whNvmMetadata),
-                WH_DMA_OPER_CLIENT_READ_POST, (whDmaFlags){0});
+                WH_DMA_OPER_CLIENT_READ_POST, (whServerDmaFlags){0});
             if (resp.rc != WH_ERROR_OK) {
                 goto transRespAddObjDma32;
             }
 
             resp.rc = wh_Server_DmaProcessClientAddress32(
                 server, req.data_hostaddr, &data, req.data_len,
-                WH_DMA_OPER_CLIENT_READ_POST, (whDmaFlags){0});
+                WH_DMA_OPER_CLIENT_READ_POST, (whServerDmaFlags){0});
         } else {
             /* Request is malformed */
             resp.rc = WH_ERROR_ABORTED;
@@ -322,7 +322,7 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
             /* perform platform-specific host address processing */
             resp.rc = wh_Server_DmaProcessClientAddress32(
                 server, req.data_hostaddr, &data, req.data_len,
-                WH_DMA_OPER_CLIENT_WRITE_PRE, (whDmaFlags){0});
+                WH_DMA_OPER_CLIENT_WRITE_PRE, (whServerDmaFlags){0});
             if (resp.rc != WH_ERROR_OK) {
                 goto transRespReadDma32;
             }
@@ -337,7 +337,7 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
             /* perform platform-specific host address processing */
             resp.rc = wh_Server_DmaProcessClientAddress32(
                 server, req.data_hostaddr, &data, req.data_len,
-                WH_DMA_OPER_CLIENT_WRITE_POST, (whDmaFlags){0});
+                WH_DMA_OPER_CLIENT_WRITE_POST, (whServerDmaFlags){0});
         } else {
             /* Request is malformed */
             resp.rc = WH_ERROR_ABORTED;
@@ -364,14 +364,14 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
             /* perform platform-specific host address processing */
             resp.rc = wh_Server_DmaProcessClientAddress64(
                 server, req.metadata_hostaddr, &metadata, sizeof(whNvmMetadata),
-                WH_DMA_OPER_CLIENT_READ_PRE, (whDmaFlags){0});
+                WH_DMA_OPER_CLIENT_READ_PRE, (whServerDmaFlags){0});
             if (resp.rc != WH_ERROR_OK) {
                 goto transRespAddObjectDma64;
             }
 
             resp.rc = wh_Server_DmaProcessClientAddress64(
                 server, req.data_hostaddr, &data, req.data_len,
-                WH_DMA_OPER_CLIENT_READ_PRE, (whDmaFlags){0});
+                WH_DMA_OPER_CLIENT_READ_PRE, (whServerDmaFlags){0});
             if (resp.rc != WH_ERROR_OK) {
                 goto transRespAddObjectDma64;
             }
@@ -388,14 +388,14 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
             /* perform platform-specific host address processing */
             resp.rc = wh_Server_DmaProcessClientAddress64(
                 server, req.metadata_hostaddr, &metadata, sizeof(whNvmMetadata),
-                WH_DMA_OPER_CLIENT_READ_POST, (whDmaFlags){0});
+                WH_DMA_OPER_CLIENT_READ_POST, (whServerDmaFlags){0});
             if (resp.rc != WH_ERROR_OK) {
                 goto transRespAddObjectDma64;
             }
 
             resp.rc = wh_Server_DmaProcessClientAddress64(
                 server, req.data_hostaddr, &data, req.data_len,
-                WH_DMA_OPER_CLIENT_READ_POST, (whDmaFlags){0});
+                WH_DMA_OPER_CLIENT_READ_POST, (whServerDmaFlags){0});
         } else {
             /* Request is malformed */
             resp.rc = WH_ERROR_ABORTED;
@@ -421,7 +421,7 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
             /* perform platform-specific host address processing */
             resp.rc = wh_Server_DmaProcessClientAddress64(
                 server, req.data_hostaddr, &data, req.data_len,
-                WH_DMA_OPER_CLIENT_WRITE_PRE, (whDmaFlags){0});
+                WH_DMA_OPER_CLIENT_WRITE_PRE, (whServerDmaFlags){0});
             if (resp.rc != WH_ERROR_OK) {
                 goto transRespReadDma64;
             }
@@ -436,7 +436,7 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
             /* perform platform-specific host address processing */
             resp.rc = wh_Server_DmaProcessClientAddress64(
                 server, req.data_hostaddr, &data, req.data_len,
-                WH_DMA_OPER_CLIENT_WRITE_POST, (whDmaFlags){0});
+                WH_DMA_OPER_CLIENT_WRITE_POST, (whServerDmaFlags){0});
         } else {
             /* Request is malformed */
             resp.rc = WH_ERROR_ABORTED;

--- a/src/wh_server_nvm.c
+++ b/src/wh_server_nvm.c
@@ -263,30 +263,45 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
                     (whMessageNvm_AddObjectDma32Request*)req_packet, &req);
 
             /* perform platform-specific host address processing */
-            wh_Server_DmaProcessClientAddress32(
+            resp.rc = wh_Server_DmaProcessClientAddress32(
                 server, req.metadata_hostaddr, &metadata, sizeof(whNvmMetadata),
                 WH_DMA_OPER_CLIENT_READ_PRE, (whDmaFlags){0});
-            wh_Server_DmaProcessClientAddress32(
+            if (resp.rc != WH_ERROR_OK) {
+                goto transRespAddObjDma32;
+            }
+
+            resp.rc = wh_Server_DmaProcessClientAddress32(
                 server, req.data_hostaddr, &data, req.data_len,
                 WH_DMA_OPER_CLIENT_READ_PRE, (whDmaFlags){0});
+            if (resp.rc != WH_ERROR_OK) {
+                goto transRespAddObjDma32;
+            }
 
             /* Process the AddObject action */
             resp.rc = wh_Nvm_AddObject(server->nvm,
                     (whNvmMetadata*)metadata,
                     req.data_len,
                     (const uint8_t*)data);
+            if (resp.rc != WH_ERROR_OK) {
+                goto transRespAddObjDma32;
+            }
 
             /* perform platform-specific host address processing */
-            wh_Server_DmaProcessClientAddress32(
+            resp.rc = wh_Server_DmaProcessClientAddress32(
                 server, req.metadata_hostaddr, &metadata, sizeof(whNvmMetadata),
                 WH_DMA_OPER_CLIENT_READ_POST, (whDmaFlags){0});
-            wh_Server_DmaProcessClientAddress32(
+            if (resp.rc != WH_ERROR_OK) {
+                goto transRespAddObjDma32;
+            }
+
+            resp.rc = wh_Server_DmaProcessClientAddress32(
                 server, req.data_hostaddr, &data, req.data_len,
                 WH_DMA_OPER_CLIENT_READ_POST, (whDmaFlags){0});
         } else {
             /* Request is malformed */
             resp.rc = WH_ERROR_ABORTED;
         }
+    transRespAddObjDma32:
         /* Convert the response struct */
         wh_MessageNvm_TranslateSimpleResponse(magic,
                 &resp, (whMessageNvm_SimpleResponse*)resp_packet);
@@ -305,22 +320,29 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
                     (whMessageNvm_ReadDma32Request*)req_packet, &req);
 
             /* perform platform-specific host address processing */
-            wh_Server_DmaProcessClientAddress32(
+            resp.rc = wh_Server_DmaProcessClientAddress32(
                 server, req.data_hostaddr, &data, req.data_len,
                 WH_DMA_OPER_CLIENT_WRITE_PRE, (whDmaFlags){0});
+            if (resp.rc != WH_ERROR_OK) {
+                goto transRespReadDma32;
+            }
 
             /* Process the Read action */
             resp.rc = wh_Nvm_Read(server->nvm, req.id, req.offset, req.data_len,
                     (uint8_t*)data);
+            if (resp.rc != WH_ERROR_OK) {
+                goto transRespReadDma32;
+            }
 
             /* perform platform-specific host address processing */
-            wh_Server_DmaProcessClientAddress32(
+            resp.rc = wh_Server_DmaProcessClientAddress32(
                 server, req.data_hostaddr, &data, req.data_len,
                 WH_DMA_OPER_CLIENT_WRITE_POST, (whDmaFlags){0});
         } else {
             /* Request is malformed */
             resp.rc = WH_ERROR_ABORTED;
         }
+    transRespReadDma32:
         /* Convert the response struct */
         wh_MessageNvm_TranslateSimpleResponse(magic,
                 &resp, (whMessageNvm_SimpleResponse*)resp_packet);
@@ -340,30 +362,45 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
                     (whMessageNvm_AddObjectDma64Request*)req_packet, &req);
 
             /* perform platform-specific host address processing */
-            wh_Server_DmaProcessClientAddress64(
+            resp.rc = wh_Server_DmaProcessClientAddress64(
                 server, req.metadata_hostaddr, &metadata, sizeof(whNvmMetadata),
                 WH_DMA_OPER_CLIENT_READ_PRE, (whDmaFlags){0});
-            wh_Server_DmaProcessClientAddress64(
+            if (resp.rc != WH_ERROR_OK) {
+                goto transRespAddObjectDma64;
+            }
+
+            resp.rc = wh_Server_DmaProcessClientAddress64(
                 server, req.data_hostaddr, &data, req.data_len,
                 WH_DMA_OPER_CLIENT_READ_PRE, (whDmaFlags){0});
+            if (resp.rc != WH_ERROR_OK) {
+                goto transRespAddObjectDma64;
+            }
 
             /* Process the AddObject action */
             resp.rc = wh_Nvm_AddObject(server->nvm,
                     (whNvmMetadata*)metadata,
                     req.data_len,
                     (const uint8_t*)data);
+            if (resp.rc != WH_ERROR_OK) {
+                goto transRespAddObjectDma64;
+            }
 
             /* perform platform-specific host address processing */
-            wh_Server_DmaProcessClientAddress64(
+            resp.rc = wh_Server_DmaProcessClientAddress64(
                 server, req.metadata_hostaddr, &metadata, sizeof(whNvmMetadata),
                 WH_DMA_OPER_CLIENT_READ_POST, (whDmaFlags){0});
-            wh_Server_DmaProcessClientAddress64(
+            if (resp.rc != WH_ERROR_OK) {
+                goto transRespAddObjectDma64;
+            }
+
+            resp.rc = wh_Server_DmaProcessClientAddress64(
                 server, req.data_hostaddr, &data, req.data_len,
                 WH_DMA_OPER_CLIENT_READ_POST, (whDmaFlags){0});
         } else {
             /* Request is malformed */
             resp.rc = WH_ERROR_ABORTED;
         }
+    transRespAddObjectDma64:
         /* Convert the response struct */
         wh_MessageNvm_TranslateSimpleResponse(magic,
                 &resp, (whMessageNvm_SimpleResponse*)resp_packet);
@@ -382,22 +419,29 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
                     (whMessageNvm_ReadDma64Request*)req_packet, &req);
 
             /* perform platform-specific host address processing */
-            wh_Server_DmaProcessClientAddress64(
+            resp.rc = wh_Server_DmaProcessClientAddress64(
                 server, req.data_hostaddr, &data, req.data_len,
                 WH_DMA_OPER_CLIENT_WRITE_PRE, (whDmaFlags){0});
+            if (resp.rc != WH_ERROR_OK) {
+                goto transRespReadDma64;
+            }
 
             /* Process the Read action */
             resp.rc = wh_Nvm_Read(server->nvm, req.id, req.offset, req.data_len,
                     (uint8_t*)data);
+            if (resp.rc != WH_ERROR_OK) {
+                goto transRespReadDma64;
+            }
 
             /* perform platform-specific host address processing */
-            wh_Server_DmaProcessClientAddress64(
+            resp.rc = wh_Server_DmaProcessClientAddress64(
                 server, req.data_hostaddr, &data, req.data_len,
                 WH_DMA_OPER_CLIENT_WRITE_POST, (whDmaFlags){0});
         } else {
             /* Request is malformed */
             resp.rc = WH_ERROR_ABORTED;
         }
+    transRespReadDma64:
         /* Convert the response struct */
         wh_MessageNvm_TranslateSimpleResponse(magic,
                 &resp, (whMessageNvm_SimpleResponse*)resp_packet);

--- a/src/wh_server_nvm.c
+++ b/src/wh_server_nvm.c
@@ -262,16 +262,27 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
             wh_MessageNvm_TranslateAddObjectDma32Request(magic,
                     (whMessageNvm_AddObjectDma32Request*)req_packet, &req);
 
-            /* TODO: Add hostaddr conversion/checking */
-            metadata =(void*)((intptr_t)req.metadata_hostaddr);
-            data = (void*)((intptr_t)req.data_hostaddr);
-            /* TODO: Add data_len checking */
+            /* perform platform-specific host address processing */
+            wh_Server_DmaProcessClientAddress32(
+                server, req.metadata_hostaddr, &metadata, sizeof(whNvmMetadata),
+                WH_DMA_OPER_CLIENT_READ_PRE, (whDmaFlags){0});
+            wh_Server_DmaProcessClientAddress32(
+                server, req.data_hostaddr, &data, req.data_len,
+                WH_DMA_OPER_CLIENT_READ_PRE, (whDmaFlags){0});
 
             /* Process the AddObject action */
             resp.rc = wh_Nvm_AddObject(server->nvm,
                     (whNvmMetadata*)metadata,
                     req.data_len,
                     (const uint8_t*)data);
+
+            /* perform platform-specific host address processing */
+            wh_Server_DmaProcessClientAddress32(
+                server, req.metadata_hostaddr, &metadata, sizeof(whNvmMetadata),
+                WH_DMA_OPER_CLIENT_READ_POST, (whDmaFlags){0});
+            wh_Server_DmaProcessClientAddress32(
+                server, req.data_hostaddr, &data, req.data_len,
+                WH_DMA_OPER_CLIENT_READ_POST, (whDmaFlags){0});
         } else {
             /* Request is malformed */
             resp.rc = WH_ERROR_ABORTED;
@@ -293,12 +304,19 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
             wh_MessageNvm_TranslateReadDma32Request(magic,
                     (whMessageNvm_ReadDma32Request*)req_packet, &req);
 
-            /* TODO: Add hostaddr conversion/checking */
-            data = (void*)((intptr_t)req.data_hostaddr);
+            /* perform platform-specific host address processing */
+            wh_Server_DmaProcessClientAddress32(
+                server, req.data_hostaddr, &data, req.data_len,
+                WH_DMA_OPER_CLIENT_WRITE_PRE, (whDmaFlags){0});
 
             /* Process the Read action */
             resp.rc = wh_Nvm_Read(server->nvm, req.id, req.offset, req.data_len,
                     (uint8_t*)data);
+
+            /* perform platform-specific host address processing */
+            wh_Server_DmaProcessClientAddress32(
+                server, req.data_hostaddr, &data, req.data_len,
+                WH_DMA_OPER_CLIENT_WRITE_POST, (whDmaFlags){0});
         } else {
             /* Request is malformed */
             resp.rc = WH_ERROR_ABORTED;
@@ -321,15 +339,27 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
             wh_MessageNvm_TranslateAddObjectDma64Request(magic,
                     (whMessageNvm_AddObjectDma64Request*)req_packet, &req);
 
-            /* TODO: Add hostaddr conversion/checking */
-            metadata =(void*)((intptr_t)req.metadata_hostaddr);
-            data = (void*)((intptr_t)req.data_hostaddr);
+            /* perform platform-specific host address processing */
+            wh_Server_DmaProcessClientAddress64(
+                server, req.metadata_hostaddr, &metadata, sizeof(whNvmMetadata),
+                WH_DMA_OPER_CLIENT_READ_PRE, (whDmaFlags){0});
+            wh_Server_DmaProcessClientAddress64(
+                server, req.data_hostaddr, &data, req.data_len,
+                WH_DMA_OPER_CLIENT_READ_PRE, (whDmaFlags){0});
 
             /* Process the AddObject action */
             resp.rc = wh_Nvm_AddObject(server->nvm,
                     (whNvmMetadata*)metadata,
                     req.data_len,
                     (const uint8_t*)data);
+
+            /* perform platform-specific host address processing */
+            wh_Server_DmaProcessClientAddress64(
+                server, req.metadata_hostaddr, &metadata, sizeof(whNvmMetadata),
+                WH_DMA_OPER_CLIENT_READ_POST, (whDmaFlags){0});
+            wh_Server_DmaProcessClientAddress64(
+                server, req.data_hostaddr, &data, req.data_len,
+                WH_DMA_OPER_CLIENT_READ_POST, (whDmaFlags){0});
         } else {
             /* Request is malformed */
             resp.rc = WH_ERROR_ABORTED;
@@ -351,12 +381,19 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
             wh_MessageNvm_TranslateReadDma64Request(magic,
                     (whMessageNvm_ReadDma64Request*)req_packet, &req);
 
-            /* TODO: Add hostaddr conversion/checking */
-            data = (void*)((intptr_t)req.data_hostaddr);
+            /* perform platform-specific host address processing */
+            wh_Server_DmaProcessClientAddress64(
+                server, req.data_hostaddr, &data, req.data_len,
+                WH_DMA_OPER_CLIENT_WRITE_PRE, (whDmaFlags){0});
 
             /* Process the Read action */
             resp.rc = wh_Nvm_Read(server->nvm, req.id, req.offset, req.data_len,
                     (uint8_t*)data);
+
+            /* perform platform-specific host address processing */
+            wh_Server_DmaProcessClientAddress64(
+                server, req.data_hostaddr, &data, req.data_len,
+                WH_DMA_OPER_CLIENT_WRITE_POST, (whDmaFlags){0});
         } else {
             /* Request is malformed */
             resp.rc = WH_ERROR_ABORTED;

--- a/test/Makefile
+++ b/test/Makefile
@@ -80,6 +80,7 @@ SRC_C += \
             $(WOLFHSM_DIR)/src/wh_client_cryptocb.c \
             $(WOLFHSM_DIR)/src/wh_server.c \
             $(WOLFHSM_DIR)/src/wh_server_customcb.c \
+            $(WOLFHSM_DIR)/src/wh_server_dma.c \
             $(WOLFHSM_DIR)/src/wh_server_nvm.c \
             $(WOLFHSM_DIR)/src/wh_server_crypto.c \
             $(WOLFHSM_DIR)/src/wh_server_keystore.c \

--- a/test/wh_test_clientserver.c
+++ b/test/wh_test_clientserver.c
@@ -229,8 +229,8 @@ static int _testDma(whServerContext* server, whClientContext* client)
     };
 
     /* Register a custom DMA callback */
-    WH_TEST_RETURN_ON_FAIL(wh_Server_DmaRegisterCb(
-        server, (whDmaCb){_customServerDma32Cb, _customServerDma64Cb}));
+    WH_TEST_RETURN_ON_FAIL(wh_Server_DmaRegisterCb32(server, _customServerDma32Cb));
+    WH_TEST_RETURN_ON_FAIL(wh_Server_DmaRegisterCb64(server, _customServerDma64Cb));
 
     /* Register our custom allow list */
     WH_TEST_RETURN_ON_FAIL(wh_Server_DmaRegisterAllowList(server, &allowList));

--- a/test/wh_test_clientserver.c
+++ b/test/wh_test_clientserver.c
@@ -154,8 +154,8 @@ static int _testCallbacks(whServerContext* server, whClientContext* client)
 
 static int _customServerDmaCb(struct whServerContext_t* server,
                               void* clientAddr, void** serverPtr,
-                              uint32_t len, whDmaOper oper,
-                              whDmaFlags flags)
+                              uint32_t len, whServerDmaOper oper,
+                              whServerDmaFlags flags)
 {
     /* remapped "client" address, a.k.a. arbitary "server" buffer */
     void *srvTmpBuf = (void*)((uintptr_t)clientAddr +
@@ -196,7 +196,7 @@ static int _customServerDmaCb(struct whServerContext_t* server,
 
 static int _customServerDma32Cb(struct whServerContext_t* server,
                                 uint32_t clientAddr, void** serverPtr,
-                                uint32_t len, whDmaOper oper, whDmaFlags flags)
+                                uint32_t len, whServerDmaOper oper, whServerDmaFlags flags)
 {
     return _customServerDmaCb(server, (void*)((uintptr_t)clientAddr), serverPtr,
                               len, oper, flags);
@@ -204,7 +204,7 @@ static int _customServerDma32Cb(struct whServerContext_t* server,
 
 static int _customServerDma64Cb(struct whServerContext_t* server,
                                 uint64_t clientAddr, void** serverPtr,
-                                uint64_t len, whDmaOper oper, whDmaFlags flags)
+                                uint64_t len, whServerDmaOper oper, whServerDmaFlags flags)
 {
     return _customServerDmaCb(server, (void*)((uintptr_t)clientAddr), serverPtr,
                               len, oper, flags);
@@ -215,7 +215,7 @@ static int _testDma(whServerContext* server, whClientContext* client)
     int rc = 0;
     TestMemory testMem = {0};
 
-    const whDmaAddrAllowList allowList = {
+    const whServerDmaAddrAllowList allowList = {
         .readList =
             {
                 {&testMem.srvBufAllow, sizeof(testMem.srvBufAllow)},
@@ -243,13 +243,13 @@ static int _testDma(whServerContext* server, whClientContext* client)
         /* 64-bit host system */
         WH_TEST_RETURN_ON_FAIL(whServerDma_CopyFromClient64(
             server, testMem.srvBufAllow, (uint64_t)((uintptr_t)testMem.cliBuf),
-            sizeof(testMem.cliBuf), (whDmaFlags){0}));
+            sizeof(testMem.cliBuf), (whServerDmaFlags){0}));
     }
     else if (sizeof(void*) == sizeof(uint32_t)) {
         /* 32-bit host system */
         WH_TEST_RETURN_ON_FAIL(whServerDma_CopyFromClient32(
             server, testMem.srvBufAllow, (uint32_t)((uintptr_t)testMem.cliBuf),
-            sizeof(testMem.cliBuf), (whDmaFlags){0}));
+            sizeof(testMem.cliBuf), (whServerDmaFlags){0}));
     }
 
     /* Ensure data was copied */
@@ -273,13 +273,13 @@ static int _testDma(whServerContext* server, whClientContext* client)
         /* 64-bit host system */
         WH_TEST_RETURN_ON_FAIL(whServerDma_CopyToClient64(
             server, (uint64_t)((uintptr_t)testMem.cliBuf), testMem.srvBufAllow,
-            sizeof(testMem.srvBufAllow), (whDmaFlags){0}));
+            sizeof(testMem.srvBufAllow), (whServerDmaFlags){0}));
     }
     else if (sizeof(void*) == sizeof(uint32_t)) {
         /* 32-bit host system */
         WH_TEST_RETURN_ON_FAIL(whServerDma_CopyToClient32(
             server, (uint32_t)((uintptr_t)testMem.cliBuf), testMem.srvBufAllow,
-            sizeof(testMem.srvBufAllow), (whDmaFlags){0}));
+            sizeof(testMem.srvBufAllow), (whServerDmaFlags){0}));
     }
 
     /* Ensure data was copied */
@@ -293,12 +293,12 @@ static int _testDma(whServerContext* server, whClientContext* client)
                               whServerDma_CopyFromClient64(
                                   server, testMem.srvBufDeny,
                                   (uint64_t)((uintptr_t)testMem.cliBuf),
-                                  sizeof(testMem.cliBuf), (whDmaFlags){0}));
+                                  sizeof(testMem.cliBuf), (whServerDmaFlags){0}));
         WH_TEST_ASSERT_RETURN(WH_ERROR_ACCESS ==
                               whServerDma_CopyToClient64(
                                   server, (uint64_t)((uintptr_t)testMem.cliBuf),
                                   testMem.srvBufDeny,
-                                  sizeof(testMem.srvBufDeny), (whDmaFlags){0}));
+                                  sizeof(testMem.srvBufDeny), (whServerDmaFlags){0}));
     }
     else if (sizeof(void*) == sizeof(uint32_t)) {
         /* 32-bit host system */
@@ -306,12 +306,12 @@ static int _testDma(whServerContext* server, whClientContext* client)
                               whServerDma_CopyFromClient32(
                                   server, testMem.srvBufDeny,
                                   (uint32_t)((uintptr_t)testMem.cliBuf),
-                                  sizeof(testMem.cliBuf), (whDmaFlags){0}));
+                                  sizeof(testMem.cliBuf), (whServerDmaFlags){0}));
         WH_TEST_ASSERT_RETURN(WH_ERROR_ACCESS ==
                               whServerDma_CopyToClient32(
                                   server, (uint32_t)((uintptr_t)testMem.cliBuf),
                                   testMem.srvBufDeny,
-                                  sizeof(testMem.srvBufDeny), (whDmaFlags){0}));
+                                  sizeof(testMem.srvBufDeny), (whServerDmaFlags){0}));
     }
 
     return rc;

--- a/wolfhsm/wh_message_nvm.h
+++ b/wolfhsm/wh_message_nvm.h
@@ -28,7 +28,8 @@ enum {
 };
 
 enum {
-    WH_MESSAGE_NVM_MAX_DESTROY_OBJECTS_COUNT = 10,
+    /* must be odd for struct whMessageNvm_DestroyObjectsRequest  alignment */
+    WH_MESSAGE_NVM_MAX_DESTROY_OBJECTS_COUNT = 9,
     WH_MESSAGE_NVM_MAX_ADD_OBJECT_LEN =
             WH_COMM_DATA_LEN - WOLFHSM_NVM_METADATA_LEN,
     WH_MESSAGE_NVM_MAX_READ_LEN = WH_COMM_DATA_LEN - sizeof(int32_t),
@@ -149,9 +150,8 @@ int wh_MessageNvm_TranslateGetMetadataResponse(uint16_t magic,
 
 /** NVM DestroyObjects Request */
 typedef struct {
-    uint16_t list_count;
     uint16_t list[WH_MESSAGE_NVM_MAX_DESTROY_OBJECTS_COUNT];
-
+    uint16_t list_count;
 } whMessageNvm_DestroyObjectsRequest;
 
 int wh_MessageNvm_TranslateDestroyObjectsRequest(uint16_t magic,

--- a/wolfhsm/wh_server.h
+++ b/wolfhsm/wh_server.h
@@ -53,7 +53,7 @@ typedef struct whServerContext_t {
     crypto_context* crypto;
     CacheSlot cache[WOLFHSM_NUM_RAMKEYS];
     whServerCustomCb customHandlerTable[WH_CUSTOM_CB_NUM_CALLBACKS];
-    whDmaContext dma;
+    whServerDmaContext dma;
 } whServerContext;
 
 typedef struct whServerConfig_t {
@@ -63,7 +63,7 @@ typedef struct whServerConfig_t {
 #if defined WOLF_CRYPTO_CB /* TODO: should we be relying on wolfSSL defines? */
     int devId;
 #endif
-    whDmaConfig* dmaConfig;
+    whServerDmaConfig* dmaConfig;
 } whServerConfig;
 
 /* Initialize the comms and crypto cache components.
@@ -89,21 +89,5 @@ int wh_Server_HandleCustomCbRequest(whServerContext* server, uint16_t magic,
                                   uint16_t action, uint16_t seq,
                                   uint16_t req_size, const void* req_packet,
                                   uint16_t* out_resp_size, void* resp_packet);
-
-/* Registers custom client DMA callbacs to handle platform specific restrictions
- * on accessing the client address space such as caching and address translation */
-int wh_Server_DmaRegisterCb32(whServerContext* server, whDmaClientMem32Cb cb);
-int wh_Server_DmaRegisterCb64(whServerContext* server, whDmaClientMem64Cb cb);
-int wh_Server_DmaRegisterAllowList(whServerContext* server, const whDmaAddrAllowList* allowlist);
-
-/* Helper functions to invoke user supplied client address DMA callbacks */
-int wh_Server_DmaProcessClientAddress32(whServerContext* server,
-                                        uint32_t clientAddr, void** serverPtr,
-                                        uint32_t len, whDmaOper oper,
-                                        whDmaFlags flags);
-int wh_Server_DmaProcessClientAddress64(whServerContext* server,
-                                        uint64_t clientAddr, void** serverPtr,
-                                        uint64_t len, whDmaOper oper,
-                                        whDmaFlags flags);
 
 #endif /* WOLFHSM_WH_SERVER_H_ */

--- a/wolfhsm/wh_server.h
+++ b/wolfhsm/wh_server.h
@@ -53,8 +53,7 @@ typedef struct whServerContext_t {
     crypto_context* crypto;
     CacheSlot cache[WOLFHSM_NUM_RAMKEYS];
     whServerCustomCb customHandlerTable[WH_CUSTOM_CB_NUM_CALLBACKS];
-    whDmaCb dmaCb;
-    const whDmaAddrAllowList* dmaAddrAllowList;
+    whDmaContext dma;
 } whServerContext;
 
 typedef struct whServerConfig_t {
@@ -64,7 +63,7 @@ typedef struct whServerConfig_t {
 #if defined WOLF_CRYPTO_CB /* TODO: should we be relying on wolfSSL defines? */
     int devId;
 #endif
-    whDmaAddrAllowList* dmaAddrAllowList;
+    whDmaConfig* dmaConfig;
 } whServerConfig;
 
 /* Initialize the comms and crypto cache components.
@@ -93,7 +92,8 @@ int wh_Server_HandleCustomCbRequest(whServerContext* server, uint16_t magic,
 
 /* Registers custom client DMA callbacs to handle platform specific restrictions
  * on accessing the client address space such as caching and address translation */
-int wh_Server_DmaRegisterCb(whServerContext* server, whDmaCb cb);
+int wh_Server_DmaRegisterCb32(whServerContext* server, whDmaClientMem32Cb cb);
+int wh_Server_DmaRegisterCb64(whServerContext* server, whDmaClientMem64Cb cb);
 int wh_Server_DmaRegisterAllowList(whServerContext* server, const whDmaAddrAllowList* allowlist);
 
 /* Helper functions to invoke user supplied client address DMA callbacks */

--- a/wolfhsm/wh_server.h
+++ b/wolfhsm/wh_server.h
@@ -13,6 +13,7 @@
 #include "wolfhsm/wh_comm.h"
 #include "wolfhsm/wh_nvm.h"
 #include "wolfhsm/wh_message_customcb.h"
+#include "wolfhsm/wh_server_dma.h"
 
 #include "wolfssl/wolfcrypt/settings.h"
 #include "wolfssl/wolfcrypt/random.h"
@@ -44,6 +45,35 @@ typedef int (*whServerCustomCb)(
     whMessageCustomCb_Response*      resp /* response from callback to client */
 );
 
+#if 0
+typedef int (*whDmaClientMem32Cb)(struct whServerContext_t* server,
+                                  uint32_t clientAddr, void** serverPtr,
+                                  uint32_t len, whDmaOper oper,
+                                  whDmaFlags flags);
+typedef int (*whDmaClientMem64Cb)(struct whServerContext_t* server,
+                                  uint64_t clientAddr, void** serverPtr,
+                                  uint64_t len, whDmaOper oper,
+                                  whDmaFlags flags);
+
+typedef struct {
+    whDmaClientMem32Cb cb32;
+    whDmaClientMem64Cb cb64;
+} whDmaCb;
+
+/* Indicates to the callback the type of operation the callback should handle */
+typedef enum {
+    WH_DMA_OPER_CLIENT_READ_PRE = 0, /* Descriptive comment: address validation/Map/unmap/prefetch/cache/etc*/
+    WH_DMA_OPER_CLIENT_READ_POST = 1,
+    WH_DMA_OPER_CLIENT_WRITE_PRE  = 2,
+    WH_DMA_OPER_CLIENT_WRITE_POST = 3,
+} whDmaOper;
+
+/* Flags embedded in request/response structs provided by client */
+typedef struct {
+    uint8_t cacheForceInvalidate : 1;
+} whDmaFlags;
+#endif
+
 /* Context structure to maintain the state of an HSM server */
 typedef struct whServerContext_t {
     whCommServer comm[1];
@@ -51,6 +81,7 @@ typedef struct whServerContext_t {
     crypto_context* crypto;
     CacheSlot cache[WOLFHSM_NUM_RAMKEYS];
     whServerCustomCb customHandlerTable[WH_CUSTOM_CB_NUM_CALLBACKS];
+    whDmaCb dmaCb; 
 } whServerContext;
 
 typedef struct whServerConfig_t {
@@ -85,5 +116,19 @@ int wh_Server_HandleCustomCbRequest(whServerContext* server, uint16_t magic,
                                   uint16_t action, uint16_t seq,
                                   uint16_t req_size, const void* req_packet,
                                   uint16_t* out_resp_size, void* resp_packet);
+
+/* Registers custom client DMA callbacs to handle platform specific restrictions
+ * on accessing the client address space such as caching and address translation */
+int wh_Server_DmaRegisterCb(whServerContext* server, whDmaCb cb);
+
+/* Helper functions to invoke user supplied client address DMA callbacks */
+int wh_Server_DmaProcessClientAddress32(whServerContext* server,
+                                        uint32_t clientAddr, void** serverPtr,
+                                        uint32_t len, whDmaOper oper,
+                                        whDmaFlags flags);
+int wh_Server_DmaProcessClientAddress64(whServerContext* server,
+                                        uint64_t clientAddr, void** serverPtr,
+                                        uint64_t len, whDmaOper oper,
+                                        whDmaFlags flags);
 
 #endif /* WOLFHSM_WH_SERVER_H_ */

--- a/wolfhsm/wh_server_dma.h
+++ b/wolfhsm/wh_server_dma.h
@@ -79,6 +79,11 @@ int wh_Server_DmaRegisterCb64(struct whServerContext_t* server,
 int wh_Server_DmaRegisterAllowList(struct whServerContext_t*       server,
                                    const whServerDmaAddrAllowList* allowlist);
 
+/* Checks a desired memory operation against the server allowlist */
+int wh_Server_DmaCheckMemOperAllowed(const struct whServerContext_t* server,
+                                     whServerDmaOper oper, void* addr,
+                                     size_t size);
+
 /* Helper functions to invoke user supplied client address DMA callbacks */
 int wh_Server_DmaProcessClientAddress32(struct whServerContext_t* server,
                                         uint32_t clientAddr, void** serverPtr,
@@ -89,6 +94,8 @@ int wh_Server_DmaProcessClientAddress64(struct whServerContext_t* server,
                                         uint64_t len, whServerDmaOper oper,
                                         whServerDmaFlags flags);
 
+/* Helper functions to copy data to/from client addresses that invoke the
+ * appropriate callbacks and allowlist checks */
 int whServerDma_CopyFromClient32(struct whServerContext_t* server,
                                  void* serverPtr, uint32_t clientAddr,
                                  size_t len, whServerDmaFlags flags);

--- a/wolfhsm/wh_server_dma.h
+++ b/wolfhsm/wh_server_dma.h
@@ -6,69 +6,102 @@
 
 #include "wolfhsm/wh_server.h"
 
+#define WH_DMA_ADDR_ALLOWLIST_SIZE (10)
+
 struct whServerContext_t;
 
-/* Indicates to the callback the type of operation the callback should handle */
+/* Indicates to a DMA callback the type of memory operation the callback must
+ * act on. Common use cases are remapping client addresses into server address
+ * space (map in READ_PRE/WRITE_PRE, unmap in READ_POST/WRITE_POST), or
+ * invalidating a cache block before reading from or after writing to client
+ * memory */
 typedef enum {
-    WH_DMA_OPER_CLIENT_READ_PRE = 0, /* Descriptive comment: address validation/Map/unmap/prefetch/cache/etc*/
+    /* Indicates server is about to read from client memory */
+    WH_DMA_OPER_CLIENT_READ_PRE = 0,
+    /* Indicates server has just read from client memory */
     WH_DMA_OPER_CLIENT_READ_POST = 1,
+    /* Indicates server is about to write to client memory */
     WH_DMA_OPER_CLIENT_WRITE_PRE  = 2,
+    /* Indicates server has just written from client memory */
     WH_DMA_OPER_CLIENT_WRITE_POST = 3,
-} whDmaOper;
+} whServerDmaOper;
 
 /* Flags embedded in request/response structs provided by client */
 typedef struct {
     uint8_t cacheForceInvalidate : 1;
-} whDmaFlags;
+} whServerDmaFlags;
 
-typedef int (*whDmaClientMem32Cb)(struct whServerContext_t* server,
-                                  uint32_t clientAddr, void** serverPtr,
-                                  uint32_t len, whDmaOper oper,
-                                  whDmaFlags flags);
-typedef int (*whDmaClientMem64Cb)(struct whServerContext_t* server,
-                                  uint64_t clientAddr, void** serverPtr,
-                                  uint64_t len, whDmaOper oper,
-                                  whDmaFlags flags);
+/* DMA callbacks invoked internally by wolfHSM before and after every client
+ * memory operation. There are separate callbacks for processing 32-bit and
+ * 64-bit client addresses */
+typedef int (*whServerDmaClientMem32Cb)(struct whServerContext_t* server,
+                                        uint32_t clientAddr, void** serverPtr,
+                                        uint32_t len, whServerDmaOper oper,
+                                        whServerDmaFlags flags);
+typedef int (*whServerDmaClientMem64Cb)(struct whServerContext_t* server,
+                                        uint64_t clientAddr, void** serverPtr,
+                                        uint64_t len, whServerDmaOper oper,
+                                        whServerDmaFlags flags);
 
 typedef struct {
     void*  addr;
     size_t size;
-} whDmaAddr;
+} whServerDmaAddr;
 
-#define WH_DMA_ADDR_ALLOWLIST_SIZE (10)
+typedef whServerDmaAddr whServerDmaAddrList[WH_DMA_ADDR_ALLOWLIST_SIZE];
 
-typedef whDmaAddr whDmaAddrList[WH_DMA_ADDR_ALLOWLIST_SIZE];
+/* Holds allowable client read/write addresses */
+typedef struct {
+    whServerDmaAddrList readList;  /* Allowed client read addresses */
+    whServerDmaAddrList writeList; /* Allowed client write addresses */
+} whServerDmaAddrAllowList;
+
+/* Configuration struct for initializing a server */
+typedef struct {
+    whServerDmaClientMem32Cb        cb32; /* DMA callback for 32-bit system */
+    whServerDmaClientMem64Cb        cb64; /* DMA callback for 64-bit system */
+    const whServerDmaAddrAllowList* dmaAddrAllowList; /* allowed addresses */
+} whServerDmaConfig;
 
 typedef struct {
-    whDmaAddrList readList;
-    whDmaAddrList writeList;
-} whDmaAddrAllowList;
+    whServerDmaClientMem32Cb        cb32; /* DMA callback for 32-bit system */
+    whServerDmaClientMem64Cb        cb64; /* DMA callback for 64-bit system */
+    const whServerDmaAddrAllowList* dmaAddrAllowList; /* allowed addresses */
+} whServerDmaContext;
 
-typedef struct {
-    whDmaClientMem32Cb        cb32; /* DMA callback for 32-bit system */
-    whDmaClientMem64Cb        cb64; /* DMA callback for 64-bit system */
-    const whDmaAddrAllowList* dmaAddrAllowList; /* list of allowed addresses */
-} whDmaConfig;
+/* Registers custom client DMA callbacks to handle platform specific
+ * restrictions on accessing the client address space such as caching and
+ * address translation */
+int wh_Server_DmaRegisterCb32(struct whServerContext_t* server,
+                              whServerDmaClientMem32Cb  cb);
+int wh_Server_DmaRegisterCb64(struct whServerContext_t* server,
+                              whServerDmaClientMem64Cb  cb);
+int wh_Server_DmaRegisterAllowList(struct whServerContext_t*       server,
+                                   const whServerDmaAddrAllowList* allowlist);
 
-typedef struct {
-    whDmaClientMem32Cb        cb32; /* DMA callback for 32-bit system */
-    whDmaClientMem64Cb        cb64; /* DMA callback for 64-bit system */
-    const whDmaAddrAllowList* dmaAddrAllowList; /* list of allowed addresses */
-} whDmaContext;
+/* Helper functions to invoke user supplied client address DMA callbacks */
+int wh_Server_DmaProcessClientAddress32(struct whServerContext_t* server,
+                                        uint32_t clientAddr, void** serverPtr,
+                                        uint32_t len, whServerDmaOper oper,
+                                        whServerDmaFlags flags);
+int wh_Server_DmaProcessClientAddress64(struct whServerContext_t* server,
+                                        uint64_t clientAddr, void** serverPtr,
+                                        uint64_t len, whServerDmaOper oper,
+                                        whServerDmaFlags flags);
 
 int whServerDma_CopyFromClient32(struct whServerContext_t* server,
                                  void* serverPtr, uint32_t clientAddr,
-                                 size_t len, whDmaFlags flags);
+                                 size_t len, whServerDmaFlags flags);
 int whServerDma_CopyFromClient64(struct whServerContext_t* server,
                                  void* serverPtr, uint64_t clientAddr,
-                                 size_t len, whDmaFlags flags);
+                                 size_t len, whServerDmaFlags flags);
 
 int whServerDma_CopyToClient32(struct whServerContext_t* server,
-                               uint32_t clientAddr, void* serverPtr,
-                               size_t len, whDmaFlags flags);
-int whServerDma_CopyToClient64(struct whServerContext_t* server, 
-                               uint64_t clientAddr, void* serverPtr,
-                               size_t len, whDmaFlags flags);                            
+                               uint32_t clientAddr, void* serverPtr, size_t len,
+                               whServerDmaFlags flags);
+int whServerDma_CopyToClient64(struct whServerContext_t* server,
+                               uint64_t clientAddr, void* serverPtr, size_t len,
+                               whServerDmaFlags flags);
 
 
 #endif /* WH_SERVER_DMA_H_ */

--- a/wolfhsm/wh_server_dma.h
+++ b/wolfhsm/wh_server_dma.h
@@ -31,11 +31,6 @@ typedef int (*whDmaClientMem64Cb)(struct whServerContext_t* server,
                                   whDmaFlags flags);
 
 typedef struct {
-    whDmaClientMem32Cb cb32;
-    whDmaClientMem64Cb cb64;
-} whDmaCb;
-
-typedef struct {
     void*  addr;
     size_t size;
 } whDmaAddr;
@@ -48,6 +43,18 @@ typedef struct {
     whDmaAddrList readList;
     whDmaAddrList writeList;
 } whDmaAddrAllowList;
+
+typedef struct {
+    whDmaClientMem32Cb        cb32; /* DMA callback for 32-bit system */
+    whDmaClientMem64Cb        cb64; /* DMA callback for 64-bit system */
+    const whDmaAddrAllowList* dmaAddrAllowList; /* list of allowed addresses */
+} whDmaConfig;
+
+typedef struct {
+    whDmaClientMem32Cb        cb32; /* DMA callback for 32-bit system */
+    whDmaClientMem64Cb        cb64; /* DMA callback for 64-bit system */
+    const whDmaAddrAllowList* dmaAddrAllowList; /* list of allowed addresses */
+} whDmaContext;
 
 int whServerDma_CopyFromClient32(struct whServerContext_t* server,
                                  void* serverPtr, uint32_t clientAddr,

--- a/wolfhsm/wh_server_dma.h
+++ b/wolfhsm/wh_server_dma.h
@@ -6,7 +6,7 @@
 
 #include "wolfhsm/wh_server.h"
 
-#define WH_DMA_ADDR_ALLOWLIST_SIZE (10)
+#define WH_DMA_ADDR_ALLOWLIST_COUNT (10)
 
 struct whServerContext_t;
 
@@ -48,7 +48,7 @@ typedef struct {
     size_t size;
 } whServerDmaAddr;
 
-typedef whServerDmaAddr whServerDmaAddrList[WH_DMA_ADDR_ALLOWLIST_SIZE];
+typedef whServerDmaAddr whServerDmaAddrList[WH_DMA_ADDR_ALLOWLIST_COUNT];
 
 /* Holds allowable client read/write addresses */
 typedef struct {

--- a/wolfhsm/wh_server_dma.h
+++ b/wolfhsm/wh_server_dma.h
@@ -2,6 +2,8 @@
 #define WH_SERVER_DMA_H_
 
 #include <stdint.h>
+#include <stddef.h>
+
 #include "wolfhsm/wh_server.h"
 
 struct whServerContext_t;
@@ -32,6 +34,34 @@ typedef struct {
     whDmaClientMem32Cb cb32;
     whDmaClientMem64Cb cb64;
 } whDmaCb;
+
+typedef struct {
+    void*  addr;
+    size_t size;
+} whDmaAddr;
+
+#define WH_DMA_ADDR_ALLOWLIST_SIZE (10)
+
+typedef whDmaAddr whDmaAddrList[WH_DMA_ADDR_ALLOWLIST_SIZE];
+
+typedef struct {
+    whDmaAddrList readList;
+    whDmaAddrList writeList;
+} whDmaAddrAllowList;
+
+int whServerDma_CopyFromClient32(struct whServerContext_t* server,
+                                 void* serverPtr, uint32_t clientAddr,
+                                 size_t len, whDmaFlags flags);
+int whServerDma_CopyFromClient64(struct whServerContext_t* server,
+                                 void* serverPtr, uint64_t clientAddr,
+                                 size_t len, whDmaFlags flags);
+
+int whServerDma_CopyToClient32(struct whServerContext_t* server,
+                               uint32_t clientAddr, void* serverPtr,
+                               size_t len, whDmaFlags flags);
+int whServerDma_CopyToClient64(struct whServerContext_t* server, 
+                               uint64_t clientAddr, void* serverPtr,
+                               size_t len, whDmaFlags flags);                            
 
 
 #endif /* WH_SERVER_DMA_H_ */

--- a/wolfhsm/wh_server_dma.h
+++ b/wolfhsm/wh_server_dma.h
@@ -1,0 +1,37 @@
+#ifndef WH_SERVER_DMA_H_
+#define WH_SERVER_DMA_H_
+
+#include <stdint.h>
+#include "wolfhsm/wh_server.h"
+
+struct whServerContext_t;
+
+/* Indicates to the callback the type of operation the callback should handle */
+typedef enum {
+    WH_DMA_OPER_CLIENT_READ_PRE = 0, /* Descriptive comment: address validation/Map/unmap/prefetch/cache/etc*/
+    WH_DMA_OPER_CLIENT_READ_POST = 1,
+    WH_DMA_OPER_CLIENT_WRITE_PRE  = 2,
+    WH_DMA_OPER_CLIENT_WRITE_POST = 3,
+} whDmaOper;
+
+/* Flags embedded in request/response structs provided by client */
+typedef struct {
+    uint8_t cacheForceInvalidate : 1;
+} whDmaFlags;
+
+typedef int (*whDmaClientMem32Cb)(struct whServerContext_t* server,
+                                  uint32_t clientAddr, void** serverPtr,
+                                  uint32_t len, whDmaOper oper,
+                                  whDmaFlags flags);
+typedef int (*whDmaClientMem64Cb)(struct whServerContext_t* server,
+                                  uint64_t clientAddr, void** serverPtr,
+                                  uint64_t len, whDmaOper oper,
+                                  whDmaFlags flags);
+
+typedef struct {
+    whDmaClientMem32Cb cb32;
+    whDmaClientMem64Cb cb64;
+} whDmaCb;
+
+
+#endif /* WH_SERVER_DMA_H_ */


### PR DESCRIPTION
- Adds support for custom platform-specific DMA callbacks, allowing for injecting operations like cache invalidation, address remapping, etc. before/after accessing client memory
- Adds basic support for memory "allow lists", enabling each server object to maintain a list of allowed regions of system memory that the client is able to read/write from
- Adds the above features to the NVM message handling layer 
- Tests for the above features that run on the POSIX sim and tricore

### A few specific areas that I'd like feedback on:
- data types / address manipulation logic when going between 32/64-bit client addresses and native server addresses
- what should be defined in `wh_server.h` vs `wh_server_dma.h`? Do we want all public server APIs in `wh_server.h` and everything else in the other module? We also have a circular dependency between the two, but two separate modules is nice to reduce file size. Happy to relocate stuff wherever, so just let me know if you have strong opinions.
- [hidden "allow list" check ](https://github.com/bigbrett/wolfHSM/blob/192fa0176b7f7db9b5dbc542cbe88f7698fed97c/src/wh_server_dma.c#L109)inside `wh_Server_DmaProcessClientAddress{32,64}` vs pulling it out and having that be an explicit separate step. Right now this function does the work and the allowlist checks are private. I'm leaning towards pushing another commit that removes the allow list check inside this function such that it only invokes the DMA callback, and making address screening accessible via public function. Having all allowlist checks in one place might be wise. 
- Use of `goto`s in [handling the NVM DMA message requests](https://github.com/bigbrett/wolfHSM/blob/192fa0176b7f7db9b5dbc542cbe88f7698fed97c/src/wh_server_nvm.c#L304) - There are a large number of sequential function calls that each produce a return code that should be returned, preventing further processing from taking place. I tried to write this using nested `if (resp.rc == WH_ERROR_OK)` blocks, but it got way too deeply nested and ugly. I think the `goto` solution is the most concise, but I know `goto`s are controversial and sometimes frowned upon, so lets discuss if this section of code is a problem.