### PR TITLE
client connect callbacks

### DIFF
--- a/wolfhsm/wh_comm.h
+++ b/wolfhsm/wh_comm.h
@@ -157,6 +157,7 @@ typedef struct {
     const whTransportClientCb* transport_cb;
     void* transport_context;
     const void* transport_config;
+    whCommSetConnectedCb connect_cb;
     uint8_t client_id;
     uint8_t pad[7];
 } whCommClientConfig;
@@ -168,6 +169,7 @@ typedef struct {
     uint64_t packet[WH_COMM_MTU_U64_COUNT];
     void* transport_context;
     const whTransportClientCb* transport_cb;
+    whCommSetConnectedCb connect_cb;
     whCommHeader* hdr;
     uint8_t* data;
     int initialized;


### PR DESCRIPTION
Adds support for client connect callbacks, which should signal to the server via external mechanism that the shared memory comms buffer is ok to process. The server is expected to handle this signal and call `wh_Server_SetConnected()` with the connect value.

How I expose the server context in the tests is kind of janky, but can't really think of another way to do it, since it needs a pointer to the server context which is a local variable to the test function :-/

