### PR TITLE
use key type and key user as part of the internal keyId

### DIFF
--- a/src/wh_client.c
+++ b/src/wh_client.c
@@ -43,7 +43,6 @@ int wh_Client_Init(whClientContext* c, const whClientConfig* config)
     }
 
     memset(c, 0, sizeof(*c));
-    c->user = config->user;
 
     if (    ((rc = wh_CommClient_Init(c->comm, config->comm)) == 0) &&
 #ifndef WOLFHSM_NO_CRYPTO
@@ -85,8 +84,8 @@ int wh_Client_SendRequest(whClientContext* c,
     if (c == NULL) {
         return WH_ERROR_BADARGS;
     }
-    rc = wh_CommClient_SendRequest(c->comm, WH_COMM_MAGIC_NATIVE, kind, c->user,
-        &req_id, data_size, data);
+    rc = wh_CommClient_SendRequest(c->comm, WH_COMM_MAGIC_NATIVE, kind, &req_id,
+        data_size, data);
     if (rc == 0) {
         c->last_req_kind = kind;
         c->last_req_id = req_id;

--- a/src/wh_client.c
+++ b/src/wh_client.c
@@ -657,4 +657,9 @@ void wh_Client_SetKeyCurve25519(curve25519_key* key, whNvmId keyId)
 {
     XMEMCPY(key->devCtx, (void*)&keyId, sizeof(keyId));
 }
+
+void wh_Client_SetKeyRsa(RsaKey* key, whNvmId keyId)
+{
+    XMEMCPY(key->devCtx, (void*)&keyId, sizeof(keyId));
+}
 #endif  /* WOLFHSM_NO_CRYPTO */

--- a/src/wh_client.c
+++ b/src/wh_client.c
@@ -43,6 +43,7 @@ int wh_Client_Init(whClientContext* c, const whClientConfig* config)
     }
 
     memset(c, 0, sizeof(*c));
+    c->user = config->user;
 
     if (    ((rc = wh_CommClient_Init(c->comm, config->comm)) == 0) &&
 #ifndef WOLFHSM_NO_CRYPTO
@@ -84,10 +85,8 @@ int wh_Client_SendRequest(whClientContext* c,
     if (c == NULL) {
         return WH_ERROR_BADARGS;
     }
-
-    rc = wh_CommClient_SendRequest(c->comm,
-                WH_COMM_MAGIC_NATIVE, kind, &req_id,
-                data_size, data);
+    rc = wh_CommClient_SendRequest(c->comm, WH_COMM_MAGIC_NATIVE, kind, c->user,
+        &req_id, data_size, data);
     if (rc == 0) {
         c->last_req_kind = kind;
         c->last_req_id = req_id;
@@ -465,6 +464,7 @@ int wh_Client_KeyCacheRequest_ex(whClientContext* c, uint32_t flags,
     uint8_t* packIn = (uint8_t*)(&packet->keyCacheReq + 1);
     if (c == NULL || in == NULL || inSz == 0)
         return WH_ERROR_BADARGS;
+    packet->keyCacheReq.id = keyId;
     packet->keyCacheReq.flags = flags;
     packet->keyCacheReq.sz = inSz;
     if (label == NULL)
@@ -489,7 +489,7 @@ int wh_Client_KeyCacheRequest(whClientContext* c, uint32_t flags,
     uint8_t* label, uint32_t labelSz, uint8_t* in, uint32_t inSz)
 {
     return wh_Client_KeyCacheRequest_ex(c, flags, label, labelSz, in, inSz,
-        WOLFHSM_ID_ERASED);
+        WOLFHSM_KEYID_ERASED);
 }
 
 int wh_Client_KeyCacheResponse(whClientContext* c, uint16_t* keyId)
@@ -514,7 +514,7 @@ int wh_Client_KeyCacheResponse(whClientContext* c, uint16_t* keyId)
 int wh_Client_KeyEvictRequest(whClientContext* c, uint16_t keyId)
 {
     whPacket packet[1] = {0};
-    if (c == NULL || keyId == WOLFHSM_ID_ERASED)
+    if (c == NULL || keyId == WOLFHSM_KEYID_ERASED)
         return WH_ERROR_BADARGS;
     /* set the keyId */
     packet->keyEvictReq.id = keyId;
@@ -544,7 +544,7 @@ int wh_Client_KeyEvictResponse(whClientContext* c)
 int wh_Client_KeyExportRequest(whClientContext* c, uint16_t keyId)
 {
     whPacket packet[1] = {0};
-    if (c == NULL || keyId == WOLFHSM_ID_ERASED)
+    if (c == NULL || keyId == WOLFHSM_KEYID_ERASED)
         return WH_ERROR_BADARGS;
     /* set keyId */
     packet->keyExportReq.id = keyId;
@@ -597,7 +597,7 @@ int wh_Client_KeyExportResponse(whClientContext* c, uint8_t* label,
 int wh_Client_KeyCommitRequest(whClientContext* c, whNvmId keyId)
 {
     whPacket packet[1] = {0};
-    if (c == NULL || keyId == WOLFHSM_ID_ERASED)
+    if (c == NULL || keyId == WOLFHSM_KEYID_ERASED)
         return WH_ERROR_BADARGS;
     /* set keyId */
     packet->keyCommitReq.id = keyId;
@@ -627,7 +627,7 @@ int wh_Client_KeyCommitResponse(whClientContext* c)
 int wh_Client_KeyEraseRequest(whClientContext* c, whNvmId keyId)
 {
     whPacket packet[1] = {0};
-    if (c == NULL || keyId == WOLFHSM_ID_ERASED)
+    if (c == NULL || keyId == WOLFHSM_KEYID_ERASED)
         return WH_ERROR_BADARGS;
     /* set keyId */
     packet->keyEraseReq.id = keyId;

--- a/src/wh_comm.c
+++ b/src/wh_comm.c
@@ -78,9 +78,8 @@ int wh_CommClient_Init(whCommClient* context, const whCommClientConfig* config)
 /* If a request buffer is available, send a new request to the server.  The
  * sequence number will be incremented on transport success.
  */
-int wh_CommClient_SendRequest(whCommClient* context,
-        uint16_t magic, uint16_t kind, uint8_t user, uint16_t *out_seq,
-        uint16_t data_size, const void* data)
+int wh_CommClient_SendRequest(whCommClient* context, uint16_t magic,
+    uint16_t kind, uint16_t *out_seq, uint16_t data_size, const void* data)
 {
     int rc = WH_ERROR_NOTREADY;
 
@@ -94,7 +93,6 @@ int wh_CommClient_SendRequest(whCommClient* context,
 
         context->hdr->magic = magic;
         context->hdr->kind = wh_Translate16(magic, kind);
-        context->hdr->user = user;
         context->hdr->seq = wh_Translate16(magic, context->seq + 1);
         if (    (data != NULL) &&
                 (data_size != 0) &&
@@ -221,14 +219,13 @@ int wh_CommServer_Init(whCommServer* context, const whCommServerConfig* config,
 }
 
 int wh_CommServer_RecvRequest(whCommServer* context,
-        uint16_t* out_magic, uint16_t* out_kind, uint16_t* outUser,
-        uint16_t* out_seq, uint16_t* out_size, void* data)
+        uint16_t* out_magic, uint16_t* out_kind, uint16_t* out_seq,
+        uint16_t* out_size, void* data)
 {
     int rc = WH_ERROR_NOTREADY;
     uint16_t magic = 0;
     uint16_t kind = 0;
     uint16_t seq = 0;
-    uint16_t user = 0;
     uint16_t size = sizeof(context->packet);
     uint16_t data_size = 0;
 
@@ -251,7 +248,6 @@ int wh_CommServer_RecvRequest(whCommServer* context,
                 magic = context->hdr->magic;
                 kind = wh_Translate16(magic, context->hdr->kind);
                 seq = wh_Translate16(magic, context->hdr->seq);
-                user = wh_Translate16(magic, context->hdr->user);
 
                 /* Copy the data from the internal buffer if necessary */
                 if (    (data != NULL) &&
@@ -261,7 +257,6 @@ int wh_CommServer_RecvRequest(whCommServer* context,
                 }
                 if (out_magic != NULL) *out_magic = magic;
                 if (out_kind != NULL) *out_kind = kind;
-                if (outUser != NULL) *outUser = user;
                 if (out_seq != NULL) *out_seq = seq;
                 if (out_size != NULL) *out_size = data_size;
             } else {

--- a/src/wh_comm.c
+++ b/src/wh_comm.c
@@ -79,7 +79,7 @@ int wh_CommClient_Init(whCommClient* context, const whCommClientConfig* config)
  * sequence number will be incremented on transport success.
  */
 int wh_CommClient_SendRequest(whCommClient* context,
-        uint16_t magic, uint16_t kind, uint16_t *out_seq,
+        uint16_t magic, uint16_t kind, uint8_t user, uint16_t *out_seq,
         uint16_t data_size, const void* data)
 {
     int rc = WH_ERROR_NOTREADY;
@@ -94,6 +94,7 @@ int wh_CommClient_SendRequest(whCommClient* context,
 
         context->hdr->magic = magic;
         context->hdr->kind = wh_Translate16(magic, kind);
+        context->hdr->user = user;
         context->hdr->seq = wh_Translate16(magic, context->seq + 1);
         if (    (data != NULL) &&
                 (data_size != 0) &&
@@ -220,13 +221,14 @@ int wh_CommServer_Init(whCommServer* context, const whCommServerConfig* config,
 }
 
 int wh_CommServer_RecvRequest(whCommServer* context,
-        uint16_t* out_magic, uint16_t* out_kind, uint16_t* out_seq,
-        uint16_t* out_size, void* data)
+        uint16_t* out_magic, uint16_t* out_kind, uint16_t* outUser,
+        uint16_t* out_seq, uint16_t* out_size, void* data)
 {
     int rc = WH_ERROR_NOTREADY;
     uint16_t magic = 0;
     uint16_t kind = 0;
     uint16_t seq = 0;
+    uint16_t user = 0;
     uint16_t size = sizeof(context->packet);
     uint16_t data_size = 0;
 
@@ -249,6 +251,7 @@ int wh_CommServer_RecvRequest(whCommServer* context,
                 magic = context->hdr->magic;
                 kind = wh_Translate16(magic, context->hdr->kind);
                 seq = wh_Translate16(magic, context->hdr->seq);
+                user = wh_Translate16(magic, context->hdr->user);
 
                 /* Copy the data from the internal buffer if necessary */
                 if (    (data != NULL) &&
@@ -258,6 +261,7 @@ int wh_CommServer_RecvRequest(whCommServer* context,
                 }
                 if (out_magic != NULL) *out_magic = magic;
                 if (out_kind != NULL) *out_kind = kind;
+                if (outUser != NULL) *outUser = user;
                 if (out_seq != NULL) *out_seq = seq;
                 if (out_size != NULL) *out_size = data_size;
             } else {

--- a/src/wh_server.c
+++ b/src/wh_server.c
@@ -219,7 +219,6 @@ int wh_Server_HandleRequestMessage(whServerContext* server)
 {
     uint16_t magic = 0;
     uint16_t kind = 0;
-    uint16_t user = 0;
     uint16_t group = 0;
     uint16_t action = 0;
     uint16_t seq = 0;
@@ -259,12 +258,12 @@ int wh_Server_HandleRequestMessage(whServerContext* server)
 
 #ifndef WOLFHSM_NO_CRYPTO
         case WH_MESSAGE_GROUP_KEY:
-            rc = wh_Server_HandleKeyRequest(server, magic, action, user, seq,
+            rc = wh_Server_HandleKeyRequest(server, magic, action, seq,
                     data, &size);
         break;
 
         case WH_MESSAGE_GROUP_CRYPTO:
-            rc = wh_Server_HandleCryptoRequest(server, action, user, data,
+            rc = wh_Server_HandleCryptoRequest(server, action, data,
                 &size);
         break;
 #endif  /* WOLFHSM_NO_CRYPTO */

--- a/src/wh_server.c
+++ b/src/wh_server.c
@@ -219,6 +219,7 @@ int wh_Server_HandleRequestMessage(whServerContext* server)
 {
     uint16_t magic = 0;
     uint16_t kind = 0;
+    uint16_t user = 0;
     uint16_t group = 0;
     uint16_t action = 0;
     uint16_t seq = 0;
@@ -258,12 +259,13 @@ int wh_Server_HandleRequestMessage(whServerContext* server)
 
 #ifndef WOLFHSM_NO_CRYPTO
         case WH_MESSAGE_GROUP_KEY:
-            rc = wh_Server_HandleKeyRequest(server, magic, action, seq,
+            rc = wh_Server_HandleKeyRequest(server, magic, action, user, seq,
                     data, &size);
         break;
 
         case WH_MESSAGE_GROUP_CRYPTO:
-            rc = wh_Server_HandleCryptoRequest(server, action, data, &size);
+            rc = wh_Server_HandleCryptoRequest(server, action, user, data,
+                &size);
         break;
 #endif  /* WOLFHSM_NO_CRYPTO */
 

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -128,7 +128,7 @@ static int hsmLoadKeyCurve25519(whServerContext* server, curve25519_key* key,
 #endif /* HAVE_CURVE25519 */
 
 int wh_Server_HandleCryptoRequest(whServerContext* server,
-    uint16_t action, uint8_t user, uint8_t* data, uint16_t* size)
+    uint16_t action, uint8_t* data, uint16_t* size)
 {
     int ret = 0;
     uint32_t field;
@@ -253,7 +253,7 @@ int wh_Server_HandleCryptoRequest(whServerContext* server,
             /* set the assigned id */
             wc_curve25519_free(server->crypto->curve25519Private);
             if (ret == 0) {
-                /* strip user */
+                /* strip client_id */
                 packet->pkCurve25519kgRes.keyId =
                     (keyId & ~WOLFHSM_KEYUSER_MASK);
                 *size = WOLFHSM_PACKET_STUB_SIZE +
@@ -276,14 +276,16 @@ int wh_Server_HandleCryptoRequest(whServerContext* server,
             if (ret == 0) {
                 ret = hsmLoadKeyCurve25519(server,
                     server->crypto->curve25519Private,
-                    MAKE_WOLFHSM_KEYID(WOLFHSM_KEYTYPE_CRYPTO, user,
+                    MAKE_WOLFHSM_KEYID(WOLFHSM_KEYTYPE_CRYPTO,
+                    server->comm->client_id,
                     packet->pkCurve25519Req.privateKeyId));
             }
             /* load the public key */
             if (ret == 0) {
                 ret = hsmLoadKeyCurve25519(server,
                     server->crypto->curve25519Public,
-                    MAKE_WOLFHSM_KEYID(WOLFHSM_KEYTYPE_CRYPTO, user,
+                    MAKE_WOLFHSM_KEYID(WOLFHSM_KEYTYPE_CRYPTO,
+                    server->comm->client_id,
                     packet->pkCurve25519Req.publicKeyId));
             }
             /* make shared secret */

--- a/src/wh_server_keystore.c
+++ b/src/wh_server_keystore.c
@@ -330,7 +330,7 @@ int wh_Server_HandleKeyRequest(whServerContext* server, uint16_t magic,
             ret = hsmCacheKey(server, meta, in);
         if (ret == 0) {
             /* remove the user, client may set type */
-            packet->keyCacheRes.id = (meta->id & (~WOLFHSM_KEYUSER_MASK));
+            packet->keyCacheRes.id = (meta->id & WOLFHSM_KEYID_MASK);
             *size = WOLFHSM_PACKET_STUB_SIZE + sizeof(packet->keyCacheRes);
         }
         break;

--- a/test/wh_test_clientserver.c
+++ b/test/wh_test_clientserver.c
@@ -457,7 +457,7 @@ int whTest_ClientServerSequential(void)
                  .transport_cb      = tccb,
                  .transport_context = (void*)tmcc,
                  .transport_config  = (void*)tmcf,
-                 .client_id         = 1234,
+                 .client_id         = 123,
     }};
 
     whClientContext client[1] = {0};
@@ -473,7 +473,7 @@ int whTest_ClientServerSequential(void)
                  .transport_cb      = tscb,
                  .transport_context = (void*)tmsc,
                  .transport_config  = (void*)tmcf,
-                 .server_id         = 5678,
+                 .server_id         = 124,
     }};
 
     /* RamSim Flash state and configuration */
@@ -1337,7 +1337,7 @@ static int wh_ClientServer_MemThreadTest(void)
                  .transport_cb      = tccb,
                  .transport_context = (void*)tmcc,
                  .transport_config  = (void*)tmcf,
-                 .client_id         = 1234,
+                 .client_id         = 123,
     }};
     whClientConfig c_conf[1] = {{
        .comm = cc_conf,
@@ -1349,7 +1349,7 @@ static int wh_ClientServer_MemThreadTest(void)
                  .transport_cb      = tscb,
                  .transport_context = (void*)tmsc,
                  .transport_config  = (void*)tmcf,
-                 .server_id         = 5678,
+                 .server_id         = 124,
     }};
 
     /* RamSim Flash state and configuration */

--- a/test/wh_test_comm.c
+++ b/test/wh_test_comm.c
@@ -80,6 +80,7 @@ int whTest_CommMem(void)
     uint16_t rx_req_len       = 0;
     uint16_t rx_req_flags     = 0;
     uint16_t rx_req_type      = 0;
+    uint16_t user             = 0;
     uint16_t rx_req_seq       = 0;
 
     uint8_t  tx_resp[RESP_SIZE] = {0};
@@ -94,7 +95,7 @@ int whTest_CommMem(void)
     /* Check that neither side is ready to recv */
     WH_TEST_ASSERT_RETURN(WH_ERROR_NOTREADY ==
                           wh_CommServer_RecvRequest(server, &rx_req_flags,
-                                                    &rx_req_type, &rx_req_seq,
+                                                    &rx_req_type, &user, &rx_req_seq,
                                                     &rx_req_len, rx_req));
 
     for (counter = 0; counter < REPEAT_COUNT; counter++) {
@@ -103,7 +104,7 @@ int whTest_CommMem(void)
         tx_req_type = counter * 2;
         WH_TEST_RETURN_ON_FAIL(
             wh_CommClient_SendRequest(client, tx_req_flags, tx_req_type,
-                                      &tx_req_seq, tx_req_len, tx_req));
+                user, &tx_req_seq, tx_req_len, tx_req));
 #if defined(WH_CFG_TEST_VERBOSE)
         printf("Client SendRequest:%d, flags %x, type:%x, seq:%d, len:%d, %s\n",
                ret, tx_req_flags, tx_req_type, tx_req_seq, tx_req_len, tx_req);
@@ -117,12 +118,12 @@ int whTest_CommMem(void)
 
             WH_TEST_ASSERT_RETURN(
                 WH_ERROR_NOTREADY ==
-                wh_CommClient_SendRequest(client, tx_req_flags, tx_req_type,
+                wh_CommClient_SendRequest(client, tx_req_flags, tx_req_type, user,
                                           &tx_req_seq, tx_req_len, tx_req));
         }
 
         WH_TEST_RETURN_ON_FAIL(
-            wh_CommServer_RecvRequest(server, &rx_req_flags, &rx_req_type,
+            wh_CommServer_RecvRequest(server, &rx_req_flags, &rx_req_type, &user,
                                       &rx_req_seq, &rx_req_len, rx_req));
 
 #if defined(WH_CFG_TEST_VERBOSE)
@@ -185,6 +186,7 @@ static void* _whCommClientTask(void* cf)
     uint16_t rx_resp_flags      = 0;
     uint16_t rx_resp_type       = 0;
     uint16_t rx_resp_seq        = 0;
+    uint16_t user               = 0;
 
     if (config == NULL) {
         return NULL;
@@ -199,7 +201,8 @@ static void* _whCommClientTask(void* cf)
         tx_req_type = counter * 2;
         do {
             ret = wh_CommClient_SendRequest(client, tx_req_flags, tx_req_type,
-                                            &tx_req_seq, tx_req_len, tx_req);
+                                            user, &tx_req_seq, tx_req_len,
+                                            tx_req);
             WH_TEST_ASSERT_MSG((ret == WH_ERROR_NOTREADY) || (0 == ret),
                                "Client SendRequest: ret=%d", ret);
 #if defined(WH_CFG_TEST_VERBOSE)
@@ -259,6 +262,7 @@ static void* _whCommServerTask(void* cf)
     uint16_t rx_req_flags     = 0;
     uint16_t rx_req_type      = 0;
     uint16_t rx_req_seq       = 0;
+    uint16_t user        = 0;
 
     uint8_t  tx_resp[RESP_SIZE] = {0};
     uint16_t tx_resp_len        = 0;
@@ -266,7 +270,8 @@ static void* _whCommServerTask(void* cf)
     for (counter = 0; counter < REPEAT_COUNT; counter++) {
         do {
             ret = wh_CommServer_RecvRequest(server, &rx_req_flags, &rx_req_type,
-                                            &rx_req_seq, &rx_req_len, rx_req);
+                                            &user, &rx_req_seq, &rx_req_len,
+                                            rx_req);
 
             WH_TEST_ASSERT_MSG((ret == WH_ERROR_NOTREADY) || (0 == ret),
                                "Server RecvRequest: ret=%d", ret);

--- a/test/wh_test_comm.c
+++ b/test/wh_test_comm.c
@@ -49,7 +49,7 @@ int whTest_CommMem(void)
                  .transport_cb      = tccb,
                  .transport_context = (void*)tmcc,
                  .transport_config  = (void*)tmcf,
-                 .client_id         = 1234,
+                 .client_id         = 123,
     }};
     whCommClient                client[1] = {0};
 
@@ -60,7 +60,7 @@ int whTest_CommMem(void)
                  .transport_cb      = tscb,
                  .transport_context = (void*)tmsc,
                  .transport_config  = (void*)tmcf,
-                 .server_id         = 5678,
+                 .server_id         = 124,
     }};
     whCommServer                server[1] = {0};
 
@@ -80,7 +80,6 @@ int whTest_CommMem(void)
     uint16_t rx_req_len       = 0;
     uint16_t rx_req_flags     = 0;
     uint16_t rx_req_type      = 0;
-    uint16_t user             = 0;
     uint16_t rx_req_seq       = 0;
 
     uint8_t  tx_resp[RESP_SIZE] = {0};
@@ -95,7 +94,7 @@ int whTest_CommMem(void)
     /* Check that neither side is ready to recv */
     WH_TEST_ASSERT_RETURN(WH_ERROR_NOTREADY ==
                           wh_CommServer_RecvRequest(server, &rx_req_flags,
-                                                    &rx_req_type, &user, &rx_req_seq,
+                                                    &rx_req_type, &rx_req_seq,
                                                     &rx_req_len, rx_req));
 
     for (counter = 0; counter < REPEAT_COUNT; counter++) {
@@ -104,7 +103,7 @@ int whTest_CommMem(void)
         tx_req_type = counter * 2;
         WH_TEST_RETURN_ON_FAIL(
             wh_CommClient_SendRequest(client, tx_req_flags, tx_req_type,
-                user, &tx_req_seq, tx_req_len, tx_req));
+                &tx_req_seq, tx_req_len, tx_req));
 #if defined(WH_CFG_TEST_VERBOSE)
         printf("Client SendRequest:%d, flags %x, type:%x, seq:%d, len:%d, %s\n",
                ret, tx_req_flags, tx_req_type, tx_req_seq, tx_req_len, tx_req);
@@ -118,12 +117,12 @@ int whTest_CommMem(void)
 
             WH_TEST_ASSERT_RETURN(
                 WH_ERROR_NOTREADY ==
-                wh_CommClient_SendRequest(client, tx_req_flags, tx_req_type, user,
+                wh_CommClient_SendRequest(client, tx_req_flags, tx_req_type,
                                           &tx_req_seq, tx_req_len, tx_req));
         }
 
         WH_TEST_RETURN_ON_FAIL(
-            wh_CommServer_RecvRequest(server, &rx_req_flags, &rx_req_type, &user,
+            wh_CommServer_RecvRequest(server, &rx_req_flags, &rx_req_type,
                                       &rx_req_seq, &rx_req_len, rx_req));
 
 #if defined(WH_CFG_TEST_VERBOSE)
@@ -186,7 +185,6 @@ static void* _whCommClientTask(void* cf)
     uint16_t rx_resp_flags      = 0;
     uint16_t rx_resp_type       = 0;
     uint16_t rx_resp_seq        = 0;
-    uint16_t user               = 0;
 
     if (config == NULL) {
         return NULL;
@@ -201,8 +199,7 @@ static void* _whCommClientTask(void* cf)
         tx_req_type = counter * 2;
         do {
             ret = wh_CommClient_SendRequest(client, tx_req_flags, tx_req_type,
-                                            user, &tx_req_seq, tx_req_len,
-                                            tx_req);
+                                            &tx_req_seq, tx_req_len, tx_req);
             WH_TEST_ASSERT_MSG((ret == WH_ERROR_NOTREADY) || (0 == ret),
                                "Client SendRequest: ret=%d", ret);
 #if defined(WH_CFG_TEST_VERBOSE)
@@ -262,7 +259,6 @@ static void* _whCommServerTask(void* cf)
     uint16_t rx_req_flags     = 0;
     uint16_t rx_req_type      = 0;
     uint16_t rx_req_seq       = 0;
-    uint16_t user        = 0;
 
     uint8_t  tx_resp[RESP_SIZE] = {0};
     uint16_t tx_resp_len        = 0;
@@ -270,7 +266,7 @@ static void* _whCommServerTask(void* cf)
     for (counter = 0; counter < REPEAT_COUNT; counter++) {
         do {
             ret = wh_CommServer_RecvRequest(server, &rx_req_flags, &rx_req_type,
-                                            &user, &rx_req_seq, &rx_req_len,
+                                            &rx_req_seq, &rx_req_len,
                                             rx_req);
 
             WH_TEST_ASSERT_MSG((ret == WH_ERROR_NOTREADY) || (0 == ret),
@@ -374,7 +370,7 @@ void wh_CommClientServer_MemThreadTest(void)
                  .transport_cb      = tmccb,
                  .transport_context = (void*)csc,
                  .transport_config  = (void*)tmcf,
-                 .client_id         = 1234,
+                 .client_id         = 123,
     }};
 
     /* Server configuration/contexts */
@@ -384,7 +380,7 @@ void wh_CommClientServer_MemThreadTest(void)
                  .transport_cb      = tmscb,
                  .transport_context = (void*)css,
                  .transport_config  = (void*)tmcf,
-                 .server_id         = 5678,
+                 .server_id         = 124,
     }};
 
     _whCommClientServerThreadTest(c_conf, s_conf);
@@ -405,7 +401,7 @@ void wh_CommClientServer_TcpThreadTest(void)
                     .transport_cb      = pttccb,
                     .transport_context = (void*)tcc,
                     .transport_config  = (void*)mytcpconfig,
-                    .client_id         = 1234,
+                    .client_id         = 123,
     }};
 
     /* Server configuration/contexts */
@@ -416,7 +412,7 @@ void wh_CommClientServer_TcpThreadTest(void)
                     .transport_cb      = pttscb,
                     .transport_context = (void*)tss,
                     .transport_config  = (void*)mytcpconfig,
-                    .server_id         = 5678,
+                    .server_id         = 124,
     }};
 
     _whCommClientServerThreadTest(c_conf, s_conf);

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -499,7 +499,6 @@ static int wh_ClientServer_MemThreadTest(void)
     }};
     whClientConfig c_conf[1] = {{
        .comm = cc_conf,
-       .user = 0,
     }};
     /* Server configuration/contexts */
     whTransportServerCb         tscb[1]   = {WH_TRANSPORT_MEM_SERVER_CB};

--- a/wolfhsm/wh_client.h
+++ b/wolfhsm/wh_client.h
@@ -38,6 +38,7 @@ struct whClientContext_t {
 typedef struct whClientContext_t whClientContext;
 
 struct whClientConfig_t {
+    uint16_t user;
     whCommClientConfig* comm;
 };
 typedef struct whClientConfig_t whClientConfig;

--- a/wolfhsm/wh_client.h
+++ b/wolfhsm/wh_client.h
@@ -38,7 +38,6 @@ struct whClientContext_t {
 typedef struct whClientContext_t whClientContext;
 
 struct whClientConfig_t {
-    uint16_t user;
     whCommClientConfig* comm;
 };
 typedef struct whClientConfig_t whClientConfig;

--- a/wolfhsm/wh_comm.h
+++ b/wolfhsm/wh_comm.h
@@ -30,7 +30,7 @@
  * DATA_LEN bytes.
  */
 enum {
-    WH_COMM_HEADER_LEN = 10,    /* whCommHeader */
+    WH_COMM_HEADER_LEN = 8,    /* whCommHeader */
     WH_COMM_DATA_LEN = 1280,
     WH_COMM_MTU = (WH_COMM_HEADER_LEN + WH_COMM_DATA_LEN),
     WH_COMM_MTU_U64_COUNT = (WH_COMM_MTU + 7) / 8,  /* internal U64 buffer */
@@ -57,8 +57,6 @@ typedef struct {
     uint16_t kind;      /* Kind of packet.  Enumerated in message.h */
     uint16_t seq;       /* Sequence number. Incremented on request, copied for
                          * response. */
-    uint16_t user;       /* User ID to allow seperate users to use the same input
-                         * keyId */
     uint16_t aux;       /* Session identifier for request or error indicator
                          * for response. */
 } whCommHeader;
@@ -141,7 +139,7 @@ typedef struct {
     const whTransportClientCb* transport_cb;
     void* transport_context;
     const void* transport_config;
-    uint32_t client_id;
+    uint8_t client_id;
     uint8_t pad[4];
 } whCommClientConfig;
 
@@ -154,12 +152,12 @@ typedef struct {
     const whTransportClientCb* transport_cb;
     whCommHeader* hdr;
     uint8_t* data;
-    uint32_t client_id;
-    uint32_t server_id;
     int initialized;
     uint16_t reqid;
     uint16_t seq;
     uint16_t size;
+    uint8_t client_id;
+    uint8_t server_id;
     uint8_t pad[6];
 } whCommClient;
 
@@ -174,8 +172,7 @@ int wh_CommClient_Init(whCommClient* context, const whCommClientConfig* config);
  * transport will update the sequence number on success.
  */
 int wh_CommClient_SendRequest(whCommClient* context, uint16_t magic,
-    uint16_t kind, uint8_t user, uint16_t *out_seq, uint16_t data_size,
-    const void* data);
+    uint16_t kind, uint16_t *out_seq, uint16_t data_size, const void* data);
 
 /* If a response packet has been buffered, get the header and copy the data out
  * of the buffer.
@@ -234,7 +231,7 @@ typedef struct {
     void* transport_context;
     const whTransportServerCb* transport_cb;
     const void* transport_config;
-    uint32_t server_id;
+    uint8_t server_id;
     uint8_t pad[4];
 } whCommServerConfig;
 
@@ -247,10 +244,10 @@ typedef struct {
     const whTransportServerCb* transport_cb;
     whCommHeader* hdr;
     uint8_t* data;
-    uint32_t client_id;
-    uint32_t server_id;
     int initialized;
     uint16_t reqid;
+    uint8_t client_id;
+    uint8_t server_id;
     uint8_t pad[2];
 } whCommServer;
 
@@ -265,8 +262,8 @@ int wh_CommServer_Init(whCommServer* context, const whCommServerConfig* config,
  * of the buffer.
  */
 int wh_CommServer_RecvRequest(whCommServer* context,
-        uint16_t* out_magic, uint16_t* out_kind, uint16_t* outUser,
-        uint16_t* out_seq, uint16_t* out_size, void* data);
+        uint16_t* out_magic, uint16_t* out_kind, uint16_t* out_seq,
+        uint16_t* out_size, void* data);
 
 /* Upon completion of the request, send the response packet using the same seq
  * as the incoming request.  Note that overriding the seq number should only be

--- a/wolfhsm/wh_comm.h
+++ b/wolfhsm/wh_comm.h
@@ -30,7 +30,7 @@
  * DATA_LEN bytes.
  */
 enum {
-    WH_COMM_HEADER_LEN = 8,    /* whCommHeader */
+    WH_COMM_HEADER_LEN = 10,    /* whCommHeader */
     WH_COMM_DATA_LEN = 1280,
     WH_COMM_MTU = (WH_COMM_HEADER_LEN + WH_COMM_DATA_LEN),
     WH_COMM_MTU_U64_COUNT = (WH_COMM_MTU + 7) / 8,  /* internal U64 buffer */
@@ -57,6 +57,8 @@ typedef struct {
     uint16_t kind;      /* Kind of packet.  Enumerated in message.h */
     uint16_t seq;       /* Sequence number. Incremented on request, copied for
                          * response. */
+    uint16_t user;       /* User ID to allow seperate users to use the same input
+                         * keyId */
     uint16_t aux;       /* Session identifier for request or error indicator
                          * for response. */
 } whCommHeader;
@@ -171,9 +173,9 @@ int wh_CommClient_Init(whCommClient* context, const whCommClientConfig* config);
 /* If a request buffer is available, send a new request to the server.  The
  * transport will update the sequence number on success.
  */
-int wh_CommClient_SendRequest(whCommClient* context,
-        uint16_t magic, uint16_t kind, uint16_t* out_seq,
-        uint16_t data_size, const void* data);
+int wh_CommClient_SendRequest(whCommClient* context, uint16_t magic,
+    uint16_t kind, uint8_t user, uint16_t *out_seq, uint16_t data_size,
+    const void* data);
 
 /* If a response packet has been buffered, get the header and copy the data out
  * of the buffer.
@@ -263,8 +265,8 @@ int wh_CommServer_Init(whCommServer* context, const whCommServerConfig* config,
  * of the buffer.
  */
 int wh_CommServer_RecvRequest(whCommServer* context,
-        uint16_t* out_magic, uint16_t* out_kind, uint16_t* out_seq,
-        uint16_t* out_size, void* buffer);
+        uint16_t* out_magic, uint16_t* out_kind, uint16_t* outUser,
+        uint16_t* out_seq, uint16_t* out_size, void* data);
 
 /* Upon completion of the request, send the response packet using the same seq
  * as the incoming request.  Note that overriding the seq number should only be

--- a/wolfhsm/wh_comm.h
+++ b/wolfhsm/wh_comm.h
@@ -140,7 +140,7 @@ typedef struct {
     void* transport_context;
     const void* transport_config;
     uint8_t client_id;
-    uint8_t pad[4];
+    uint8_t pad[7];
 } whCommClientConfig;
 
 /* Context structure for a client.  Note the client context will track the
@@ -158,7 +158,7 @@ typedef struct {
     uint16_t size;
     uint8_t client_id;
     uint8_t server_id;
-    uint8_t pad[6];
+    uint8_t pad[4];
 } whCommClient;
 
 
@@ -232,7 +232,7 @@ typedef struct {
     const whTransportServerCb* transport_cb;
     const void* transport_config;
     uint8_t server_id;
-    uint8_t pad[4];
+    uint8_t pad[7];
 } whCommServerConfig;
 
 /* Context structure for a server.  Note the client context will track the
@@ -248,7 +248,6 @@ typedef struct {
     uint16_t reqid;
     uint8_t client_id;
     uint8_t server_id;
-    uint8_t pad[2];
 } whCommServer;
 
 /* Reset the state of the server context and begin the connection to a client

--- a/wolfhsm/wh_common.h
+++ b/wolfhsm/wh_common.h
@@ -58,7 +58,7 @@ typedef uint16_t whKeyId;
 #define WOLFHSM_KEYTYPE_SHE     0x2000
 
 #define MAKE_WOLFHSM_KEYID(_type, _user, _id) \
-    (whKeyId)(((_type) & WOLFHSM_KEYID_MASK) | (((_user) & 0xF) << 8) | ((_id) & WOLFHSM_KEYID_MASK))
+    (whKeyId)(((_type) & WOLFHSM_KEYTYPE_MASK) | (((_user) & 0xF) << 8) | ((_id) & WOLFHSM_KEYID_MASK))
 
 
 /** NVM Management */

--- a/wolfhsm/wh_common.h
+++ b/wolfhsm/wh_common.h
@@ -35,12 +35,30 @@ typedef uint16_t whCounterId;
 /* HSM key identifier type.  Top nibble identifies key type/location */
 typedef uint16_t whKeyId;
 
-#define WOLFHSM_KEYID_MASK 0xF000
-#define WOLFHSM_KEYID_CRYPTO 0x1000
-#define WOLFHSM_KEYID_SHE 0x2000
-#define WOLFHSM_KEYID_SHE_RAM 0x3000
-#define MAKE_WOLFHSM_KEYID(_kind, _id) \
-    (whKeyId)(((_kind) & WOLFHSM_KEYID_MASK) | ((_id) & ~WOLFHSM_KEYID_MASK))
+/* Id Constants */
+#define WOLFHSM_KEYID_ERASED 0x0000
+
+/* Key Masks */
+#define WOLFHSM_KEYID_MASK   0x00FF
+#define WOLFHSM_KEYUSER_MASK 0x0F00
+#define WOLFHSM_KEYTYPE_MASK 0xF000
+
+/* Key Flags */
+#define WOLFHSM_KEYFLAG_RSA         0x1000
+#define WOLFHSM_KEYFLAG_ECC         0x2000
+#define WOLFHSM_KEYFLAG_CURVE25519  0x3000
+#define WOLFHSM_KEYFLAG_ED25519     0x4000
+#define WOLFHSM_KEYFLAG_AES         0x5000
+#define WOLFHSM_KEYFLAG_HMAC        0x6000
+#define WOLFHSM_KEYFLAG_CMAC        0x7000
+
+/* Key Types */
+#define WOLFHSM_KEYTYPE_CRYPTO  0x1000
+/* She keys are technically raw keys but a SHE keyId needs */
+#define WOLFHSM_KEYTYPE_SHE     0x2000
+
+#define MAKE_WOLFHSM_KEYID(_type, _user, _id) \
+    (whKeyId)(((_type) & WOLFHSM_KEYID_MASK) | (((_user) & 0xF) << 8) | ((_id) & WOLFHSM_KEYID_MASK))
 
 
 /** NVM Management */
@@ -81,6 +99,5 @@ typedef struct {
 
 /* Custom request shared defs */
 #define WH_CUSTOM_CB_NUM_CALLBACKS 8
-#define WOLFHSM_ID_ERASED 0
 
 #endif /* WOLFHSM_WH_COMMON_H_ */

--- a/wolfhsm/wh_server_crypto.h
+++ b/wolfhsm/wh_server_crypto.h
@@ -4,7 +4,7 @@
 #include "wolfhsm/wh_server.h"
 
 int wh_Server_HandleCryptoRequest(whServerContext* server, uint16_t action,
-    uint8_t user, uint8_t* data, uint16_t* size);
+    uint8_t* data, uint16_t* size);
 
 
 #endif

--- a/wolfhsm/wh_server_crypto.h
+++ b/wolfhsm/wh_server_crypto.h
@@ -3,8 +3,8 @@
 
 #include "wolfhsm/wh_server.h"
 
-int wh_Server_HandleCryptoRequest(whServerContext* server,
-    uint16_t action, uint8_t* data, uint16_t* size);
+int wh_Server_HandleCryptoRequest(whServerContext* server, uint16_t action,
+    uint8_t user, uint8_t* data, uint16_t* size);
 
 
 #endif

--- a/wolfhsm/wh_server_keystore.h
+++ b/wolfhsm/wh_server_keystore.h
@@ -13,6 +13,6 @@ int hsmEvictKey(whServerContext* server, uint16_t keyId);
 int hsmCommitKey(whServerContext* server, uint16_t keyId);
 int hsmEraseKey(whServerContext* server, whNvmId keyId);
 int wh_Server_HandleKeyRequest(whServerContext* server, uint16_t magic,
-    uint16_t action, uint8_t user, uint16_t seq, uint8_t* data, uint16_t* size);
+    uint16_t action, uint16_t seq, uint8_t* data, uint16_t* size);
 
 #endif

--- a/wolfhsm/wh_server_keystore.h
+++ b/wolfhsm/wh_server_keystore.h
@@ -3,17 +3,16 @@
 
 #include "wolfhsm/wh_server.h"
 
-int hsmGetUniqueId(whServerContext* server);
+int hsmGetUniqueId(whServerContext* server, whNvmId* outId);
 int hsmCacheFindSlot(whServerContext* server);
 int hsmCacheKey(whServerContext* server, whNvmMetadata* meta, uint8_t* in);
 int hsmFreshenKey(whServerContext* server, whKeyId keyId);
-int hsmReadKey(whServerContext* server, whKeyId keyId, whNvmMetadata* meta,
+int hsmReadKey(whServerContext* server, whKeyId keyId, whNvmMetadata* outMeta,
     uint8_t* out, uint32_t* outSz);
 int hsmEvictKey(whServerContext* server, uint16_t keyId);
 int hsmCommitKey(whServerContext* server, uint16_t keyId);
 int hsmEraseKey(whServerContext* server, whNvmId keyId);
-int wh_Server_HandleKeyRequest(whServerContext* server,
-        uint16_t magic, uint16_t action, uint16_t seq,
-        uint8_t* data, uint16_t* size);
+int wh_Server_HandleKeyRequest(whServerContext* server, uint16_t magic,
+    uint16_t action, uint8_t user, uint16_t seq, uint8_t* data, uint16_t* size);
 
 #endif


### PR DESCRIPTION
splitting the key handle up into 3 parts internally, while presenting a one byte key id to the user, allows the same external or user facing key to be identical for each user value and between SHE and crypto keys. algorithm types were added as flags instead of being a part of the key handle and the user param was added to the client so a user can split operations between 16 clients. may not fully implement multiple client handling but seems good for keys