### PR TITLE
compiler warning fixes for 32-bit platforms

### DIFF
--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -81,7 +81,7 @@ static int hsmLoadKeyRsa(whServerContext* server, RsaKey* key, whKeyId keyId)
     /* decode the key */
     if (ret >= 0) {
         size = WOLFHSM_KEYCACHE_BUFSIZE;
-        ret = wc_RsaPrivateKeyDecode(server->cache[slotIdx].buffer, &idx, key,
+        ret = wc_RsaPrivateKeyDecode(server->cache[slotIdx].buffer, (word32*)&idx, key,
             size);
     }
     return ret;
@@ -151,7 +151,7 @@ int wh_Server_HandleCryptoRequest(whServerContext* server,
     int ret = 0;
     uint32_t field;
     uint8_t* in;
-    whKeyId keyId;
+    whKeyId keyId = WOLFHSM_KEYID_ERASED;
     uint8_t* out;
     whPacket* packet = (whPacket*)data;
 #ifdef WOLFHSM_SYMMETRIC_INTERNAL
@@ -216,7 +216,7 @@ int wh_Server_HandleCryptoRequest(whServerContext* server,
                     if (ret == 0) {
                         field = packet->pkRsaReq.outLen;
                         ret = wc_RsaFunction( in, packet->pkRsaReq.inLen,
-                            out, &field, packet->pkRsaReq.opType,
+                            out, (word32*)&field, packet->pkRsaReq.opType,
                             server->crypto->rsa, server->crypto->rng);
                     }
                     /* free the key */
@@ -311,7 +311,7 @@ int wh_Server_HandleCryptoRequest(whServerContext* server,
                 field = CURVE25519_KEYSIZE;
                 ret = wc_curve25519_shared_secret_ex(
                     server->crypto->curve25519Private,
-                    server->crypto->curve25519Public, out, &field,
+                    server->crypto->curve25519Public, out, (word32*)&field,
                     packet->pkCurve25519Req.endian);
             }
             wc_curve25519_free(server->crypto->curve25519Private);

--- a/test/wh_test_clientserver.c
+++ b/test/wh_test_clientserver.c
@@ -609,7 +609,7 @@ int whTest_ClientServerSequential(void)
 
 #if defined(WH_CFG_TEST_VERBOSE)
     printf("Client NvmInitResponse:%d, server_rc:%d, clientid:%d serverid:%d\n",
-           ret, server_rc, client_id, server_id);
+           ret, (int)server_rc, (int)client_id, (int)server_id);
 #endif
     WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
 
@@ -622,8 +622,8 @@ int whTest_ClientServerSequential(void)
 #if defined(WH_CFG_TEST_VERBOSE)
     printf("Client NvmGetAvailableResponse:%d, server_rc:%d avail_size:%d "
            "avail_objects:%d, reclaim_size:%d reclaim_objects:%d\n",
-           ret, server_rc, avail_size, avail_objects, reclaim_size,
-           reclaim_objects);
+           ret, (int)server_rc, (int)avail_size, (int)avail_objects, (int)reclaim_size,
+           (int)reclaim_objects);
 #endif
     WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
     WH_TEST_ASSERT_RETURN(avail_objects == NF_OBJECT_COUNT);
@@ -666,7 +666,7 @@ int whTest_ClientServerSequential(void)
             wh_Client_NvmAddObjectResponse(client, &server_rc));
 #if defined(WH_CFG_TEST_VERBOSE)
         printf("Client NvmAddObjectResponse:%d, server_rc:%d\n", ret,
-               server_rc);
+                (int)server_rc);
 #endif
         WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
 
@@ -678,8 +678,8 @@ int whTest_ClientServerSequential(void)
 #if defined(WH_CFG_TEST_VERBOSE)
         printf("Client NvmGetAvailableResponse:%d, server_rc:%d, avail_size:%d "
                "avail_objects:%d, reclaim_size:%d reclaim_objects:%d\n",
-               ret, server_rc, avail_size, avail_objects, reclaim_size,
-               reclaim_objects);
+               ret, (int)server_rc, (int)avail_size, (int)avail_objects, (int)reclaim_size,
+               (int)reclaim_objects);
 #endif
 
         /* Check that available objects decreased by one */
@@ -709,7 +709,7 @@ int whTest_ClientServerSequential(void)
 #if defined(WH_CFG_TEST_VERBOSE)
         printf(
             "Client NvmReadResponse:%d, server_rc:%d id:%u, len:%u data:%s\n",
-            ret, server_rc, gid, rlen, recv_buffer);
+            ret, (int)server_rc, (unsigned int)gid, (unsigned int)rlen, recv_buffer);
 #endif
 
         /* Ensure data and size of response object matches that of the written
@@ -731,7 +731,7 @@ int whTest_ClientServerSequential(void)
             client, &server_rc, &list_count, &list_id));
 #if defined(WH_CFG_TEST_VERBOSE)
         printf("Client NvmListResponse:%d, server_rc:%d count:%u id:%u\n", ret,
-               server_rc, list_count, list_id);
+                (int)server_rc, (unsigned int)list_count, (unsigned int)list_id);
 #endif
 
         if (list_count > 0) {
@@ -747,7 +747,7 @@ int whTest_ClientServerSequential(void)
 #if defined(WH_CFG_TEST_VERBOSE)
             printf("Client NvmDestroyObjectsResponse:%d, server_rc:%d for "
                    "id:%u with count:%u\n",
-                   ret, server_rc, list_id, list_count);
+                   ret, (int)server_rc, (unsigned int)list_id, (unsigned int)list_count);
 #endif
             WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
 
@@ -761,7 +761,7 @@ int whTest_ClientServerSequential(void)
 
 #if defined(WH_CFG_TEST_VERBOSE)
             printf("Client NvmListResponse:%d, server_rc:%d count:%u id:%u\n",
-                   ret, server_rc, list_count, list_id);
+                   ret, (int)server_rc, (unsigned int)list_count, (unsigned int)list_id);
 #endif
 
             list_id = 0;
@@ -814,7 +814,7 @@ int whTest_ClientServerSequential(void)
             wh_Client_NvmAddObjectDmaResponse(client, &server_rc));
 #if defined(WH_CFG_TEST_VERBOSE)
         printf("Client NvmAddObjectDmaResponse:%d, server_rc:%d, meta.len:%u\n",
-               ret, server_rc, meta.len);
+               ret, (int)server_rc, (unsigned int)meta.len);
 #endif
         WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
 
@@ -826,8 +826,8 @@ int whTest_ClientServerSequential(void)
 #if defined(WH_CFG_TEST_VERBOSE)
         printf("Client NvmGetAvailableResponse:%d, server_rc:%d, avail_size:%d "
                "avail_objects:%d, reclaim_size:%d reclaim_objects:%d\n",
-               ret, server_rc, avail_size, avail_objects, reclaim_size,
-               reclaim_objects);
+               ret, (int)server_rc, (int)avail_size, (int)avail_objects, (int)reclaim_size,
+               (int)reclaim_objects);
 #endif
         WH_TEST_ASSERT_RETURN(lastAvailObjects - 1 == avail_objects);
 
@@ -856,7 +856,7 @@ int whTest_ClientServerSequential(void)
 #if defined(WH_CFG_TEST_VERBOSE)
         printf("Client NvmReadDmaResponse:%d, server_rc:%d id:%u, len:%u "
                "data:%s\n",
-               ret, server_rc, gid, glen, recv_buffer);
+               ret, (int)server_rc, (unsigned int)gid, (unsigned int)glen, recv_buffer);
 #endif
 
         /* Ensure data and size of response object matches that of the written
@@ -874,7 +874,7 @@ int whTest_ClientServerSequential(void)
             client, &server_rc, &list_count, &list_id));
 #if defined(WH_CFG_TEST_VERBOSE)
         printf("Client NvmListResponse:%d, server_rc:%d count:%u id:%u\n", ret,
-               server_rc, list_count, list_id);
+                (int)server_rc, (unsigned int)list_count, (unsigned int)list_id);
 #endif
         WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
 
@@ -893,7 +893,7 @@ int whTest_ClientServerSequential(void)
 #if defined(WH_CFG_TEST_VERBOSE)
             printf("Client NvmDestroyObjectsResponse:%d, server_rc:%d for "
                    "id:%u with count:%u\n",
-                   ret, server_rc, list_id, list_count);
+                   ret, (int)server_rc, (unsigned int)list_id, (unsigned int)list_count);
 #endif
 
             /* Ensure object was destroyed and no longer exists */
@@ -913,7 +913,7 @@ int whTest_ClientServerSequential(void)
     WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
     WH_TEST_RETURN_ON_FAIL(wh_Client_NvmCleanupResponse(client, &server_rc));
 #if defined(WH_CFG_TEST_VERBOSE)
-    printf("Client NvmCleanupResponse:%d, server_rc:%d\n", ret, server_rc);
+    printf("Client NvmCleanupResponse:%d, server_rc:%d\n", ret, (int)server_rc);
 #endif
     WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
 
@@ -925,8 +925,8 @@ int whTest_ClientServerSequential(void)
 #if defined(WH_CFG_TEST_VERBOSE)
     printf("Client NvmGetAvailableResponse:%d, server_rc:%d, avail_size:%d "
            "avail_objects:%d, reclaim_size:%d reclaim_objects:%d\n",
-           ret, server_rc, avail_size, avail_objects, reclaim_size,
-           reclaim_objects);
+           ret, (int)server_rc, (int)avail_size, (int)avail_objects, (int)reclaim_size,
+           (int)reclaim_objects);
 #endif
     WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
     WH_TEST_ASSERT_RETURN(avail_objects == NF_OBJECT_COUNT);
@@ -1000,8 +1000,8 @@ int whTest_ClientCfg(whClientConfig* clientCfg)
 #if defined(WH_CFG_TEST_VERBOSE)
     printf("Client NvmGetAvailable:%d, server_rc:%d avail_size:%d "
            "avail_objects:%d, reclaim_size:%d reclaim_objects:%d\n",
-           ret, server_rc, avail_size, avail_objects, reclaim_size,
-           reclaim_objects);
+           ret, (int)server_rc, (int)avail_size, (int)avail_objects, (int)reclaim_size,
+           (int)reclaim_objects);
 #endif
     WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
     WH_TEST_ASSERT_RETURN(avail_objects == NF_OBJECT_COUNT);
@@ -1036,7 +1036,7 @@ int whTest_ClientCfg(whClientConfig* clientCfg)
 
 #if defined(WH_CFG_TEST_VERBOSE)
         printf("Client NvmAddObject:%d, server_rc:%d\n", ret,
-               server_rc);
+               (int)server_rc);
 #endif
         WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
 
@@ -1047,8 +1047,8 @@ int whTest_ClientCfg(whClientConfig* clientCfg)
 #if defined(WH_CFG_TEST_VERBOSE)
         printf("Client NvmGetAvailable:%d, server_rc:%d, avail_size:%d "
                "avail_objects:%d, reclaim_size:%d reclaim_objects:%d\n",
-               ret, server_rc, avail_size, avail_objects, reclaim_size,
-               reclaim_objects);
+               ret, (int)server_rc, (int)avail_size, (int)avail_objects, (int)reclaim_size,
+               (int)reclaim_objects);
 #endif
 
         /* Check that available objects decreased by one */
@@ -1078,7 +1078,7 @@ int whTest_ClientCfg(whClientConfig* clientCfg)
 #if defined(WH_CFG_TEST_VERBOSE)
         printf(
             "Client NvmRead:%d, server_rc:%d id:%u, len:%u data:%s\n",
-            ret, server_rc, gid, rlen, recv_buffer);
+            ret, (int)server_rc, (unsigned int)gid, (unsigned int)rlen, recv_buffer);
 #endif
 
         /* Ensure data and size of response object matches that of the written
@@ -1098,7 +1098,7 @@ int whTest_ClientCfg(whClientConfig* clientCfg)
                               &server_rc, &list_count, &list_id));
 #if defined(WH_CFG_TEST_VERBOSE)
         printf("Client NvmList:%d, server_rc:%d count:%u id:%u\n", ret,
-               server_rc, list_count, list_id);
+                (int)server_rc, (unsigned int)list_count, (unsigned int)list_id);
 #endif
 
         if (list_count > 0) {
@@ -1113,7 +1113,7 @@ int whTest_ClientCfg(whClientConfig* clientCfg)
 #if defined(WH_CFG_TEST_VERBOSE)
             printf("Client NvmDestroyObjects:%d, server_rc:%d for "
                    "id:%u with count:%u\n",
-                   ret, server_rc, list_id, list_count);
+                   ret, (int)server_rc, (unsigned int)list_id, (unsigned int)list_count);
 #endif
             WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
 
@@ -1123,7 +1123,7 @@ int whTest_ClientCfg(whClientConfig* clientCfg)
 
 #if defined(WH_CFG_TEST_VERBOSE)
             printf("Client NvmGetMetadata:%d, server_rc:%d count:%u id:%u\n",
-                   ret, server_rc, list_count, list_id);
+                   ret, (int)server_rc, (unsigned int)list_count, (unsigned int)list_id);
 #endif
 
             list_id = 0;
@@ -1164,7 +1164,7 @@ int whTest_ClientCfg(whClientConfig* clientCfg)
 
 #if defined(WH_CFG_TEST_VERBOSE)
         printf("Client NvmAddObjectDma:%d, server_rc:%d, meta.len:%u\n",
-               ret, server_rc, meta.len);
+               ret, (int)server_rc, meta.len);
 #endif
         WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
 
@@ -1173,8 +1173,8 @@ int whTest_ClientCfg(whClientConfig* clientCfg)
 #if defined(WH_CFG_TEST_VERBOSE)
         printf("Client NvmGetAvailable:%d, server_rc:%d, avail_size:%d "
                "avail_objects:%d, reclaim_size:%d reclaim_objects:%d\n",
-               ret, server_rc, avail_size, avail_objects, reclaim_size,
-               reclaim_objects);
+               ret, (int)server_rc, (int)avail_size, (int)avail_objects, (int)reclaim_size,
+               (int)reclaim_objects);
 #endif
         WH_TEST_ASSERT_RETURN(lastAvailObjects - 1 == avail_objects);
 
@@ -1183,7 +1183,7 @@ int whTest_ClientCfg(whClientConfig* clientCfg)
 #if defined(WH_CFG_TEST_VERBOSE)
         printf("Client NvmGetMetadata:%d, id:%u, access:0x%x, "
                "flags:0x%x, len:%u label:%s\n",
-               ret, gid, gaccess, gflags, glen, glabel);
+               ret, (unsigned int)gid, (unsigned int)gaccess, (unsigned int)gflags, (unsigned int)glen, glabel);
 #endif
 
         /* Ensure metadata matches that of the object we just wrote */
@@ -1197,7 +1197,7 @@ int whTest_ClientCfg(whClientConfig* clientCfg)
 #if defined(WH_CFG_TEST_VERBOSE)
         printf("Client NvmReadDma:%d, server_rc:%d id:%u, len:%u "
                "data:%s\n",
-               ret, server_rc, gid, glen, recv_buffer);
+               ret, (int)server_rc, (unsigned int)gid, (unsigned int)glen, recv_buffer);
 #endif
 
         /* Ensure data and size of response object matches that of the written
@@ -1213,7 +1213,7 @@ int whTest_ClientCfg(whClientConfig* clientCfg)
                                     &server_rc, &list_count, &list_id));
 #if defined(WH_CFG_TEST_VERBOSE)
         printf("Client NvmList:%d, server_rc:%d count:%u id:%u\n", ret,
-               server_rc, list_count, list_id);
+               (int)server_rc, (unsigned int)list_count, (unsigned int)list_id);
 #endif
         WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
 
@@ -1231,7 +1231,7 @@ int whTest_ClientCfg(whClientConfig* clientCfg)
 #if defined(WH_CFG_TEST_VERBOSE)
             printf("Client NvmDestroyObjects:%d, server_rc:%d for "
                    "id:%u with count:%u\n",
-                   ret, server_rc, list_id, list_count);
+                   ret, (int)server_rc, (unsigned int)list_id, (unsigned int)list_count);
 #endif
 
             /* Ensure object was destroyed and no longer exists */
@@ -1245,7 +1245,7 @@ int whTest_ClientCfg(whClientConfig* clientCfg)
 
     WH_TEST_RETURN_ON_FAIL(ret = wh_Client_NvmCleanup(client, &server_rc));
 #if defined(WH_CFG_TEST_VERBOSE)
-    printf("Client NvmCleanup:%d, server_rc:%d\n", ret, server_rc);
+    printf("Client NvmCleanup:%d, server_rc:%d\n", ret, (int)server_rc);
 #endif
     WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
 
@@ -1255,8 +1255,8 @@ int whTest_ClientCfg(whClientConfig* clientCfg)
 #if defined(WH_CFG_TEST_VERBOSE)
     printf("Client NvmGetAvailable:%d, server_rc:%d, avail_size:%d "
            "avail_objects:%d, reclaim_size:%d reclaim_objects:%d\n",
-           ret, server_rc, avail_size, avail_objects, reclaim_size,
-           reclaim_objects);
+           ret, (int)server_rc, (int)avail_size, (int)avail_objects, (int)reclaim_size,
+           (int)reclaim_objects);
 #endif
     WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
     WH_TEST_ASSERT_RETURN(avail_objects == NF_OBJECT_COUNT);

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -380,12 +380,12 @@ int whTest_CryptoClientConfig(whClientConfig* config)
     }
 
     outLen = sizeof(sharedOne);
-    if ((ret = wc_curve25519_shared_secret(curve25519PrivateKey, curve25519PublicKey, sharedOne, &outLen)) != 0) {
+    if ((ret = wc_curve25519_shared_secret(curve25519PrivateKey, curve25519PublicKey, sharedOne, (word32*)&outLen)) != 0) {
         WH_ERROR_PRINT("Failed to wc_curve25519_shared_secret %d\n", ret);
         goto exit;
     }
 
-    if ((ret = wc_curve25519_shared_secret(curve25519PublicKey, curve25519PrivateKey, sharedTwo, &outLen)) != 0) {
+    if ((ret = wc_curve25519_shared_secret(curve25519PublicKey, curve25519PrivateKey, sharedTwo, (word32*)&outLen)) != 0) {
         WH_ERROR_PRINT("Failed to wc_curve25519_shared_secret %d\n", ret);
         goto exit;
     }

--- a/test/wh_test_flash_ramsim.c
+++ b/test/wh_test_flash_ramsim.c
@@ -110,7 +110,7 @@ int whTest_Flash_RamSim(void)
             0) {
             WH_ERROR_PRINT("whFlashRamsim_Erase failed to erase sector %u "
                            "(offset=%u, size=%u): ret=%d\n",
-                           sector, sectorOffset, cfg.sectorSize, ret);
+                           (unsigned int)sector, (unsigned int)sectorOffset, (unsigned int)cfg.sectorSize, ret);
             whFlashRamsim_Cleanup(&ctx);
             return ret;
         }
@@ -118,8 +118,8 @@ int whTest_Flash_RamSim(void)
         if ((ret = whFlashRamsim_BlankCheck(&ctx, sectorOffset,
                                             cfg.sectorSize)) != 0) {
             WH_ERROR_PRINT(
-                "Sector %u is not blank (offset=%u, size=%u): ret=%d\n", sector,
-                sectorOffset, cfg.sectorSize, ret);
+                "Sector %u is not blank (offset=%u, size=%u): ret=%d\n", (unsigned int)sector,
+                (unsigned int)sectorOffset, (unsigned int)cfg.sectorSize, ret);
             whFlashRamsim_Cleanup(&ctx);
             return ret;
         }
@@ -139,7 +139,7 @@ int whTest_Flash_RamSim(void)
             };
 
 #if WH_TEST_FLASH_RAMSIM_DEBUG
-            printf("Page %u in sector %u before programming:\n", page, sector);
+            printf("Page %u in sector %u before programming:\n", (unsigned int)page, (unsigned int)sector);
             printMemory(readData, cfg.pageSize, pageOffset);
 #endif /* WH_TEST_FLASH_RAMSIM_DEBUG */
 
@@ -147,13 +147,13 @@ int whTest_Flash_RamSim(void)
                                              testData)) != 0) {
                 WH_ERROR_PRINT("whFlashRamsim_Program failed to program page "
                                "%u in sector %u: ret=%d\n",
-                               page, sector, ret);
+                               (unsigned int)page, (unsigned int)sector, ret);
                 whFlashRamsim_Cleanup(&ctx);
                 return ret;
             }
 
 #if WH_TEST_FLASH_RAMSIM_DEBUG
-            printf("Page %u in sector %u after programming:\n", page, sector);
+            printf("Page %u in sector %u after programming:\n", (unsigned int)page, (unsigned int)sector);
             whFlashRamsim_Read(&ctx, pageOffset, cfg.pageSize, readData);
             printMemory(readData, cfg.pageSize, pageOffset);
 #endif /* WH_TEST_FLASH_RAMSIM_DEBUG */
@@ -162,7 +162,7 @@ int whTest_Flash_RamSim(void)
                                             testData)) != 0) {
                 WH_ERROR_PRINT("whFlashRamsim_Verify failed for page %u in "
                                "sector %u: ret=%d\n",
-                               page, sector, ret);
+                               (unsigned int)page, (unsigned int)sector, ret);
                 whFlashRamsim_Cleanup(&ctx);
                 return ret;
             }
@@ -170,7 +170,7 @@ int whTest_Flash_RamSim(void)
 
         if ((ret = whFlashRamsim_BlankCheck(
                  &ctx, sectorOffset, cfg.sectorSize)) != WH_ERROR_NOTBLANK) {
-            WH_ERROR_PRINT("Sector %u is not blank, ret=%d\n", sector, ret);
+            WH_ERROR_PRINT("Sector %u is not blank, ret=%d\n", (unsigned int)sector, ret);
             whFlashRamsim_Cleanup(&ctx);
             return ret;
         }
@@ -179,14 +179,14 @@ int whTest_Flash_RamSim(void)
             0) {
             WH_ERROR_PRINT(
                 "whFlashRamsim_Erase failed to erase sector %u: ret=%d\n",
-                sector, ret);
+                (unsigned int)sector, ret);
             whFlashRamsim_Cleanup(&ctx);
             return ret;
         }
 
         if ((ret = whFlashRamsim_BlankCheck(&ctx, sectorOffset,
                                             cfg.sectorSize)) != 0) {
-            WH_ERROR_PRINT("Sector %u is not blank, ret=%d\n", sector, ret);
+            WH_ERROR_PRINT("Sector %u is not blank, ret=%d\n", (unsigned int)sector, ret);
             whFlashRamsim_Cleanup(&ctx);
             return ret;
         }


### PR DESCRIPTION
adds some casting for print statements and `word32` pointers so compiler doesn't complain about `unsigned long int` vs `unsigned int` discrepancy on 32-bit platforms