### PR TITLE
No crypto and padding

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,6 +21,10 @@ jobs:
         repository: wolfssl/wolfssl
         path: wolfssl
 
+    # Build and test debug build with ASAN and NOCRYPTO 
+    - name: Build and test ASAN DEBUG
+      run: cd test && make DEBUG=1 ASAN=1 NOCRYPTO=1 WOLFSSL_DIR=../wolfssl run
+
     # Build and test debug build with ASAN 
     - name: Build and test ASAN DEBUG
       run: cd test && make DEBUG=1 ASAN=1 WOLFSSL_DIR=../wolfssl run

--- a/port/posix/posix_flash_file.h
+++ b/port/posix/posix_flash_file.h
@@ -22,6 +22,7 @@ typedef struct posixFlashFileContext_t {
     int unlocked;
     uint32_t partition_size;
     uint8_t erased_byte;
+    uint8_t padding[3];
 } posixFlashFileContext;
 
 /* In memory configuration structure associated with an NVM instance */
@@ -29,6 +30,7 @@ typedef struct posixFlashFileConfig_t {
     const char* filename;       /* Null terminated */
     uint32_t partition_size;
     uint8_t erased_byte;
+    uint8_t padding[3];
 } posixFlashFileConfig;
 
 int posixFlashFile_Init(void* c, const void* cf);

--- a/port/posix/posix_transport_tcp.h
+++ b/port/posix/posix_transport_tcp.h
@@ -50,20 +50,22 @@
 typedef struct {
     char* server_ip_string;
     short int server_port;
+    uint8_t padding[6];
 } posixTransportTcpConfig;
 
 
 /** Client context and functions */
 
 typedef struct {
+    whCommSetConnectedCb connectcb;
+    void* connectcb_arg;
     struct sockaddr_in server_addr;
     int connect_fd_p1;      /* fd plus 1 so 0 is invalid */
     int connected;
     int request_sent;
-    whCommSetConnectedCb connectcb;
-    void* connectcb_arg;
     uint16_t buffer_offset;
     uint8_t buffer[PTT_BUFFER_SIZE];
+    uint8_t padding[6];
 } posixTransportTcpClientContext;
 
 int posixTransportTcp_InitConnect(void* context, const void* config,
@@ -86,15 +88,16 @@ int posixTransportTcp_CleanupConnect(void* context);
 /** Server context and functions */
 
 typedef struct {
+    whCommSetConnectedCb connectcb;
+    void* connectcb_arg;
     struct sockaddr_in server_addr;
     struct sockaddr_in client_addr;
     int listen_fd_p1;       /* fd plus 1 so 0 is invalid */
     int accept_fd_p1;       /* fd plus 1 so 0 is invalid */
     int request_recv;
-    whCommSetConnectedCb connectcb;
-    void* connectcb_arg;
     uint16_t buffer_offset;
     uint8_t buffer[PTT_BUFFER_SIZE];
+    uint8_t padding[6];
 } posixTransportTcpServerContext;
 
 int posixTransportTcp_InitListen(void* context, const void* config,

--- a/src/wh_client.c
+++ b/src/wh_client.c
@@ -7,12 +7,14 @@
 #include <stdlib.h>  /* For NULL */
 #include <string.h>  /* For memset, memcpy */
 
+#ifndef WOLFHSM_NO_CRYPTO
 /* wolfCrypt */
 #include "wolfssl/wolfcrypt/settings.h"
 #include "wolfssl/wolfcrypt/error-crypt.h"
 #include "wolfssl/wolfcrypt/wc_port.h"
 #include "wolfssl/wolfcrypt/cryptocb.h"
 #include "wolfssl/wolfcrypt/curve25519.h"
+#endif
 
 /* Common WolfHSM types and defines shared with the server */
 #include "wolfhsm/wh_common.h"
@@ -20,7 +22,10 @@
 
 /* Components */
 #include "wolfhsm/wh_comm.h"
+
+#ifndef WOLFHSM_NO_CRYPTO
 #include "wolfhsm/wh_cryptocb.h"
+#endif
 
 /* Message definitions */
 #include "wolfhsm/wh_message.h"
@@ -40,8 +45,10 @@ int wh_Client_Init(whClientContext* c, const whClientConfig* config)
     memset(c, 0, sizeof(*c));
 
     if (    ((rc = wh_CommClient_Init(c->comm, config->comm)) == 0) &&
+#ifndef WOLFHSM_NO_CRYPTO
             ((rc = wolfCrypt_Init()) == 0) &&
             ((rc = wc_CryptoCb_RegisterDevice(WOLFHSM_DEV_ID, wolfHSM_CryptoCb, c)) == 0) &&
+#endif  /* WOLFHSM_NO_CRYPTO */
             1) {
         /* All good */
     }
@@ -58,7 +65,10 @@ int wh_Client_Cleanup(whClientContext* c)
     }
 
     (void)wh_CommClient_Cleanup(c->comm);
+#ifndef WOLFHSM_NO_CRYPTO
     (void)wolfCrypt_Cleanup();
+#endif  /* WOLFHSM_NO_CRYPTO */
+
     memset(c, 0, sizeof(*c));
     return 0;
 }
@@ -443,6 +453,9 @@ int wh_Client_CustomCbCheckRegistered(whClientContext* c, uint16_t id, int* resp
     return rc;
 }
 
+
+#ifndef WOLFHSM_NO_CRYPTO
+
 int wh_Client_KeyCacheRequest_ex(whClientContext* c, uint32_t flags,
     uint8_t* label, uint32_t labelSz, uint8_t* in, uint32_t inSz,
     uint16_t keyId)
@@ -645,3 +658,4 @@ void wh_Client_SetKeyCurve25519(curve25519_key* key, whNvmId keyId)
 {
     XMEMCPY(key->devCtx, (void*)&keyId, sizeof(keyId));
 }
+#endif  /* WOLFHSM_NO_CRYPTO */

--- a/src/wh_client_cryptocb.c
+++ b/src/wh_client_cryptocb.c
@@ -21,6 +21,8 @@
 #include <stdint.h>
 #include <unistd.h>
 
+#ifndef WOLFHSM_NO_CRYPTO
+
 #include "wolfssl/wolfcrypt/settings.h"
 #include "wolfssl/wolfcrypt/types.h"
 #include "wolfssl/wolfcrypt/error-crypt.h"
@@ -246,3 +248,4 @@ int wolfHSM_CryptoCb(int devId, wc_CryptoInfo* info, void* inCtx)
 
     return ret;
 }
+#endif  /* WOLFHSM_NO_CRYPTO */

--- a/src/wh_client_cryptocb.c
+++ b/src/wh_client_cryptocb.c
@@ -28,6 +28,7 @@
 #include "wolfssl/wolfcrypt/error-crypt.h"
 #include "wolfssl/wolfcrypt/aes.h"
 #include "wolfssl/wolfcrypt/cmac.h"
+#include "wolfssl/wolfcrypt/rsa.h"
 #include "wolfssl/wolfcrypt/cryptocb.h"
 #include "wolfhsm/wh_packet.h"
 #include "wolfhsm/wh_error.h"
@@ -68,6 +69,8 @@ int wolfHSM_CryptoCb(int devId, wc_CryptoInfo* info, void* inCtx)
         packet->pkAnyReq.type = info->pk.type;
         switch (info->pk.type)
         {
+#ifndef NO_RSA
+#ifdef WOLFSSL_KEY_GEN
         case WC_PK_TYPE_RSA_KEYGEN:
             /* set size */
             packet->pkRsakgReq.size = info->pk.rsakg.size;
@@ -93,6 +96,7 @@ int wolfHSM_CryptoCb(int devId, wc_CryptoInfo* info, void* inCtx)
                 }
             }
             break;
+#endif  /* WOLFSSL_KEY_GEN */
         case WC_PK_TYPE_RSA:
             /* in and out are after the fixed size fields */
             in = (uint8_t*)(&packet->pkRsaReq + 1);
@@ -158,6 +162,8 @@ int wolfHSM_CryptoCb(int devId, wc_CryptoInfo* info, void* inCtx)
                 }
             }
             break;
+#endif  /* !NO_RSA */
+
         case WC_PK_TYPE_CURVE25519_KEYGEN:
             packet->pkCurve25519kgReq.sz = info->pk.curve25519kg.size;
             /* write request */

--- a/src/wh_server.c
+++ b/src/wh_server.c
@@ -47,9 +47,10 @@ int wh_Server_Init(whServerContext* server, whServerConfig* config)
     }
 
     memset(server, 0, sizeof(*server));
-    server->crypto = config->crypto;
     server->nvm = config->nvm;
 
+#ifndef WOLFHSM_NO_CRYPTO
+    server->crypto = config->crypto;
     if (server->crypto != NULL) {
 #if defined(WOLF_CRYPTO_CB)
         server->crypto->devId = config->devId;
@@ -57,6 +58,7 @@ int wh_Server_Init(whServerContext* server, whServerConfig* config)
         server->crypto->devId = INVALID_DEVID;
 #endif
     }
+#endif
 
     rc = wh_CommServer_Init(server->comm, config->comm_config,
             wh_Server_SetConnectedCb, (void*)server);
@@ -254,6 +256,7 @@ int wh_Server_HandleRequestMessage(whServerContext* server)
                     size, data, &size, data);
         break;
 
+        #ifndef WOLFHSM_NO_CRYPTO
         case WH_MESSAGE_GROUP_KEY:
             rc = wh_Server_HandleKeyRequest(server, magic, action, seq,
                     data, &size);
@@ -262,6 +265,7 @@ int wh_Server_HandleRequestMessage(whServerContext* server)
         case WH_MESSAGE_GROUP_CRYPTO:
             rc = wh_Server_HandleCryptoRequest(server, action, data, &size);
         break;
+#endif  /* WOLFHSM_NO_CRYPTO */
 
         case WH_MESSAGE_GROUP_PKCS11:
             rc = _wh_Server_HandlePkcs11Request(server, magic, action, seq,

--- a/src/wh_server.c
+++ b/src/wh_server.c
@@ -256,7 +256,7 @@ int wh_Server_HandleRequestMessage(whServerContext* server)
                     size, data, &size, data);
         break;
 
-        #ifndef WOLFHSM_NO_CRYPTO
+#ifndef WOLFHSM_NO_CRYPTO
         case WH_MESSAGE_GROUP_KEY:
             rc = wh_Server_HandleKeyRequest(server, magic, action, seq,
                     data, &size);

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -34,6 +34,7 @@ static int hsmCacheKeyRsa(whServerContext* server, RsaKey* key)
     }
     if (ret > 0 ) {
         /* export key */
+        /* TODO: Fix wolfCrypto to allow KeyToDer when KEY_GEN is NOT set */
         ret = wc_RsaKeyToDer(key, server->cache[slotIdx].buffer,
             WOLFHSM_KEYCACHE_BUFSIZE);
     }
@@ -142,6 +143,7 @@ int wh_Server_HandleCryptoRequest(whServerContext* server,
         switch (packet->pkAnyReq.type)
         {
 #ifndef NO_RSA
+#ifdef WOLFSSL_KEY_GEN
         case WC_PK_TYPE_RSA_KEYGEN:
             /* init the rsa key */
             ret = wc_InitRsaKey_ex(server->crypto->rsa, NULL, INVALID_DEVID);
@@ -165,6 +167,8 @@ int wh_Server_HandleCryptoRequest(whServerContext* server,
                 ret = 0;
             }
             break;
+#endif  /* WOLFSSL_KEY_GEN */
+
         case WC_PK_TYPE_RSA:
             switch (packet->pkRsaReq.opType)
             {

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -3,6 +3,8 @@
 #include <stdlib.h>  /* For NULL */
 #include <string.h>  /* For memset, memcpy */
 
+#ifndef WOLFHSM_NO_CRYPTO
+
 #include "wolfssl/wolfcrypt/settings.h"
 #include "wolfssl/wolfcrypt/types.h"
 #include "wolfssl/wolfcrypt/error-crypt.h"
@@ -312,3 +314,5 @@ int wh_Server_HandleCryptoRequest(whServerContext* server,
     packet->rc = ret;
     return 0;
 }
+
+#endif  /* WOLFHSM_NO_CRYPTO */

--- a/src/wh_server_dma.c
+++ b/src/wh_server_dma.c
@@ -2,6 +2,10 @@
  * src/wh_server_dma.c
  */
 
+#include <stdint.h>
+#include <string.h>
+#include <stddef.h>
+
 #include "wolfhsm/wh_error.h"
 #include "wolfhsm/wh_server.h"
 

--- a/src/wh_server_keystore.c
+++ b/src/wh_server_keystore.c
@@ -3,6 +3,8 @@
 #include <stdlib.h>  /* For NULL */
 #include <string.h>  /* For memset, memcpy */
 
+#ifndef WOLFHSM_NO_CRYPTO
+
 #include "wolfssl/wolfcrypt/settings.h"
 #include "wolfssl/wolfcrypt/error-crypt.h"
 
@@ -379,3 +381,5 @@ int wh_Server_HandleKeyRequest(whServerContext* server,
     (void)seq;
     return 0;
 }
+
+#endif  /* WOLFHSM_NO_CRYPTO */

--- a/test/Makefile
+++ b/test/Makefile
@@ -53,7 +53,7 @@ CFLAGS += -DWOLFHSM_NO_CRYPTO -Wpadded
 endif
 
 # wolfHSM-specific defines
-CFLAGS += -DWH_CONFIG -DWOLFHSM_NO_CRYPTO
+CFLAGS += -DWH_CONFIG
 
 
 # Assembly source files

--- a/test/Makefile
+++ b/test/Makefile
@@ -23,8 +23,8 @@ ARCHFLAGS ?=
 
 # Compiler and linker flags
 ASFLAGS ?= $(ARCHFLAGS)
-CFLAGS_EXTRA ?=
-CFLAGS ?= $(ARCHFLAGS) -std=c99 -D_GNU_SOURCE -Wall -Werror -Wno-cpp $(CFLAGS_EXTRA)
+CFLAGS_EXTRA ?= -Wmissing-field-initializers -Wmissing-braces -Wpadded
+CFLAGS ?= $(ARCHFLAGS) -std=c90 -D_GNU_SOURCE -Wall -Werror -Wno-cpp $(CFLAGS_EXTRA)
 LDFLAGS ?= $(ARCHFLAGS)
 
 # Libc for printf
@@ -48,14 +48,14 @@ LDFLAGS += -fsanitize=address
 endif
 
 # wolfHSM-specific defines
-CFLAGS += -DWH_CONFIG
+CFLAGS += -DWH_CONFIG -DWOLFHSM_NO_CRYPTO
 
 
 # Assembly source files
 SRC_ASM +=
 
 # wolfCrypt source files
-SRC_C += \
+WSRC_C += \
             $(WOLFSSL_DIR)/wolfcrypt/src/wc_port.c \
             $(WOLFSSL_DIR)/wolfcrypt/src/memory.c \
             $(WOLFSSL_DIR)/wolfcrypt/src/misc.c \

--- a/test/Makefile
+++ b/test/Makefile
@@ -23,7 +23,7 @@ ARCHFLAGS ?=
 
 # Compiler and linker flags
 ASFLAGS ?= $(ARCHFLAGS)
-CFLAGS_EXTRA ?= -Wmissing-field-initializers -Wmissing-braces -Wpadded
+CFLAGS_EXTRA ?= -Wmissing-field-initializers -Wmissing-braces
 CFLAGS ?= $(ARCHFLAGS) -std=c90 -D_GNU_SOURCE -Wall -Werror -Wno-cpp $(CFLAGS_EXTRA)
 LDFLAGS ?= $(ARCHFLAGS)
 
@@ -47,6 +47,11 @@ CFLAGS += -fsanitize=address
 LDFLAGS += -fsanitize=address
 endif
 
+# Support a NO CRYPTO build
+ifeq ($(NOCRYPTO),1)
+CFLAGS += -DWOLFHSM_NO_CRYPTO -Wpadded
+endif
+
 # wolfHSM-specific defines
 CFLAGS += -DWH_CONFIG -DWOLFHSM_NO_CRYPTO
 
@@ -54,8 +59,9 @@ CFLAGS += -DWH_CONFIG -DWOLFHSM_NO_CRYPTO
 # Assembly source files
 SRC_ASM +=
 
+ifneq ($(NOCRYPTO),1)
 # wolfCrypt source files
-WSRC_C += \
+SRC_C += \
             $(WOLFSSL_DIR)/wolfcrypt/src/wc_port.c \
             $(WOLFSSL_DIR)/wolfcrypt/src/memory.c \
             $(WOLFSSL_DIR)/wolfcrypt/src/misc.c \
@@ -72,6 +78,8 @@ WSRC_C += \
             $(WOLFSSL_DIR)/wolfcrypt/src/sha256.c \
             $(WOLFSSL_DIR)/wolfcrypt/src/aes.c \
             $(WOLFSSL_DIR)/wolfcrypt/src/cmac.c \
+
+endif
 
 # wolfHSM source files
 SRC_C += \

--- a/test/wh_test.c
+++ b/test/wh_test.c
@@ -18,7 +18,9 @@ int whTest_Unit(void)
 {
     /* Comm tests */
     WH_TEST_ASSERT(0 == whTest_Comm());
+#ifndef WOLFHSM_NO_CRYPTO
     WH_TEST_ASSERT(0 == whTest_Crypto());
+#endif
     WH_TEST_ASSERT(0 == whTest_Flash_RamSim());
     WH_TEST_ASSERT(0 == whTest_NvmFlash());
     WH_TEST_ASSERT(0 == whTest_ClientServer());

--- a/test/wh_test_clientserver.c
+++ b/test/wh_test_clientserver.c
@@ -501,20 +501,25 @@ int whTest_ClientServerSequential(void)
          .config  = nf_conf,
     }};
     whNvmContext nvm[1]    = {{0}};
-
+#ifndef WOLFHSM_NO_CRYPTO
     crypto_context crypto[1] = {{
         .devId = INVALID_DEVID,
     }};
+#endif
 
     whServerConfig  s_conf[1] = {{
          .comm_config = cs_conf,
          .nvm         = nvm,
+#ifndef WOLFHSM_NO_CRYPTO
          .crypto      = crypto,
+#endif
     }};
     whServerContext server[1] = {0};
 
+#ifndef WOLFHSM_NO_CRYPTO
     WH_TEST_RETURN_ON_FAIL(wolfCrypt_Init());
     WH_TEST_RETURN_ON_FAIL(wc_InitRng_ex(crypto->rng, NULL, crypto->devId));
+#endif
     WH_TEST_RETURN_ON_FAIL(wh_Nvm_Init(nvm, n_conf));
 
     /* Init client and server */
@@ -918,8 +923,10 @@ int whTest_ClientServerSequential(void)
     WH_TEST_RETURN_ON_FAIL(wh_Client_Cleanup(client));
 
     wh_Nvm_Cleanup(nvm);
+#ifndef WOLFHSM_NO_CRYPTO
     wc_FreeRng(crypto->rng);
     wolfCrypt_Cleanup();
+#endif
 
     return ret;
 }
@@ -1371,27 +1378,35 @@ static int wh_ClientServer_MemThreadTest(void)
     }};
     whNvmContext nvm[1] = {{0}};
 
+#ifndef WOLFHSM_NO_CRYPTO
     /* Crypto context */
     crypto_context crypto[1] = {{
             .devId = INVALID_DEVID,
     }};
+#endif
 
     whServerConfig                  s_conf[1] = {{
        .comm_config = cs_conf,
        .nvm = nvm,
+#ifndef WOLFHSM_NO_CRYPTO
        .crypto = crypto,
+#endif
     }};
 
     WH_TEST_RETURN_ON_FAIL(wh_Nvm_Init(nvm, n_conf));
 
+#ifndef WOLFHSM_NO_CRYPTO
     WH_TEST_RETURN_ON_FAIL(wolfCrypt_Init());
     WH_TEST_RETURN_ON_FAIL(wc_InitRng_ex(crypto->rng, NULL, crypto->devId));
-
+#endif
     _whClientServerThreadTest(c_conf, s_conf);
 
     wh_Nvm_Cleanup(nvm);
+
+#ifndef WOLFHSM_NO_CRYPTO
     wc_FreeRng(crypto->rng);
     wolfCrypt_Cleanup();
+#endif
 
     return WH_ERROR_OK;
 }

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -7,6 +7,8 @@
 #include <stdio.h>  /* For printf */
 #include <string.h> /* For memset, memcpy */
 
+#ifndef WOLFHSM_NO_CRYPTO
+
 #include "wolfssl/wolfcrypt/settings.h"
 
 #if defined(WH_CONFIG)
@@ -484,3 +486,5 @@ int whTest_Crypto(void)
 #endif
     return 0;
 }
+
+#endif  /* WOLFHSM_NO_CRYPTO */

--- a/wolfhsm/wh_client.h
+++ b/wolfhsm/wh_client.h
@@ -33,6 +33,7 @@ struct whClientContext_t {
     whCommClient comm[1];
     uint16_t last_req_id;
     uint16_t last_req_kind;
+    uint8_t pad[4];
 };
 typedef struct whClientContext_t whClientContext;
 

--- a/wolfhsm/wh_comm.h
+++ b/wolfhsm/wh_comm.h
@@ -140,6 +140,7 @@ typedef struct {
     void* transport_context;
     const void* transport_config;
     uint32_t client_id;
+    uint8_t pad[4];
 } whCommClientConfig;
 
 /* Context structure for a client.  Note the client context will track the
@@ -157,6 +158,7 @@ typedef struct {
     uint16_t reqid;
     uint16_t seq;
     uint16_t size;
+    uint8_t pad[6];
 } whCommClient;
 
 
@@ -231,6 +233,7 @@ typedef struct {
     const whTransportServerCb* transport_cb;
     const void* transport_config;
     uint32_t server_id;
+    uint8_t pad[4];
 } whCommServerConfig;
 
 /* Context structure for a server.  Note the client context will track the
@@ -246,6 +249,7 @@ typedef struct {
     uint32_t server_id;
     int initialized;
     uint16_t reqid;
+    uint8_t pad[2];
 } whCommServer;
 
 /* Reset the state of the server context and begin the connection to a client

--- a/wolfhsm/wh_common.h
+++ b/wolfhsm/wh_common.h
@@ -80,7 +80,7 @@ typedef struct {
 
 
 /** Manifest storage  */
-
+#if 0
 enum {
     WOLFHSM_MANIFEST_CMAC_LEN = 16,
 };
@@ -95,8 +95,8 @@ typedef struct {
 } whManifest_ex;
 
 /* TODO Update Stored manifest data at compile time */
-
 extern const whManifest_ex manifests[WOLFHSM_NUM_MANIFESTS];
+#endif
 
 /* Custom request shared defs */
 #define WH_CUSTOM_CB_NUM_CALLBACKS 8

--- a/wolfhsm/wh_common.h
+++ b/wolfhsm/wh_common.h
@@ -79,25 +79,6 @@ typedef struct {
 /* static_assert(sizeof(whNvmMetadata) == WOLFHSM_NVM_METADATA_LEN) */
 
 
-/** Manifest storage  */
-#if 0
-enum {
-    WOLFHSM_MANIFEST_CMAC_LEN = 16,
-};
-
-typedef struct {
-    void* address;              /* Flash address that matches this entry */
-    /* TODO: Make this match customer format */
-    uint8_t payload_cmac[WOLFHSM_MANIFEST_CMAC_LEN];  /* CMAC of the image */
-    uint8_t* payload_start;     /* Flash address where the payload starts */
-    uint32_t payload_len;       /* Leng of the payload */
-    uint8_t manifest_cmac[WOLFHSM_MANIFEST_CMAC_LEN]; /* CMAC of the manifest */
-} whManifest_ex;
-
-/* TODO Update Stored manifest data at compile time */
-extern const whManifest_ex manifests[WOLFHSM_NUM_MANIFESTS];
-#endif
-
 /* Custom request shared defs */
 #define WH_CUSTOM_CB_NUM_CALLBACKS 8
 #define WOLFHSM_ID_ERASED 0

--- a/wolfhsm/wh_flash_ramsim.h
+++ b/wolfhsm/wh_flash_ramsim.h
@@ -9,6 +9,7 @@ typedef struct {
     uint32_t sectorSize;
     uint32_t pageSize;
     uint8_t  erasedByte;
+    uint8_t padding[3];
 } whFlashRamsimCfg;
 
 typedef struct {
@@ -18,6 +19,7 @@ typedef struct {
     uint32_t pageSize;
     int      writeLocked;
     uint8_t  erasedByte;
+    uint8_t padding[7];
 } whFlashRamsimCtx;
 
 

--- a/wolfhsm/wh_message_nvm.h
+++ b/wolfhsm/wh_message_nvm.h
@@ -187,6 +187,7 @@ typedef struct {
     uint32_t metadata_hostaddr;
     uint32_t data_hostaddr;
     uint16_t data_len;
+    uint8_t padding[6];
 } whMessageNvm_AddObjectDma32Request;
 
 int wh_MessageNvm_TranslateAddObjectDma32Request(uint16_t magic,
@@ -202,6 +203,7 @@ typedef struct {
     uint16_t id;
     uint16_t offset;
     uint16_t data_len;
+    uint8_t padding[6];
 } whMessageNvm_ReadDma32Request;
 
 int wh_MessageNvm_TranslateReadDma32Request(uint16_t magic,
@@ -216,6 +218,7 @@ typedef struct {
     uint64_t metadata_hostaddr;
     uint64_t data_hostaddr;
     uint16_t data_len;
+    uint8_t padding[6];
 } whMessageNvm_AddObjectDma64Request;
 
 int wh_MessageNvm_TranslateAddObjectDma64Request(uint16_t magic,
@@ -231,6 +234,7 @@ typedef struct {
     uint16_t id;
     uint16_t offset;
     uint16_t data_len;
+    uint8_t padding[2];
 } whMessageNvm_ReadDma64Request;
 
 int wh_MessageNvm_TranslateReadDma64Request(uint16_t magic,

--- a/wolfhsm/wh_nvm_flash.h
+++ b/wolfhsm/wh_nvm_flash.h
@@ -58,15 +58,14 @@ typedef struct whNvmFlashConfig_t {
 } whNvmFlashConfig;
 
 typedef struct whNvmFlashContext_t {
-    int initialized;
-
     const whFlashCb* cb;            /* Flash callbacks */
     void* flash;                    /* Flash context to use */
-    uint32_t partition_units;       /* Size of partition in units */
-
-    int active;                     /* Which partition (0 or 1) is active */
     nfMemState state;               /* State of active partition */
     nfMemDirectory directory;       /* Cache of active objects */
+    uint32_t partition_units;       /* Size of partition in units */
+    int active;                     /* Which partition (0 or 1) is active */
+    int initialized;
+    uint8_t padding[4];
 } whNvmFlashContext;
 
 /** whNvm Interface */

--- a/wolfhsm/wh_server.h
+++ b/wolfhsm/wh_server.h
@@ -8,22 +8,26 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 #include "wolfhsm/wh_common.h"
 #include "wolfhsm/wh_comm.h"
 #include "wolfhsm/wh_nvm.h"
 #include "wolfhsm/wh_message_customcb.h"
 
+#ifndef WOLFHSM_NO_CRYPTO
 #include "wolfssl/wolfcrypt/settings.h"
 #include "wolfssl/wolfcrypt/random.h"
 #include "wolfssl/wolfcrypt/rsa.h"
 #include "wolfssl/wolfcrypt/curve25519.h"
 #include "wolfssl/wolfcrypt/cryptocb.h"
+#endif  /* WOLFHSM_NO_CRYPTO */
 
 /* Forward declaration of the server structure so its elements can reference
  * itself  (e.g. server argument to custom callback) */
 typedef struct whServerContext_t whServerContext;
 
+#ifndef WOLFHSM_NO_CRYPTO
 /** Server crypto context and resource allocation */
 typedef struct CacheSlot {
     uint8_t commited;
@@ -38,6 +42,7 @@ typedef struct {
     curve25519_key curve25519Public[1];
     WC_RNG rng[1];
 } crypto_context;
+#endif  /* WOLFHSM_NO_CRYPTO */
 
 
 /** Server custom callback */
@@ -73,6 +78,7 @@ typedef enum {
 /* Flags embedded in request/response structs provided by client */
 typedef struct {
     uint8_t cacheForceInvalidate : 1;
+    uint8_t :7;
 } whServerDmaFlags;
 
 /* DMA callbacks invoked internally by wolfHSM before and after every client
@@ -121,10 +127,13 @@ typedef struct {
 typedef struct whServerConfig_t {
     whCommServerConfig* comm_config;
     whNvmContext* nvm;
+
+#ifndef WOLFHSM_NO_CRYPTO
     crypto_context* crypto;
 #if defined WOLF_CRYPTO_CB /* TODO: should we be relying on wolfSSL defines? */
     int devId;
 #endif
+#endif  /* WOLFHSM_NO_CRYPTO */
     whServerDmaConfig* dmaConfig;
 } whServerConfig;
 
@@ -133,11 +142,14 @@ typedef struct whServerConfig_t {
 struct whServerContext_t {
     whCommServer comm[1];
     whNvmContext* nvm;
+#ifndef WOLFHSM_NO_CRYPTO
     crypto_context* crypto;
     CacheSlot cache[WOLFHSM_NUM_RAMKEYS];
+#endif  /* WOLFHSM_NO_CRYPTO */
     whServerCustomCb customHandlerTable[WH_CUSTOM_CB_NUM_CALLBACKS];
     whServerDmaContext dma;
     int connected;
+    uint8_t padding[4];
 };
 
 

--- a/wolfhsm/wh_transport_mem.h
+++ b/wolfhsm/wh_transport_mem.h
@@ -80,9 +80,10 @@
 /** Common configuration structure */
 typedef struct {
     void* req;
-    uint16_t req_size;
     void* resp;
+    uint16_t req_size;
     uint16_t resp_size;
+    uint8_t padding[4];
 } whTransportMemConfig;
 
 
@@ -101,12 +102,12 @@ typedef union whTransportMemCsr_t {
 
 typedef struct {
     volatile whTransportMemCsr* req;
-    void* req_data;
-    uint16_t req_size;
     volatile whTransportMemCsr* resp;
+    void* req_data;
     void* resp_data;
-    uint16_t resp_size;
     int initialized;
+    uint16_t req_size;
+    uint16_t resp_size;
 } whTransportMemContext;
 
 /* Naming conveniences. Reuses the same types. */


### PR DESCRIPTION
1. Support for doing a no crypto build and enabling -Wpadded on all of wolfHSM.
2. Adds additional workflow action to run this build
3. Corrects some wolfCrypt conditional compile misses.  Note WOLFSSL_KEY_GEN is required on server for now.
4. Reorders structures and adds additional padding bytes.