### PR TITLE
Fix comm error and improve test to report failure.

### DIFF
--- a/src/wh_comm.c
+++ b/src/wh_comm.c
@@ -125,8 +125,7 @@ int wh_CommClient_RecvResponse(whCommClient* context,
     uint16_t size = sizeof(context->packet);
     uint16_t data_size = 0;
 
-    if (    (context == NULL) ||
-            (data == NULL)) {
+    if (context == NULL) {
         return WH_ERROR_BADARGS;
     }
 

--- a/test/wh_test_clientserver.c
+++ b/test/wh_test_clientserver.c
@@ -1263,6 +1263,7 @@ int whTest_ServerCfgLoop(whServerConfig* serverCfg)
     }
 
     if ((ret == 0) || (ret == WH_ERROR_NOTREADY)){
+        ret = 0;
         WH_TEST_RETURN_ON_FAIL(wh_Server_Cleanup(server));
     } else {
         ret = wh_Server_Cleanup(server);
@@ -1275,13 +1276,13 @@ int whTest_ServerCfgLoop(whServerConfig* serverCfg)
 #if defined(WH_CFG_TEST_POSIX)
 static void* _whClientTask(void *cf)
 {
-    (void)whTest_ClientCfg(cf);
+    WH_TEST_ASSERT(0 == whTest_ClientCfg(cf));
     return NULL;
 }
 
 static void* _whServerTask(void* cf)
 {
-    (void)whTest_ServerCfgLoop(cf);
+    WH_TEST_ASSERT(0 == whTest_ServerCfgLoop(cf));
     return NULL;
 }
 

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -309,13 +309,13 @@ int whTest_CryptoServerConfig(whServerConfig* config)
 #if defined(WH_CFG_TEST_POSIX)
 static void* _whClientTask(void *cf)
 {
-    (void)whTest_CryptoClientConfig(cf);
+    WH_TEST_ASSERT(0 == whTest_CryptoClientConfig(cf));
     return NULL;
 }
 
 static void* _whServerTask(void* cf)
 {
-    (void)whTest_CryptoServerConfig(cf);
+    WH_TEST_ASSERT(0 == whTest_CryptoServerConfig(cf));
     return NULL;
 }
 


### PR DESCRIPTION
Fixes the comm bug now that we allow NULL data pointers.  Fixes test to assert on thread test failure.