### PR TITLE
first pass at client and server doxygen API

### DIFF
--- a/wolfhsm/wh_client.h
+++ b/wolfhsm/wh_client.h
@@ -59,9 +59,9 @@
 /* Client context */
 struct whClientContext_t {
     whCommClient comm[1];
-    uint16_t last_req_id;
-    uint16_t last_req_kind;
-    uint8_t pad[4];
+    uint16_t     last_req_id;
+    uint16_t     last_req_kind;
+    uint8_t      pad[4];
 };
 typedef struct whClientContext_t whClientContext;
 
@@ -72,194 +72,1391 @@ typedef struct whClientConfig_t whClientConfig;
 
 
 /** Context initialization and shutdown functions */
-/* Initialize client context and connect to server based on provided
- * configuration */
+
+/**
+ * Initializes a whClientContext object with the provided configuration.
+ *
+ * @param c The pointer to the whClientContext object to be initialized.
+ * @param config The pointer to the whClientConfig object containing the
+ * configuration settings.
+ * @return Returns 0 on success, or a negative value indicating an error.
+ */
 int wh_Client_Init(whClientContext* c, const whClientConfig* config);
 
-/* Disconnect from server and release any resources */
+/**
+ * @brief Disconnects from the server and releases client context resources
+ *
+ * This function frees any resources allocated during the initialization
+ * of the whClientContext. It should be called when the client is no longer
+ * needed
+ *
+ * @param c A pointer to the whClientContext structure to be cleaned up.
+ * @return Returns 0 on success, or a negative value on failure.
+ */
 int wh_Client_Cleanup(whClientContext* c);
 
 
 /** Generic request/response functions */
 /* TODO: Move these to internal API */
-int wh_Client_SendRequest(whClientContext* c,
-        uint16_t group, uint16_t action,
-        uint16_t data_size, const void* data);
-int wh_Client_RecvResponse(whClientContext *c,
-        uint16_t *out_group, uint16_t *out_action,
-        uint16_t *out_size, void* data);
+
+
+/**
+ * Sends a request to the server using the specified client context.
+ *
+ * @param c The client context.
+ * @param group The group identifier.
+ * @param action The action identifier.
+ * @param data_size The size of the data to be sent.
+ * @param data A pointer to the data to be sent.
+ * @return Returns 0 on success, or a negative value on failure.
+ */
+int wh_Client_SendRequest(whClientContext* c, uint16_t group, uint16_t action,
+                          uint16_t data_size, const void* data);
+/**
+ * Receives a response from the server and extracts the group, action, size, and
+ * data.
+ *
+ * @param c The client context.
+ * @param out_group Pointer to store the received group value.
+ * @param out_action Pointer to store the received action value.
+ * @param out_size Pointer to store the received size value.
+ * @param data Pointer to store the received data.
+ * @return 0 if successful, a negative value if an error occurred.
+ */
+int wh_Client_RecvResponse(whClientContext* c, uint16_t* out_group,
+                           uint16_t* out_action, uint16_t* out_size,
+                           void* data);
 
 
 /** Comm component functions */
-int wh_Client_CommInitRequest(whClientContext* c);
-int wh_Client_CommInitResponse(whClientContext* c,
-                                uint32_t *out_clientid,
-                                uint32_t *out_serverid);
-int wh_Client_CommInit(whClientContext* c,
-                        uint32_t *out_clientid,
-                        uint32_t *out_serverid);
 
+/**
+ * @brief Sends a communication initialization request to the server.
+ *
+ * This function prepares and sends a communication initialization request
+ * message to the server. It populates the message with the client's ID
+ * and sends it using the communication context.
+ *
+ * @param[in] c Pointer to the client context.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_CommInitRequest(whClientContext* c);
+
+/**
+ * @brief Receives a communication initialization response from the server.
+ *
+ * This function waits for and processes a communication initialization
+ * response message from the server. It validates the response and extracts
+ * the client and server IDs from the message.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] out_clientid Pointer to store the client ID from the response.
+ * @param[out] out_serverid Pointer to store the server ID from the response.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_CommInitResponse(whClientContext* c, uint32_t* out_clientid,
+                               uint32_t* out_serverid);
+
+/**
+ * @brief Initializes communication with the server with a blocking call.
+ *
+ * This function handles the complete process of initializing communication
+ * with the server. It sends an initialization request and waits for a valid
+ * response, extracting the client and server IDs from the response.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] out_clientid Pointer to store the client ID from the response.
+ * @param[out] out_serverid Pointer to store the server ID from the response.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_CommInit(whClientContext* c, uint32_t* out_clientid,
+                       uint32_t* out_serverid);
+
+/**
+ * @brief Sends a communication close request to the server.
+ *
+ * This function prepares and sends a communication close request
+ * message to the server. It signals the server to close the communication
+ * channel with the client.
+ *
+ * @param[in] c Pointer to the client context.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_CommCloseRequest(whClientContext* c);
+
+/**
+ * @brief Receives a communication close response from the server.
+ *
+ * This function checks for and processes a communication close response
+ * message from the server.
+ *
+ * @param[in] c Pointer to the client context.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_CommCloseResponse(whClientContext* c);
+
+/**
+ * @brief Closes communication with the server.
+ *
+ * This function handles the complete process of closing communication
+ * with the server. It sends a close request and waits for a valid response
+ * to confirm that the communication channel has been closed.
+ *
+ * @param[in] c Pointer to the client context.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_CommClose(whClientContext* c);
 
+/**
+ * @brief Sends an echo request to the server.
+ *
+ * This function prepares and sends an echo request message to the server.
+ * The message contains a data payload of the specified size. This function
+ * does not block; it returns immediately after sending the request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] size Size of the data payload.
+ * @param[in] data Pointer to the data payload.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_EchoRequest(whClientContext* c, uint16_t size, const void* data);
-int wh_Client_EchoResponse(whClientContext* c, uint16_t *out_size, void* data);
+
+/**
+ * @brief Receives an echo response from the server.
+ *
+ * This function attempts to process an echo response message from the server.
+ * It validates the response and extracts the data payload. This function does
+ * not block; it returns WH_ERROR_NOTREADY if a response has not been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] out_size Pointer to store the size of the received data payload.
+ * @param[out] data Pointer to store the received data payload.
+ * @return int Returns 0 on success, WH_ERROR_NOTREADY if no response is
+ * available, or a negative error code on failure.
+ */
+int wh_Client_EchoResponse(whClientContext* c, uint16_t* out_size, void* data);
+
+/**
+ * @brief Sends an echo request to the server and receives the response.
+ *
+ * This function handles the complete process of sending an echo request to the
+ * server and receiving the response. It sends the request and repeatedly
+ * attempts to receive a valid response, extracting the data payload from the
+ * response once received. This function blocks until the entire operation is
+ * complete or an error occurs.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] snd_len Size of the data payload to send.
+ * @param[in] snd_data Pointer to the data payload to send.
+ * @param[out] out_rcv_len Pointer to store the size of the received data
+ * payload.
+ * @param[out] rcv_data Pointer to store the received data payload.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_Echo(whClientContext* c, uint16_t snd_len, const void* snd_data,
-        uint16_t *out_rcv_len, void* rcv_data);
+                   uint16_t* out_rcv_len, void* rcv_data);
 
 /** Key functions */
 #ifndef WOLFHSM_NO_CRYPTO
+/**
+ * @brief Sends a key cache request to the server.
+ *
+ * This function prepares and sends a key cache request message to the server.
+ * The message contains the specified flags, label, and input data. This
+ * function does not block; it returns immediately after sending the request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] flags Flags for the key cache request.
+ * @param[in] label Pointer to the label associated with the key.
+ * @param[in] labelSz Size of the label.
+ * @param[in] in Pointer to the key data to be cached.
+ * @param[in] inSz Size of the key data.
+ * @param[in] keyId Key ID to be used for caching. If set to
+ * WOLFHSM_KEYID_ERASED, a new ID will be generated.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_KeyCacheRequest_ex(whClientContext* c, uint32_t flags,
-    uint8_t* label, uint32_t labelSz, uint8_t* in, uint32_t inSz,
-    uint16_t keyId);
+                                 uint8_t* label, uint32_t labelSz, uint8_t* in,
+                                 uint32_t inSz, uint16_t keyId);
+
+/**
+ * @brief Sends a key cache request to the server.
+ *
+ * This function prepares and sends a key cache request message to the server.
+ * The message contains the specified flags, label, and input data. This
+ * function does not block; it returns immediately after sending the request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] flags Flags for the key cache request.
+ * @param[in] label Pointer to the label associated with the key.
+ * @param[in] labelSz Size of the label.
+ * @param[in] in Pointer to the key data to be cached.
+ * @param[in] inSz Size of the key data.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_KeyCacheRequest(whClientContext* c, uint32_t flags,
-    uint8_t* label, uint32_t labelSz, uint8_t* in, uint32_t inSz);
+                              uint8_t* label, uint32_t labelSz, uint8_t* in,
+                              uint32_t inSz);
+
+/**
+ * @brief Receives a key cache response from the server.
+ *
+ * This function attempts to process a key cache response message from the
+ * server. It validates the response and extracts the key ID. This function does
+ * not block; it returns WH_ERROR_NOTREADY if a response has not been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] keyId Pointer to store the key ID assigned by the server.
+ * @return int Returns 0 on success, WH_ERROR_NOTREADY if no response is
+ * available, or a negative error code on failure.
+ */
 int wh_Client_KeyCacheResponse(whClientContext* c, uint16_t* keyId);
-int wh_Client_KeyCache(whClientContext* c, uint32_t flags,
-    uint8_t* label, uint32_t labelSz, uint8_t* in, uint32_t inSz,
-    uint16_t* keyId);
+
+/**
+ * @brief Sends a key cache request to the server and receives the response.
+ *
+ * This function handles the complete process of sending a key cache request to
+ * the server and receiving the response. It sends the request and repeatedly
+ * attempts to receive a valid response, extracting the key ID from the response
+ * once received. This function blocks until the entire operation is complete or
+ * an error occurs.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] flags Flags for the key cache request.
+ * @param[in] label Pointer to the label associated with the key.
+ * @param[in] labelSz Size of the label.
+ * @param[in] in Pointer to the key data to be cached.
+ * @param[in] inSz Size of the key data.
+ * @param[out] keyId Pointer to store the key ID assigned by the server.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_KeyCache(whClientContext* c, uint32_t flags, uint8_t* label,
+                       uint32_t labelSz, uint8_t* in, uint32_t inSz,
+                       uint16_t* keyId);
+
+/**
+ * @brief Sends a key eviction request to the server.
+ *
+ * This function prepares and sends a key eviction request message to the
+ * server. The message contains the specified key ID. This function does not
+ * block; it returns immediately after sending the request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] keyId Key ID to be evicted.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_KeyEvictRequest(whClientContext* c, uint16_t keyId);
+
+/**
+ * @brief Receives a key eviction response from the server.
+ *
+ * This function attempts to process a key eviction response message from the
+ * server. It validates the response. This function does not block; it returns
+ * WH_ERROR_NOTREADY if a response has not been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @return int Returns 0 on success, WH_ERROR_NOTREADY if no response is
+ * available, or a negative error code on failure.
+ */
 int wh_Client_KeyEvictResponse(whClientContext* c);
+
+/**
+ * @brief Sends a key eviction request to the server and receives the response.
+ *
+ * This function handles the complete process of sending a key eviction request
+ * to the server and receiving the response. It sends the request and repeatedly
+ * attempts to receive a valid response. This function blocks until the entire
+ * operation is complete or an error occurs.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] keyId Key ID to be evicted.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_KeyEvict(whClientContext* c, uint16_t keyId);
+
+/**
+ * @brief Sends a key export request to the server.
+ *
+ * This function prepares and sends a key export request message to the server.
+ * The message contains the specified key ID. This function does not block;
+ * it returns immediately after sending the request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] keyId Key ID to be exported.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_KeyExportRequest(whClientContext* c, uint16_t keyId);
+
+/**
+ * @brief Receives a key export response from the server.
+ *
+ * This function attempts to process a key export response message from the
+ * server. It validates the response and extracts the label and key data. This
+ * function does not block; it returns WH_ERROR_NOTREADY if a response has not
+ * been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] label Pointer to store the label associated with the key.
+ * @param[in] labelSz Size of the label buffer.
+ * @param[out] out Pointer to store the exported key data.
+ * @param[out] outSz Pointer to store the size of the exported key data.
+ * @return int Returns 0 on success, WH_ERROR_NOTREADY if no response is
+ * available, or a negative error code on failure.
+ */
 int wh_Client_KeyExportResponse(whClientContext* c, uint8_t* label,
-    uint32_t labelSz, uint8_t* out, uint32_t* outSz);
-int wh_Client_KeyExport(whClientContext* c, uint16_t keyId,
-    uint8_t* label, uint32_t labelSz, uint8_t* out, uint32_t* outSz);
+                                uint32_t labelSz, uint8_t* out,
+                                uint32_t* outSz);
+
+/**
+ * @brief Sends a key export request to the server and receives the response.
+ *
+ * This function handles the complete process of sending a key export request to
+ * the server and receiving the response. It sends the request and repeatedly
+ * attempts to receive a valid response, extracting the label and key data from
+ * the response once received. This function blocks until the entire operation
+ * is complete or an error occurs.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] keyId Key ID to be exported.
+ * @param[out] label Pointer to store the label associated with the key.
+ * @param[in] labelSz Size of the label buffer.
+ * @param[out] out Pointer to store the exported key data.
+ * @param[out] outSz Pointer to store the size of the exported key data.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_KeyExport(whClientContext* c, uint16_t keyId, uint8_t* label,
+                        uint32_t labelSz, uint8_t* out, uint32_t* outSz);
+
+/**
+ * @brief Sends a key commit request to the server.
+ *
+ * This function prepares and sends a key commit request message to the server.
+ * The message contains the specified key ID. This function does not block;
+ * it returns immediately after sending the request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] keyId Key ID to be committed. Committing a key means making it
+ * persistent in non-volatile memory.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_KeyCommitRequest(whClientContext* c, whNvmId keyId);
+
+/**
+ * @brief Receives a key commit response from the server.
+ *
+ * This function attempts to process a key commit response message from the
+ * server. It validates the response. This function does not block; it returns
+ * WH_ERROR_NOTREADY if a response has not been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @return int Returns 0 on success, WH_ERROR_NOTREADY if no response is
+ * available, or a negative error code on failure.
+ */
 int wh_Client_KeyCommitResponse(whClientContext* c);
+
+/**
+ * @brief Sends a key commit request to the server and receives the response.
+ *
+ * This function handles the complete process of sending a key commit request to
+ * the server and receiving the response. It sends the request and repeatedly
+ * attempts to receive a valid response. This function blocks until the entire
+ * operation is complete or an error occurs.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] keyId Key ID to be committed. Committing a key means making it
+ * persistent in non-volatile memory.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_KeyCommit(whClientContext* c, whNvmId keyId);
+
+/**
+ * @brief Sends a key erase request to the server.
+ *
+ * This function prepares and sends a key erase request message to the server.
+ * The message contains the specified key ID. This function does not block;
+ * it returns immediately after sending the request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] keyId Key ID to be erased.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_KeyEraseRequest(whClientContext* c, whNvmId keyId);
+
+/**
+ * @brief Receives a key erase response from the server.
+ *
+ * This function attempts to process a key erase response message from the
+ * server. It validates the response. This function does not block; it returns
+ * WH_ERROR_NOTREADY if a response has not been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @return int Returns 0 on success, WH_ERROR_NOTREADY if no response is
+ * available, or a negative error code on failure.
+ */
 int wh_Client_KeyEraseResponse(whClientContext* c);
+
+/**
+ * @brief Sends a key erase request to the server and receives the response.
+ *
+ * This function handles the complete process of sending a key erase request to
+ * the server and receiving the response. It sends the request and repeatedly
+ * attempts to receive a valid response. This function blocks until the entire
+ * operation is complete or an error occurs.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] keyId Key ID to be erased.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_KeyErase(whClientContext* c, whNvmId keyId);
+/**
+ * @brief Associates a Curve25519 key with a specific key ID.
+ *
+ * This function sets the device context of a Curve25519 key to the specified
+ * key ID. On the server side, this key ID is used to reference the key stored
+ * in the HSM
+ *
+ * @param[in] key Pointer to the Curve25519 key structure.
+ * @param[in] keyId Key ID to be associated with the Curve25519 key.
+ */
 void wh_Client_SetKeyCurve25519(curve25519_key* key, whNvmId keyId);
+
+/**
+ * @brief Associates an RSA key with a specific key ID.
+ *
+ * This function sets the device context of an RSA key to the specified key ID.
+ * On the server side, this key ID is used to reference the key stored in the
+ * HSM.
+ *
+ * @param[in] key Pointer to the RSA key structure.
+ * @param[in] keyId Key ID to be associated with the RSA key.
+ */
 void wh_Client_SetKeyRsa(RsaKey* key, whNvmId keyId);
+
+/**
+ * @brief Associates an AES key with a specific key ID.
+ *
+ * This function sets the device context of an AES key to the specified key ID.
+ * On the server side, this key ID is used to reference the key stored in the
+ * HSM
+ *
+ * @param[in] aes Pointer to the AES key structure.
+ * @param[in] keyId Key ID to be associated with the AES key.
+ */
 void wh_Client_SetKeyAes(Aes* aes, whNvmId keyId);
 #endif
 
 /** NVM functions */
+/**
+ * @brief Sends a non-volatile memory (NVM) initialization request to the
+ * server.
+ *
+ * This function prepares and sends an NVM initialization request message to the
+ * server. The message contains the client NVM ID. This function does not block;
+ * it returns immediately after sending the request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_NvmInitRequest(whClientContext* c);
-int wh_Client_NvmInitResponse(whClientContext* c, int32_t *out_rc,
-        uint32_t *out_clientnvm_id, uint32_t *out_servernvm_id);
-int wh_Client_NvmInit(whClientContext* c, int32_t *out_rc,
-        uint32_t *out_clientnvm_id, uint32_t *out_servernvm_id);
 
+/**
+ * @brief Receives a non-volatile memory (NVM) initialization response from the
+ * server.
+ *
+ * This function attempts to process an NVM initialization response message from
+ * the server. It validates the response and extracts the client and server NVM
+ * IDs. This function does not block; it returns WH_ERROR_NOTREADY if a response
+ * has not been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @param[out] out_clientnvm_id Pointer to store the client NVM ID assigned by
+ * the server.
+ * @param[out] out_servernvm_id Pointer to store the server NVM ID assigned by
+ * the server.
+ * @return int Returns 0 on success, WH_ERROR_NOTREADY if no response is
+ * available, or a negative error code on failure.
+ */
+int wh_Client_NvmInitResponse(whClientContext* c, int32_t* out_rc,
+                              uint32_t* out_clientnvm_id,
+                              uint32_t* out_servernvm_id);
+
+/**
+ * @brief Sends a non-volatile memory (NVM) initialization request to the server
+ * and receives the response.
+ *
+ * This function handles the complete process of sending an NVM initialization
+ * request to the server and receiving the response. It sends the request and
+ * repeatedly attempts to receive a valid response, extracting the client and
+ * server NVM IDs from the response once received. This function blocks until
+ * the entire operation is complete or an error occurs.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @param[out] out_clientnvm_id Pointer to store the client NVM ID assigned by
+ * the server.
+ * @param[out] out_servernvm_id Pointer to store the server NVM ID assigned by
+ * the server.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_NvmInit(whClientContext* c, int32_t* out_rc,
+                      uint32_t* out_clientnvm_id, uint32_t* out_servernvm_id);
+
+/**
+ * @brief Sends a non-volatile memory (NVM) cleanup request to the server.
+ *
+ * This function prepares and sends an NVM cleanup request message to the
+ * server. This function does not block; it returns immediately after sending
+ * the request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_NvmCleanupRequest(whClientContext* c);
-int wh_Client_NvmCleanupResponse(whClientContext* c, int32_t *out_rc);
-int wh_Client_NvmCleanup(whClientContext* c, int32_t *out_rc);
 
+/**
+ * @brief Receives a non-volatile memory (NVM) cleanup response from the server.
+ *
+ * This function attempts to process an NVM cleanup response message from the
+ * server. It validates the response. This function does not block; it returns
+ * WH_ERROR_NOTREADY if a response has not been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @return int Returns 0 on success, WH_ERROR_NOTREADY if no response is
+ * available, or a negative error code on failure.
+ */
+int wh_Client_NvmCleanupResponse(whClientContext* c, int32_t* out_rc);
+
+/**
+ * @brief Sends a non-volatile memory (NVM) cleanup request to the server and
+ * receives the response.
+ *
+ * This function handles the complete process of sending an NVM cleanup request
+ * to the server and receiving the response. It sends the request and repeatedly
+ * attempts to receive a valid response. This function blocks until the entire
+ * operation is complete or an error occurs.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_NvmCleanup(whClientContext* c, int32_t* out_rc);
+
+/**
+ * @brief Sends a request to the server to get available non-volatile memory
+ * (NVM) information.
+ *
+ * This function prepares and sends a request to the server to retrieve
+ * information about the available and reclaimable NVM space and objects. This
+ * function does not block; it returns immediately after sending the request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_NvmGetAvailableRequest(whClientContext* c);
-int wh_Client_NvmGetAvailableResponse(whClientContext* c, int32_t *out_rc,
-        uint32_t *out_avail_size, whNvmId *out_avail_objects,
-        uint32_t *out_reclaim_size, whNvmId *out_reclaim_objects);
-int wh_Client_NvmGetAvailable(whClientContext* c, int32_t *out_rc,
-        uint32_t *out_avail_size, whNvmId *out_avail_objects,
-        uint32_t *out_reclaim_size, whNvmId *out_reclaim_objects);
 
-int wh_Client_NvmAddObjectRequest(whClientContext* c,
-        whNvmId id, whNvmAccess access, whNvmFlags flags,
-        whNvmSize label_len, uint8_t* label,
-        whNvmSize len, const uint8_t* data);
-int wh_Client_NvmAddObjectResponse(whClientContext* c, int32_t *out_rc);
-int wh_Client_NvmAddObject(whClientContext* c,
-        whNvmId id, whNvmAccess access, whNvmFlags flags,
-        whNvmSize label_len, uint8_t* label,
-        whNvmSize len, const uint8_t* data, int32_t *out_rc);
+/**
+ * @brief Receives a response from the server with available non-volatile memory
+ * (NVM) information.
+ *
+ * This function attempts to process a response message from the server
+ * containing information about the available and reclaimable NVM space and
+ * objects. This function does not block; it returns WH_ERROR_NOTREADY if a
+ * response has not been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @param[out] out_avail_size Pointer to store the available NVM size.
+ * @param[out] out_avail_objects Pointer to store the available NVM objects.
+ * @param[out] out_reclaim_size Pointer to store the reclaimable NVM size.
+ * @param[out] out_reclaim_objects Pointer to store the reclaimable NVM objects.
+ * @return int Returns 0 on success, WH_ERROR_NOTREADY if no response is
+ * available, or a negative error code on failure.
+ */
+int wh_Client_NvmGetAvailableResponse(whClientContext* c, int32_t* out_rc,
+                                      uint32_t* out_avail_size,
+                                      whNvmId*  out_avail_objects,
+                                      uint32_t* out_reclaim_size,
+                                      whNvmId*  out_reclaim_objects);
 
-int wh_Client_NvmListRequest(whClientContext* c,
-        whNvmAccess access, whNvmFlags flags, whNvmId start_id);
-int wh_Client_NvmListResponse(whClientContext* c, int32_t *out_rc,
-        whNvmId *out_count, whNvmId *out_id);
-int wh_Client_NvmList(whClientContext* c,
-        whNvmAccess access, whNvmFlags flags, whNvmId start_id,
-        int32_t *out_rc, whNvmId *out_count, whNvmId *out_id);
+/**
+ * @brief Sends a request to the server and receives a response with available
+ * non-volatile memory (NVM) information.
+ *
+ * This function handles the complete process of sending a request to the server
+ * to retrieve information about the available and reclaimable NVM space and
+ * objects, and receiving the response. It sends the request and repeatedly
+ * attempts to receive a valid response. This function blocks until the entire
+ * operation is complete or an error occurs.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @param[out] out_avail_size Pointer to store the available NVM size.
+ * @param[out] out_avail_objects Pointer to store the available NVM objects.
+ * @param[out] out_reclaim_size Pointer to store the reclaimable NVM size.
+ * @param[out] out_reclaim_objects Pointer to store the reclaimable NVM objects.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_NvmGetAvailable(whClientContext* c, int32_t* out_rc,
+                              uint32_t* out_avail_size,
+                              whNvmId*  out_avail_objects,
+                              uint32_t* out_reclaim_size,
+                              whNvmId*  out_reclaim_objects);
 
+/**
+ * @brief Sends a request to the server to add an object to non-volatile memory
+ * (NVM).
+ *
+ * This function prepares and sends a request to the server to add an object to
+ * the NVM. The request includes the object ID, access permissions, flags,
+ * label, and data. This function does not block; it returns immediately after
+ * sending the request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] id The ID of the NVM object to add.
+ * @param[in] access The access permissions for the NVM object.
+ * @param[in] flags Flags associated with the NVM object.
+ * @param[in] label_len The length of the label.
+ * @param[in] label Pointer to the label data.
+ * @param[in] len The length of the data.
+ * @param[in] data Pointer to the data to be added.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_NvmAddObjectRequest(whClientContext* c, whNvmId id,
+                                  whNvmAccess access, whNvmFlags flags,
+                                  whNvmSize label_len, uint8_t* label,
+                                  whNvmSize len, const uint8_t* data);
+
+/**
+ * @brief Receives a response from the server after attempting to add an object
+ * to non-volatile memory (NVM).
+ *
+ * This function attempts to process a response message from the server after an
+ * add object request. It validates the response and extracts the return code.
+ * This function does not block; it returns WH_ERROR_NOTREADY if a response has
+ * not been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @return int Returns 0 on success, WH_ERROR_NOTREADY if no response is
+ * available, or a negative error code on failure.
+ */
+int wh_Client_NvmAddObjectResponse(whClientContext* c, int32_t* out_rc);
+
+/**
+ * @brief Sends a request to the server and receives a response to add an object
+ * to non-volatile memory (NVM).
+ *
+ * This function handles the complete process of sending a request to the server
+ * to add an object to the NVM and receiving the response. It sends the request
+ * and repeatedly attempts to receive a valid response. This function blocks
+ * until the entire operation is complete or an error occurs.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] id The ID of the NVM object to add.
+ * @param[in] access The access permissions for the NVM object.
+ * @param[in] flags Flags associated with the NVM object.
+ * @param[in] label_len The length of the label.
+ * @param[in] label Pointer to the label data.
+ * @param[in] len The length of the data.
+ * @param[in] data Pointer to the data to be added.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_NvmAddObject(whClientContext* c, whNvmId id, whNvmAccess access,
+                           whNvmFlags flags, whNvmSize label_len,
+                           uint8_t* label, whNvmSize len, const uint8_t* data,
+                           int32_t* out_rc);
+
+/**
+ * @brief Sends a request to the server to list non-volatile memory (NVM)
+ * objects.
+ *
+ * This function prepares and sends a request to the server to list NVM objects.
+ * The request includes the access permissions, flags, and the starting object
+ * ID. This function does not block; it returns immediately after sending the
+ * request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] access The access permissions for the NVM objects to list.
+ * @param[in] flags Flags associated with the NVM objects to list.
+ * @param[in] start_id The starting ID of the NVM objects to list.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_NvmListRequest(whClientContext* c, whNvmAccess access,
+                             whNvmFlags flags, whNvmId start_id);
+
+/**
+ * @brief Receives a response from the server with a list of non-volatile memory
+ * (NVM) objects.
+ *
+ * This function attempts to process a response message from the server
+ * containing a list of NVM objects. It validates the response and extracts the
+ * return code, count of objects, and the object IDs. The count is the number of
+ * objects that match the flags/access pattern starting at start_id. The out_id
+ * is the first matching object ID. This function does not block; it returns
+ * WH_ERROR_NOTREADY if a response has not been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @param[out] out_count Pointer to store the count of NVM objects that match
+ * the criteria.
+ * @param[out] out_id Pointer to store the ID of the first matching NVM object.
+ * @return int Returns 0 on success, WH_ERROR_NOTREADY if no response is
+ * available, or a negative error code on failure.
+ */
+int wh_Client_NvmListResponse(whClientContext* c, int32_t* out_rc,
+                              whNvmId* out_count, whNvmId* out_id);
+
+/**
+ * @brief Sends a request to the server and receives a response to list
+ * non-volatile memory (NVM) objects.
+ *
+ * This function handles the complete process of sending a request to the server
+ * to list NVM objects and receiving the response. It sends the request and
+ * repeatedly attempts to receive a valid response. The count is the number of
+ * objects that match the flags/access pattern starting at start_id. The out_id
+ * is the first matching object ID. This function blocks until the entire
+ * operation is complete or an error occurs.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] access The access permissions for the NVM objects to list.
+ * @param[in] flags Flags associated with the NVM objects to list.
+ * @param[in] start_id The starting ID of the NVM objects to list.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @param[out] out_count Pointer to store the count of NVM objects that match
+ * the criteria.
+ * @param[out] out_id Pointer to store the ID of the first matching NVM object.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_NvmList(whClientContext* c, whNvmAccess access, whNvmFlags flags,
+                      whNvmId start_id, int32_t* out_rc, whNvmId* out_count,
+                      whNvmId* out_id);
+
+/**
+ * @brief Sends a request to the server to get metadata of a non-volatile memory
+ * (NVM) object.
+ *
+ * This function prepares and sends a request to the server to retrieve metadata
+ * for a specific NVM object. The request includes the object ID. This function
+ * does not block; it returns immediately after sending the request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] id The ID of the NVM object for which metadata is requested.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_NvmGetMetadataRequest(whClientContext* c, whNvmId id);
-int wh_Client_NvmGetMetadataResponse(whClientContext* c, int32_t *out_rc,
-        whNvmId *out_id, whNvmAccess *out_access, whNvmFlags *out_flags,
-        whNvmSize *out_len,
-        whNvmSize label_len, uint8_t* label);
-int wh_Client_NvmGetMetadata(whClientContext* c, whNvmId id,
-        int32_t *out_rc, whNvmId *out_id, whNvmAccess *out_access,
-        whNvmFlags *out_flags, whNvmSize *out_len,
-        whNvmSize label_len, uint8_t* label);
 
-int wh_Client_NvmDestroyObjectsRequest(whClientContext* c,
-        whNvmId list_count, const whNvmId* id_list);
-int wh_Client_NvmDestroyObjectsResponse(whClientContext* c, int32_t *out_rc);
-int wh_Client_NvmDestroyObjects(whClientContext* c,
-        whNvmId list_count, const whNvmId* id_list,
-        whNvmSize len, const uint8_t* data, int32_t *out_rc);
+/**
+ * @brief Receives a response from the server with metadata of a non-volatile
+ * memory (NVM) object.
+ *
+ * This function attempts to process a response message from the server
+ * containing metadata of an NVM object. It validates the response and extracts
+ * the return code, object ID, access permissions, flags, data length, and
+ * label. This function does not block; it returns WH_ERROR_NOTREADY if a
+ * response has not been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @param[out] out_id Pointer to store the ID of the NVM object.
+ * @param[out] out_access Pointer to store the access permissions of the NVM
+ * object.
+ * @param[out] out_flags Pointer to store the flags of the NVM object.
+ * @param[out] out_len Pointer to store the length of the data.
+ * @param[in] label_len The length of the label buffer.
+ * @param[out] label Pointer to store the label data.
+ * @return int Returns 0 on success, WH_ERROR_NOTREADY if no response is
+ * available, or a negative error code on failure.
+ */
+int wh_Client_NvmGetMetadataResponse(whClientContext* c, int32_t* out_rc,
+                                     whNvmId* out_id, whNvmAccess* out_access,
+                                     whNvmFlags* out_flags, whNvmSize* out_len,
+                                     whNvmSize label_len, uint8_t* label);
 
-int wh_Client_NvmReadRequest(whClientContext* c,
-        whNvmId id, whNvmSize offset, whNvmSize data_len);
-int wh_Client_NvmReadResponse(whClientContext* c, int32_t *out_rc,
-        whNvmSize *out_len, uint8_t* data);
-int wh_Client_NvmRead(whClientContext* c,
-        whNvmId id, whNvmSize offset, whNvmSize data_len,
-        int32_t *out_rc, whNvmSize *out_len, uint8_t* data);
+/**
+ * @brief Sends a request to the server and receives a response to get metadata
+ * of a non-volatile memory (NVM) object.
+ *
+ * This function handles the complete process of sending a request to the server
+ * to get metadata of an NVM object and receiving the response. It sends the
+ * request and repeatedly attempts to receive a valid response. This function
+ * blocks until the entire operation is complete or an error occurs.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] id The ID of the NVM object for which metadata is requested.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @param[out] out_id Pointer to store the ID of the NVM object.
+ * @param[out] out_access Pointer to store the access permissions of the NVM
+ * object.
+ * @param[out] out_flags Pointer to store the flags of the NVM object.
+ * @param[out] out_len Pointer to store the length of the data.
+ * @param[in] label_len The length of the label buffer.
+ * @param[out] label Pointer to store the label data.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_NvmGetMetadata(whClientContext* c, whNvmId id, int32_t* out_rc,
+                             whNvmId* out_id, whNvmAccess* out_access,
+                             whNvmFlags* out_flags, whNvmSize* out_len,
+                             whNvmSize label_len, uint8_t* label);
 
+/**
+ * @brief Sends a request to the server to destroy non-volatile memory (NVM)
+ * objects.
+ *
+ * This function prepares and sends a request to the server to destroy a list of
+ * NVM objects. The request includes the count of objects and their IDs. This
+ * function does not block; it returns immediately after sending the request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] list_count The number of NVM objects to destroy.
+ * @param[in] id_list Pointer to an array of IDs of the NVM objects to destroy.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_NvmDestroyObjectsRequest(whClientContext* c, whNvmId list_count,
+                                       const whNvmId* id_list);
+
+/**
+ * @brief Receives a response from the server after attempting to destroy
+ * non-volatile memory (NVM) objects.
+ *
+ * This function attempts to process a response message from the server after
+ * attempting to destroy NVM objects. It validates the response and extracts the
+ * return code. This function does not block; it returns WH_ERROR_NOTREADY if a
+ * response has not been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @return int Returns 0 on success, WH_ERROR_NOTREADY if no response is
+ * available, or a negative error code on failure.
+ */
+int wh_Client_NvmDestroyObjectsResponse(whClientContext* c, int32_t* out_rc);
+
+/**
+ * @brief Sends a request to the server and receives a response to destroy
+ * non-volatile memory (NVM) objects.
+ *
+ * This function handles the complete process of sending a request to the server
+ * to destroy NVM objects and receiving the response. It sends the request and
+ * repeatedly attempts to receive a valid response. This function blocks until
+ * the entire operation is complete or an error occurs.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] list_count The number of NVM objects to destroy.
+ * @param[in] id_list Pointer to an array of IDs of the NVM objects to destroy.
+ * @param[in] len The length of the data.
+ * @param[in] data Pointer to the data associated with the NVM objects.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_NvmDestroyObjects(whClientContext* c, whNvmId list_count,
+                                const whNvmId* id_list, whNvmSize len,
+                                const uint8_t* data, int32_t* out_rc);
+
+/**
+ * @brief Sends a request to the server to read data from a non-volatile memory
+ * (NVM) object.
+ *
+ * This function prepares and sends a request to the server to read data from a
+ * specific NVM object. The request includes the object ID, the offset within
+ * the NVM object data to start reading from, and the length of data to read.
+ * This function does not block; it returns immediately after sending the
+ * request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] id The ID of the NVM object to read from.
+ * @param[in] offset The offset within the NVM object data to start reading
+ * from.
+ * @param[in] data_len The length of data to read.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_NvmReadRequest(whClientContext* c, whNvmId id, whNvmSize offset,
+                             whNvmSize data_len);
+
+/**
+ * @brief Receives a response from the server with NVM object data.
+ *
+ * This function attempts to process a response message from the server
+ * containing NVM object data. It validates the response and extracts the return
+ * code, the length of the data read, and the data itself. This function does
+ * not block; it returns WH_ERROR_NOTREADY if a response has not been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @param[out] out_len Pointer to store the length of the data read.
+ * @param[out] data Pointer to store the NVM object data.
+ * @return int Returns 0 on success, WH_ERROR_NOTREADY if no response is
+ * available, or a negative error code on failure.
+ */
+int wh_Client_NvmReadResponse(whClientContext* c, int32_t* out_rc,
+                              whNvmSize* out_len, uint8_t* data);
+
+/**
+ * @brief Sends a request to the server and receives a response to read data
+ * from a non-volatile memory (NVM) object.
+ *
+ * This function handles the complete process of sending a request to the server
+ * to read data from an NVM object and receiving the response. It sends the
+ * request and repeatedly attempts to receive a valid response. This function
+ * blocks until the entire operation is complete or an error occurs.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] id The ID of the NVM object to read from.
+ * @param[in] offset The offset within the NVM object data to start reading
+ * from.
+ * @param[in] data_len The length of data to read.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @param[out] out_len Pointer to store the length of the data read.
+ * @param[out] data Pointer to store the NVM object data.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_NvmRead(whClientContext* c, whNvmId id, whNvmSize offset,
+                      whNvmSize data_len, int32_t* out_rc, whNvmSize* out_len,
+                      uint8_t* data);
+
+/**
+ * @brief Sends a request to the server to add an object to non-volatile memory
+ * (NVM) using DMA with 32-bit client addresses.
+ *
+ * This function prepares and sends a request to the server to add an object to
+ * NVM using DMA. The request includes the metadata client address, the length
+ * of the data, and the data client address. This function does not block; it
+ * returns immediately after sending the request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] metadata_hostaddr The client address of the metadata.
+ * @param[in] data_len The length of the data to be added.
+ * @param[in] data_hostaddr The client address of the data to be added.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_NvmAddObjectDma32Request(whClientContext* c,
-        uint32_t metadata_hostaddr,
-        whNvmSize data_len, uint32_t data_hostaddr);
-int wh_Client_NvmAddObjectDma32Response(whClientContext* c, int32_t *out_rc);
-int wh_Client_NvmAddObjectDma32(whClientContext* c,
-        uint32_t metadata_hostaddr, whNvmSize data_len, uint32_t data_hostaddr,
-        int32_t *out_rc);
+                                       uint32_t         metadata_hostaddr,
+                                       whNvmSize        data_len,
+                                       uint32_t         data_hostaddr);
 
+/**
+ * @brief Receives a response from the server after attempting to add an object
+ * to non-volatile memory (NVM) using DMA with 32-bit client addresses.
+ *
+ * This function attempts to process a response message from the server after
+ * attempting to add an object to NVM using DMA. It validates the response and
+ * extracts the return code. This function does not block; it returns
+ * WH_ERROR_NOTREADY if a response has not been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @return int Returns 0 on success, WH_ERROR_NOTREADY if no response is
+ * available, or a negative error code on failure.
+ */
+int wh_Client_NvmAddObjectDma32Response(whClientContext* c, int32_t* out_rc);
+
+/**
+ * @brief Sends a request to the server and receives a response to add an object
+ * to non-volatile memory (NVM) using DMA with 32-bit client addresses.
+ *
+ * This function handles the complete process of sending a request to the server
+ * to add an object to NVM using DMA and receiving the response. It sends the
+ * request and repeatedly attempts to receive a valid response. This function
+ * blocks until the entire operation is complete or an error occurs.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] metadata_hostaddr The client address of the metadata.
+ * @param[in] data_len The length of the data to be added.
+ * @param[in] data_hostaddr The client address of the data to be added.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_NvmAddObjectDma32(whClientContext* c, uint32_t metadata_hostaddr,
+                                whNvmSize data_len, uint32_t data_hostaddr,
+                                int32_t* out_rc);
+
+/**
+ * @brief Sends a request to the server to add an object to non-volatile memory
+ * (NVM) using DMA with 64-bit client addresses.
+ *
+ * This function prepares and sends a request to the server to add an object to
+ * NVM using DMA. The request includes the metadata client address, the length
+ * of the data, and the data client address. This function does not block; it
+ * returns immediately after sending the request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] metadata_hostaddr The client address of the metadata.
+ * @param[in] data_len The length of the data to be added.
+ * @param[in] data_hostaddr The client address of the data to be added.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_NvmAddObjectDma64Request(whClientContext* c,
-        uint64_t metadata_hostaddr,
-        whNvmSize data_len, uint64_t data_hostaddr);
-int wh_Client_NvmAddObjectDma64Response(whClientContext* c, int32_t *out_rc);
-int wh_Client_NvmAddObjectDma64(whClientContext* c,
-        uint64_t metadata_hostaddr, whNvmSize data_len, uint64_t data_hostaddr,
-        int32_t *out_rc);
+                                       uint64_t         metadata_hostaddr,
+                                       whNvmSize        data_len,
+                                       uint64_t         data_hostaddr);
 
+/**
+ * @brief Receives a response from the server after attempting to add an object
+ * to non-volatile memory (NVM) using DMA with 64-bit client addresses.
+ *
+ * This function attempts to process a response message from the server after
+ * attempting to add an object to NVM using DMA. It validates the response and
+ * extracts the return code. This function does not block; it returns
+ * WH_ERROR_NOTREADY if a response has not been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @return int Returns 0 on success, WH_ERROR_NOTREADY if no response is
+ * available, or a negative error code on failure.
+ */
+int wh_Client_NvmAddObjectDma64Response(whClientContext* c, int32_t* out_rc);
+
+/**
+ * @brief Sends a request to the server and receives a response to add an object
+ * to non-volatile memory (NVM) using DMA with 64-bit client addresses.
+ *
+ * This function handles the complete process of sending a request to the server
+ * to add an object to NVM using DMA and receiving the response. It sends the
+ * request and repeatedly attempts to receive a valid response. This function
+ * blocks until the entire operation is complete or an error occurs.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] metadata_hostaddr The client address of the metadata.
+ * @param[in] data_len The length of the data to be added.
+ * @param[in] data_hostaddr The client address of the data to be added.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_NvmAddObjectDma64(whClientContext* c, uint64_t metadata_hostaddr,
+                                whNvmSize data_len, uint64_t data_hostaddr,
+                                int32_t* out_rc);
+
+/**
+ * @brief Sends a request to the server to add an object to non-volatile memory
+ * (NVM) using DMA, with automatic detection of client address width (32-bit or
+ * 64-bit).
+ *
+ * This function prepares and sends a request to the server to add an object to
+ * NVM using DMA. The client address width (32-bit or 64-bit) is automatically
+ * detected. The request includes the metadata client address, the length of the
+ * data, and the data client address. This function does not block; it returns
+ * immediately after sending the request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] metadata Pointer to the metadata.
+ * @param[in] data_len The length of the data to be added.
+ * @param[in] data Pointer to the data to be added.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_NvmAddObjectDmaRequest(whClientContext* c,
-        whNvmMetadata* metadata,
-        whNvmSize data_len, const uint8_t* data);
-int wh_Client_NvmAddObjectDmaResponse(whClientContext* c, int32_t *out_rc);
-int wh_Client_NvmAddObjectDma(whClientContext* c,
-        whNvmMetadata* metadata, whNvmSize data_len, const uint8_t* data,
-        int32_t *out_rc);
+                                     whNvmMetadata*   metadata,
+                                     whNvmSize data_len, const uint8_t* data);
 
-int wh_Client_NvmReadDma32Request(whClientContext* c,
-        whNvmId id, whNvmSize offset, whNvmSize data_len,
-        uint32_t data_hostaddr);
-int wh_Client_NvmReadDma32Response(whClientContext* c, int32_t *out_rc);
-int wh_Client_NvmReadDma32(whClientContext* c,
-        whNvmId id, whNvmSize offset, whNvmSize data_len,
-        uint32_t data_hostaddr, int32_t *out_rc);
+/**
+ * @brief Receives a response from the server after attempting to add an object
+ * to non-volatile memory (NVM) using DMA, with automatic detection of client
+ * address width (32-bit or 64-bit).
+ *
+ * This function attempts to process a response message from the server after
+ * attempting to add an object to NVM using DMA. The client address width
+ * (32-bit or 64-bit) is automatically detected. It validates the response and
+ * extracts the return code. This function does not block; it returns
+ * WH_ERROR_NOTREADY if a response has not been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @return int Returns 0 on success, WH_ERROR_NOTREADY if no response is
+ * available, or a negative error code on failure.
+ */
+int wh_Client_NvmAddObjectDmaResponse(whClientContext* c, int32_t* out_rc);
 
-int wh_Client_NvmReadDma64Request(whClientContext* c,
-        whNvmId id, whNvmSize offset, whNvmSize data_len,
-        uint64_t data_hostaddr);
-int wh_Client_NvmReadDma64Response(whClientContext* c, int32_t *out_rc);
-int wh_Client_NvmReadDma64(whClientContext* c,
-        whNvmId id, whNvmSize offset, whNvmSize data_len,
-        uint64_t data_hostaddr, int32_t *out_rc);
+/**
+ * @brief Sends a request to the server and receives a response to add an object
+ * to non-volatile memory (NVM) using DMA, with automatic detection of client
+ * address width (32-bit or 64-bit).
+ *
+ * This function handles the complete process of sending a request to the server
+ * to add an object to NVM using DMA and receiving the response. The client
+ * address width (32-bit or 64-bit) is automatically detected. It sends the
+ * request and repeatedly attempts to receive a valid response. This function
+ * blocks until the entire operation is complete or an error occurs.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] metadata Pointer to the metadata.
+ * @param[in] data_len The length of the data to be added.
+ * @param[in] data Pointer to the data to be added.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_NvmAddObjectDma(whClientContext* c, whNvmMetadata* metadata,
+                              whNvmSize data_len, const uint8_t* data,
+                              int32_t* out_rc);
 
-int wh_Client_NvmReadDmaRequest(whClientContext* c,
-        whNvmId id, whNvmSize offset, whNvmSize data_len,
-        uint8_t* data);
-int wh_Client_NvmReadDmaResponse(whClientContext* c, int32_t *out_rc);
-int wh_Client_NvmReadDma(whClientContext* c,
-        whNvmId id, whNvmSize offset, whNvmSize data_len, uint8_t* data,
-        int32_t *out_rc);
+/**
+ * @brief Sends a request to the server to read data from non-volatile memory
+ * (NVM) using DMA with a 32-bit client address.
+ *
+ * This function prepares and sends a request to the server to read data from
+ * NVM using DMA with a 32-bit client address. The request includes the NVM ID,
+ * offset, length of the data, and the data client address. This function does
+ * not block; it returns immediately after sending the request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] id The NVM ID of the object to read.
+ * @param[in] offset The offset within the object to start reading from.
+ * @param[in] data_len The length of the data to be read.
+ * @param[in] data_hostaddr The 32-bit client address where the data will be
+ * read into.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_NvmReadDma32Request(whClientContext* c, whNvmId id,
+                                  whNvmSize offset, whNvmSize data_len,
+                                  uint32_t data_hostaddr);
 
+/**
+ * @brief Receives a response from the server after attempting to read data from
+ * non-volatile memory (NVM) using DMA with a 32-bit client address.
+ *
+ * This function attempts to process a response message from the server after
+ * attempting to read data from NVM using DMA with a 32-bit client address. It
+ * validates the response and extracts the return code. This function does not
+ * block; it returns WH_ERROR_NOTREADY if a response has not been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @return int Returns 0 on success, WH_ERROR_NOTREADY if no response is
+ * available, or a negative error code on failure.
+ */
+int wh_Client_NvmReadDma32Response(whClientContext* c, int32_t* out_rc);
+
+/**
+ * @brief Sends a request to the server and receives a response to read data
+ * from non-volatile memory (NVM) using DMA with a 32-bit client address.
+ *
+ * This function handles the complete process of sending a request to the server
+ * to read data from NVM using DMA with a 32-bit client address and receiving
+ * the response. It sends the request and repeatedly attempts to receive a valid
+ * response. This function blocks until the entire operation is complete or an
+ * error occurs.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] id The NVM ID of the object to read.
+ * @param[in] offset The offset within the object to start reading from.
+ * @param[in] data_len The length of the data to be read.
+ * @param[in] data_hostaddr The 32-bit client address where the data will be
+ * read into.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_NvmReadDma32(whClientContext* c, whNvmId id, whNvmSize offset,
+                           whNvmSize data_len, uint32_t data_hostaddr,
+                           int32_t* out_rc);
+
+/**
+ * @brief Sends a request to the server to read data from non-volatile memory
+ * (NVM) using DMA with a 64-bit client address.
+ *
+ * This function prepares and sends a request to the server to read data from
+ * NVM using DMA with a 64-bit client address. The request includes the NVM ID,
+ * offset, length of the data, and the data client address. This function does
+ * not block; it returns immediately after sending the request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] id The NVM ID of the object to read.
+ * @param[in] offset The offset within the object to start reading from.
+ * @param[in] data_len The length of the data to be read.
+ * @param[in] data_hostaddr The 64-bit client address where the data will be
+ * read into.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_NvmReadDma64Request(whClientContext* c, whNvmId id,
+                                  whNvmSize offset, whNvmSize data_len,
+                                  uint64_t data_hostaddr);
+
+/**
+ * @brief Receives a response from the server after attempting to read data from
+ * non-volatile memory (NVM) using DMA with a 64-bit client address.
+ *
+ * This function attempts to process a response message from the server after
+ * attempting to read data from NVM using DMA with a 64-bit client address. It
+ * validates the response and extracts the return code. This function does not
+ * block; it returns WH_ERROR_NOTREADY if a response has not been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @return int Returns 0 on success, WH_ERROR_NOTREADY if no response is
+ * available, or a negative error code on failure.
+ */
+int wh_Client_NvmReadDma64Response(whClientContext* c, int32_t* out_rc);
+
+/**
+ * @brief Sends a request to the server and receives a response to read data
+ * from non-volatile memory (NVM) using DMA with a 64-bit client address.
+ *
+ * This function handles the complete process of sending a request to the server
+ * to read data from NVM using DMA with a 64-bit client address and receiving
+ * the response. It sends the request and repeatedly attempts to receive a valid
+ * response. This function blocks until the entire operation is complete or an
+ * error occurs.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] id The NVM ID of the object to read.
+ * @param[in] offset The offset within the object to start reading from.
+ * @param[in] data_len The length of the data to be read.
+ * @param[in] data_hostaddr The 64-bit client address where the data will be
+ * read into.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_NvmReadDma64(whClientContext* c, whNvmId id, whNvmSize offset,
+                           whNvmSize data_len, uint64_t data_hostaddr,
+                           int32_t* out_rc);
+
+/**
+ * @brief Sends a request to the server to read data from non-volatile memory
+ * (NVM) using DMA, with automatic detection of client address width (32-bit or
+ * 64-bit).
+ *
+ * This function prepares and sends a request to the server to read data from
+ * NVM using DMA. The client address width (32-bit or 64-bit) is automatically
+ * detected. The request includes the NVM ID, offset, length of the data, and
+ * the data client address. This function does not block; it returns immediately
+ * after sending the request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] id The NVM ID of the object to read.
+ * @param[in] offset The offset within the object to start reading from.
+ * @param[in] data_len The length of the data to be read.
+ * @param[in] data Pointer to the data buffer where the data will be read into.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_NvmReadDmaRequest(whClientContext* c, whNvmId id,
+                                whNvmSize offset, whNvmSize data_len,
+                                uint8_t* data);
+
+/**
+ * @brief Receives a response from the server after attempting to read data from
+ * non-volatile memory (NVM) using DMA, with automatic detection of client
+ * address width (32-bit or 64-bit).
+ *
+ * This function attempts to process a response message from the server after
+ * attempting to read data from NVM using DMA. The client address width (32-bit
+ * or 64-bit) is automatically detected. It validates the response and extracts
+ * the return code. This function does not block; it returns WH_ERROR_NOTREADY
+ * if a response has not been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @return int Returns 0 on success, WH_ERROR_NOTREADY if no response is
+ * available, or a negative error code on failure.
+ */
+int wh_Client_NvmReadDmaResponse(whClientContext* c, int32_t* out_rc);
+
+/**
+ * @brief Sends a request to the server and receives a response to read data
+ * from non-volatile memory (NVM) using DMA, with automatic detection of client
+ * address width (32-bit or 64-bit).
+ *
+ * This function handles the complete process of sending a request to the server
+ * to read data from NVM using DMA and receiving the response. The client
+ * address width (32-bit or 64-bit) is automatically detected. It sends the
+ * request and repeatedly attempts to receive a valid response. This function
+ * blocks until the entire operation is complete or an error occurs.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] id The NVM ID of the object to read.
+ * @param[in] offset The offset within the object to start reading from.
+ * @param[in] data_len The length of the data to be read.
+ * @param[in] data Pointer to the data buffer where the data will be read into.
+ * @param[out] out_rc Pointer to store the return code from the server.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_NvmReadDma(whClientContext* c, whNvmId id, whNvmSize offset,
+                         whNvmSize data_len, uint8_t* data, int32_t* out_rc);
 
 /* Client custom-callback support */
-int wh_Client_CustomCbRequest(whClientContext* c, const whMessageCustomCb_Request* req);
-int wh_Client_CustomCbResponse(whClientContext* c, whMessageCustomCb_Response *resp);
-/* Instructs server to query if a callback is registered */
+
+/**
+ * @brief Sends a custom callback request to the server.
+ *
+ * This function prepares and sends a custom callback request to the server.
+ * The request includes the custom callback request structure.
+ * This function does not block; it returns immediately after sending the
+ * request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] req Pointer to the custom callback request structure.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
+int wh_Client_CustomCbRequest(whClientContext*                 c,
+                              const whMessageCustomCb_Request* req);
+
+/**
+ * @brief Receives a response from the server after sending a custom callback
+ * request.
+ *
+ * This function attempts to process a response message from the server after
+ * sending a custom callback request. It validates the response and extracts the
+ * return code. This function does not block; it returns WH_ERROR_NOTREADY if a
+ * response has not been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] resp Pointer to store the custom callback response from the
+ * server.
+ * @return int Returns 0 on success, WH_ERROR_NOTREADY if no response is
+ * available, or a negative error code on failure.
+ */
+int wh_Client_CustomCbResponse(whClientContext*            c,
+                               whMessageCustomCb_Response* resp);
+
+/**
+ * @brief Sends a request to the server to check if a custom callback is
+ * registered.
+ *
+ * This function prepares and sends a request to the server to check if a custom
+ * callback is registered. The request includes the callback ID. This function
+ * does not block; it returns immediately after sending the request.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] id The ID of the custom callback to check.
+ * @return int Returns 0 on success, or a negative error code on failure.
+ */
 int wh_Client_CustomCheckRegisteredRequest(whClientContext* c, uint32_t id);
-/* Processes a server response to callback query. OutId is set to the ID of the
- * received query. ResponseError is set to WH_ERROR_OK if the callback is
- * registered, and WH_ERROR_NOHANDLER if not */
-int wh_Client_CustomCbCheckRegisteredResponse(whClientContext* c, uint16_t* outId, int* responseError);
-/* Blocking call to check if a callback is registered */
-int wh_Client_CustomCbCheckRegistered(whClientContext* c, uint16_t id, int* responseError);
+
+/**
+ * @brief Receives a response from the server after checking if a custom
+ * callback is registered.
+ *
+ * This function attempts to process a response message from the server after
+ * checking if a custom callback is registered. It validates the response and
+ * extracts the return code and callback ID. This function does not block; it
+ * returns WH_ERROR_NOTREADY if a response has not been received.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[out] outId Pointer to store the callback ID from the server.
+ * @param[out] responseError Pointer to store the response error code from the
+ * server.
+ * @return int Returns 0 if the callback is registered, WH_ERROR_NOHANDLER if it
+ * is not registered, or a negative error code on failure.
+ */
+int wh_Client_CustomCbCheckRegisteredResponse(whClientContext* c,
+                                              uint16_t*        outId,
+                                              int*             responseError);
+
+/**
+ * @brief Sends a request to the server and receives a response to check if a
+ * custom callback is registered.
+ *
+ * This function handles the complete process of sending a request to the server
+ * to check if a custom callback is registered and receiving the response. It
+ * sends the request and repeatedly attempts to receive a valid response. This
+ * function blocks until the entire operation is complete or an error occurs.
+ *
+ * @param[in] c Pointer to the client context.
+ * @param[in] id The ID of the custom callback to check.
+ * @param[out] responseError Pointer to store the response error code from the
+ * server.
+ * @return int Returns 0 if the callback is registered, WH_ERROR_NOHANDLER if it
+ * is not registered, or a negative error code on failure.
+ */
+int wh_Client_CustomCbCheckRegistered(whClientContext* c, uint16_t id,
+                                      int* responseError);
 
 
 #endif /* WOLFHSM_WH_CLIENT_H_ */

--- a/wolfhsm/wh_client.h
+++ b/wolfhsm/wh_client.h
@@ -106,8 +106,10 @@ int wh_Client_Cleanup(whClientContext* c);
  * @param c The client context.
  * @param group The group identifier.
  * @param action The action identifier.
- * @param data_size The size of the data to be sent.
- * @param data A pointer to the data to be sent.
+ * @param data_size The size of the data to be sent. Zero is allowed in the case
+ * of NULL data.
+ * @param data A pointer to the data to be sent. NULL is allowed in the case of
+ * zero-sized data.
  * @return Returns 0 on success, or a negative value on failure.
  */
 int wh_Client_SendRequest(whClientContext* c, uint16_t group, uint16_t action,
@@ -135,7 +137,8 @@ int wh_Client_RecvResponse(whClientContext* c, uint16_t* out_group,
  *
  * This function prepares and sends a communication initialization request
  * message to the server. It populates the message with the client's ID
- * and sends it using the communication context.
+ * (initialized from the config struct at client initialization) and sends it
+ * using the communication context.
  *
  * @param[in] c Pointer to the client context.
  * @return int Returns 0 on success, or a negative error code on failure.
@@ -256,7 +259,20 @@ int wh_Client_EchoResponse(whClientContext* c, uint16_t* out_size, void* data);
 int wh_Client_Echo(whClientContext* c, uint16_t snd_len, const void* snd_data,
                    uint16_t* out_rcv_len, void* rcv_data);
 
-/** Key functions */
+/** Key functions
+ *
+ * For client-side key data to be used, it must first be brought into the key
+ * cache (RAM) of the HSM server.  Key cache requests instruct the server to
+ * transfer key data from client memory and allocate space in the HSM server RAM
+ * to hold this key.  Key eviction requests instruct the HSM server to remove
+ * the key from the cache so that the RAM may be reused.  Key export requests
+ * instruct the server to send back the cached key data to client RAM.  Key
+ * commit requests instruct the HSM server to write the cached key into the HSM
+ * NVM. Key erase requests instruct the HSM server to remove a previously
+ * committed key from NVM.
+ */
+
+
 #ifndef WOLFHSM_NO_CRYPTO
 /**
  * @brief Sends a key cache request to the server.

--- a/wolfhsm/wh_server.h
+++ b/wolfhsm/wh_server.h
@@ -40,7 +40,7 @@
 #include "wolfssl/wolfcrypt/ecc.h"
 #include "wolfssl/wolfcrypt/curve25519.h"
 #include "wolfssl/wolfcrypt/cryptocb.h"
-#endif  /* WOLFHSM_NO_CRYPTO */
+#endif /* WOLFHSM_NO_CRYPTO */
 
 /* Forward declaration of the server structure so its elements can reference
  * itself  (e.g. server argument to custom callback) */
@@ -49,14 +49,14 @@ typedef struct whServerContext_t whServerContext;
 #ifndef WOLFHSM_NO_CRYPTO
 /** Server crypto context and resource allocation */
 typedef struct CacheSlot {
-    uint8_t commited;
+    uint8_t       commited;
     whNvmMetadata meta[1];
-    uint8_t buffer[WOLFHSM_KEYCACHE_BUFSIZE];
+    uint8_t       buffer[WOLFHSM_KEYCACHE_BUFSIZE];
 } CacheSlot;
 
 typedef struct {
-    int devId;
-    Aes aes[1];
+    int    devId;
+    Aes    aes[1];
     RsaKey rsa[1];
 #ifdef HAVE_ECC
     ecc_key eccPrivate[1];
@@ -64,30 +64,30 @@ typedef struct {
 #endif
     curve25519_key curve25519Private[1];
     curve25519_key curve25519Public[1];
-    WC_RNG rng[1];
+    WC_RNG         rng[1];
 } crypto_context;
 
 #ifdef WOLFHSM_SHE_EXTENSION
 typedef struct {
-    uint8_t sbState;
-    uint8_t cmacKeyFound;
-    uint8_t ramKeyPlain;
-    uint8_t uidSet;
+    uint8_t  sbState;
+    uint8_t  cmacKeyFound;
+    uint8_t  ramKeyPlain;
+    uint8_t  uidSet;
     uint32_t blSize;
     uint32_t blSizeReceived;
     uint32_t rndInited;
-    uint8_t prngState[WOLFHSM_SHE_KEY_SZ];
-    uint8_t prngKey[WOLFHSM_SHE_KEY_SZ];
-    uint8_t uid[WOLFHSM_SHE_UID_SZ];
+    uint8_t  prngState[WOLFHSM_SHE_KEY_SZ];
+    uint8_t  prngKey[WOLFHSM_SHE_KEY_SZ];
+    uint8_t  uid[WOLFHSM_SHE_UID_SZ];
 } she_context;
 #endif
-#endif  /* WOLFHSM_NO_CRYPTO */
+#endif /* WOLFHSM_NO_CRYPTO */
 
 /** Server custom callback */
 
 /* Type definition for a custom server callback  */
 typedef int (*whServerCustomCb)(
-    whServerContext* server,   /* points to dispatching server ctx */
+    whServerContext* server,              /* points to dispatching server ctx */
     const whMessageCustomCb_Request* req, /* request from client to callback */
     whMessageCustomCb_Response*      resp /* response from callback to client */
 );
@@ -108,7 +108,7 @@ typedef enum {
     /* Indicates server has just read from client memory */
     WH_DMA_OPER_CLIENT_READ_POST = 1,
     /* Indicates server is about to write to client memory */
-    WH_DMA_OPER_CLIENT_WRITE_PRE  = 2,
+    WH_DMA_OPER_CLIENT_WRITE_PRE = 2,
     /* Indicates server has just written from client memory */
     WH_DMA_OPER_CLIENT_WRITE_POST = 3,
 } whServerDmaOper;
@@ -116,7 +116,7 @@ typedef enum {
 /* Flags embedded in request/response structs provided by client */
 typedef struct {
     uint8_t cacheForceInvalidate : 1;
-    uint8_t :7;
+    uint8_t : 7;
 } whServerDmaFlags;
 
 /* DMA callbacks invoked internally by wolfHSM before and after every client
@@ -164,35 +164,36 @@ typedef struct {
 
 typedef struct whServerConfig_t {
     whCommServerConfig* comm_config;
-    whNvmContext* nvm;
+    whNvmContext*       nvm;
 
 #ifndef WOLFHSM_NO_CRYPTO
     crypto_context* crypto;
 #ifdef WOLFHSM_SHE_EXTENSION
     she_context* she;
 #endif
-#if defined WOLF_CRYPTO_CB /* TODO: should we be relying on wolfSSL defines? */
+#if defined WOLF_CRYPTO_CB /* TODO: should we be relying on wolfSSL defines? \
+                            */
     int devId;
 #endif
-#endif  /* WOLFHSM_NO_CRYPTO */
+#endif /* WOLFHSM_NO_CRYPTO */
     whServerDmaConfig* dmaConfig;
 } whServerConfig;
 
 
 /* Context structure to maintain the state of an HSM server */
 struct whServerContext_t {
-    whCommServer comm[1];
+    whCommServer  comm[1];
     whNvmContext* nvm;
 #ifndef WOLFHSM_NO_CRYPTO
     crypto_context* crypto;
-    CacheSlot cache[WOLFHSM_NUM_RAMKEYS];
+    CacheSlot       cache[WOLFHSM_NUM_RAMKEYS];
 #ifdef WOLFHSM_SHE_EXTENSION
     she_context* she;
 #endif
-#endif  /* WOLFHSM_NO_CRYPTO */
-    whServerCustomCb customHandlerTable[WH_CUSTOM_CB_NUM_CALLBACKS];
+#endif /* WOLFHSM_NO_CRYPTO */
+    whServerCustomCb   customHandlerTable[WH_CUSTOM_CB_NUM_CALLBACKS];
     whServerDmaContext dma;
-    int connected;
+    int                connected;
 #ifdef WOLFHSM_SHE_EXTENSION
 #endif
     uint8_t padding[4];
@@ -204,85 +205,330 @@ struct whServerContext_t {
 /* Initialize the comms and crypto cache components.
  * Note: NVM and Crypto components must be initialized prior to Server Init
  */
+
+/**
+ * @brief Initializes the server context with the provided configuration.
+ *
+ * This function must be called before any other server functions are used on
+ * the supplied context. Note that the NVM and Crypto components of the config
+ * structure MUST be initialized before calling this function.
+ *
+ * @param[in] server Pointer to the server context.
+ * @param[in] config Pointer to the server configuration.
+ * @return int Returns 0 on success, WH_ERROR_BADARGS if the arguments are
+ * invalid, or WH_ERROR_ABORTED if initialization fails.
+ */
 int wh_Server_Init(whServerContext* server, whServerConfig* config);
 
-/* Allow an external input to set the connected state. */
-int wh_Server_SetConnected(whServerContext *server, whCommConnected connected);
+/**
+ * @brief Sets the connection state of the server.
+ *
+ * The connection state indicates whether the server is ready to handle incoming
+ * requests. This function should be invoked when the underlying transport is
+ * ready for use.
+ *
+ * @param[in] server Pointer to the server context.
+ * @param[in] connected The connection state to set.
+ * @return int Returns 0 on success, or WH_ERROR_BADARGS if the arguments are
+ * invalid.
+ */
+int wh_Server_SetConnected(whServerContext* server, whCommConnected connected);
 
-/* Invoke SetConnected but using an untyped context pointer, suitable for a
- * CommServer callback */
+/**
+ * @brief Sets a callback function that should be invoked by the underlying
+ * transport after it is initialized
+ *
+ * The connection state indicates whether the server is ready to handle incoming
+ * requests. This function should be invoked when the underlying transport
+ * is ready for use.
+ *
+ * @param[in] s Pointer to the server context.
+ * @param[in] connected The connection state to set.
+ * @return int Returns 0 on success.
+ */
 int wh_Server_SetConnectedCb(void* s, whCommConnected connected);
 
-/* Return the connected state. */
-int wh_Server_GetConnected(whServerContext *server,
-                            whCommConnected *out_connected);
+/**
+ * @brief Gets the connection state of the server.
+ *
+ * @param[in] server Pointer to the server context.
+ * @param[out] out_connected Pointer to store the connection state.
+ * @return int Returns 0 on success, or WH_ERROR_BADARGS if the arguments are
+ * invalid.
+ */
+int wh_Server_GetConnected(whServerContext* server,
+                           whCommConnected* out_connected);
 
-/*
- * Receive and handle an incoming request message if present.
+/**
+ * @brief Handles incoming request messages and dispatches them to the
+ * appropriate handlers.
+ *
+ * This function processes incoming request messages from the communication
+ * server in a non-blocking fashion. It determines the message group and action,
+ * and dispatches the request to the appropriate handler. The function also
+ * sends a response back to the client.
+ *
+ * @param[in] server Pointer to the server context.
+ * @return int Returns 0 on success, WH_ERROR_BADARGS if the arguments are
+ * invalid, WH_ERROR_NOTREADY if the server is not connected or no data is
+ * available, or a negative error code on failure.
  */
 int wh_Server_HandleRequestMessage(whServerContext* server);
 
-/*
- * Stop all active and pending work, disconnect, and close all used resources.
+/**
+ * @brief Cleans up the server context and associated resources.
+ *
+ * This function releases any resources associated with the server context,
+ * including communication server resources. It resets the server context
+ * to its initial state.
+ *
+ * @param[in] server Pointer to the server context.
+ * @return int Returns WH_ERROR_OK on success, or WH_ERROR_BADARGS if the
+ * arguments are invalid.
  */
 int wh_Server_Cleanup(whServerContext* server);
 
 /** Server custom callback functions */
 
-/* Registers a custom callback with the server
-*/
-int wh_Server_RegisterCustomCb( whServerContext* server,
-                                uint16_t actionId,
-                                whServerCustomCb cb);
+/**
+ * @brief Registers a custom callback handler for a specific action.
+ *
+ * This function allows the server to register a custom callback handler
+ * for a specific action ID. The callback will be invoked when a request
+ * with the corresponding action ID is received.
+ *
+ * @param[in] server Pointer to the server context.
+ * @param[in] actionId The action ID for which the callback is being registered.
+ * @param[in] cb The custom callback handler to register.
+ * @return int Returns WH_ERROR_OK on success, or WH_ERROR_BADARGS if the
+ * arguments are invalid.
+ */
+int wh_Server_RegisterCustomCb(whServerContext* server, uint16_t actionId,
+                               whServerCustomCb cb);
 
-/* Receive and handle an incoming custom callback request
-*/
+/**
+ * @brief Handles incoming custom callback requests.
+ *
+ * This function processes incoming custom callback requests by invoking
+ * the registered custom callback handler for the specified action. It
+ * translates the request and response messages and sends the appropriate
+ * response back to the client.
+ *
+ * @param[in] server Pointer to the server context.
+ * @param[in] magic The magic number for the request.
+ * @param[in] action The action ID of the request.
+ * @param[in] seq The sequence number of the request.
+ * @param[in] req_size The size of the request packet.
+ * @param[in] req_packet Pointer to the request packet data.
+ * @param[out] out_resp_size Pointer to store the size of the response packet.
+ * @param[out] resp_packet Pointer to store the response packet data.
+ * @return int Returns WH_ERROR_OK on success, WH_ERROR_BADARGS if the arguments
+ * are invalid, WH_ERROR_ABORTED if the request is malformed, or a negative
+ * error code on failure.
+ */
 int wh_Server_HandleCustomCbRequest(whServerContext* server, uint16_t magic,
-                                  uint16_t action, uint16_t seq,
-                                  uint16_t req_size, const void* req_packet,
-                                  uint16_t* out_resp_size, void* resp_packet);
+                                    uint16_t action, uint16_t seq,
+                                    uint16_t req_size, const void* req_packet,
+                                    uint16_t* out_resp_size, void* resp_packet);
 
 /** Server DMA functions */
 
-/* Registers custom client DMA callbacks to handle platform specific
- * restrictions on accessing the client address space such as caching and
- * address translation */
+/**
+ * @brief Registers a custom client DMA callback for 32-bit systems.
+ *
+ * This function allows the server to register a custom callback handler
+ * for processing client memory operations on 32-bit systems. The callback
+ * will be invoked during DMA operations to transform client addresses,
+ * manipulate caches, etc.
+ *
+ * @param[in] server Pointer to the server context.
+ * @param[in] cb The custom DMA callback handler to register.
+ * @return int Returns WH_ERROR_OK on success, or WH_ERROR_BADARGS if the
+ * arguments are invalid.
+ */
 int wh_Server_DmaRegisterCb32(struct whServerContext_t* server,
                               whServerDmaClientMem32Cb  cb);
+
+/**
+ * @brief Registers a custom client DMA callback for 64-bit systems.
+ *
+ * This function allows the server to register a custom callback handler
+ * for processing client memory operations on 64-bit systems. The callback
+ * will be invoked during DMA operations to transform client addresses,
+ * manipulate caches, etc.
+ *
+ * @param[in] server Pointer to the server context.
+ * @param[in] cb The custom DMA callback handler to register.
+ * @return int Returns WH_ERROR_OK on success, or WH_ERROR_BADARGS if the
+ * arguments are invalid.
+ */
 int wh_Server_DmaRegisterCb64(struct whServerContext_t* server,
                               whServerDmaClientMem64Cb  cb);
+
+/**
+ * @brief Registers the allowable client read/write addresses for DMA.
+ *
+ * This function allows the server to register a list of allowable client
+ * addresses for DMA read and write operations. The server will check
+ * these addresses during DMA operations to ensure they are within the
+ * allowed range for the client
+ *
+ * @param[in] server Pointer to the server context.
+ * @param[in] allowlist Pointer to the list of allowable client addresses.
+ * @return int Returns WH_ERROR_OK on success, or WH_ERROR_BADARGS if the
+ * arguments are invalid.
+ */
 int wh_Server_DmaRegisterAllowList(struct whServerContext_t*       server,
                                    const whServerDmaAddrAllowList* allowlist);
 
-/* Checks a desired memory operation against the server allowlist */
+/**
+ * @brief Checks if a DMA memory operation is allowed based on the server's
+ * allowlist.
+ *
+ * This function verifies whether a specified DMA memory operation is permitted
+ * by checking the operation type and the address range against the server's
+ * registered allowlist. If no allowlist is registered, the operation is
+ * allowed.
+ *
+ * @param[in] server Pointer to the server context.
+ * @param[in] oper The DMA operation type (e.g., read or write).
+ * @param[in] addr The address to be checked.
+ * @param[in] size The size of the memory operation.
+ * @return int Returns WH_ERROR_OK if the operation is allowed, WH_ERROR_BADARGS
+ * if the arguments are invalid, or WH_ERROR_ACCESS if the operation is not
+ * allowed.
+ */
 int wh_Server_DmaCheckMemOperAllowed(const struct whServerContext_t* server,
                                      whServerDmaOper oper, void* addr,
                                      size_t size);
 
-/* Helper functions to invoke user supplied client address DMA callbacks */
+/**
+ * @brief Processes a client address for DMA operations on 32-bit systems.
+ *
+ * This function transforms a client address for DMA operations on 32-bit
+ * systems. It performs user-supplied address transformations, cache
+ * manipulations, and checks the transformed address against the server's
+ * allowlist if registered.
+ *
+ * @param[in] server Pointer to the server context.
+ * @param[in] clientAddr The client address to be processed.
+ * @param[out] serverPtr Pointer to store the transformed server address.
+ * @param[in] len The length of the memory operation.
+ * @param[in] oper The DMA operation type (e.g., read or write).
+ * @param[in] flags Flags for the DMA operation.
+ * @return int Returns WH_ERROR_OK on success, WH_ERROR_BADARGS if the arguments
+ * are invalid, or a negative error code on failure.
+ */
 int wh_Server_DmaProcessClientAddress32(struct whServerContext_t* server,
                                         uint32_t clientAddr, void** serverPtr,
                                         uint32_t len, whServerDmaOper oper,
                                         whServerDmaFlags flags);
+
+/**
+ * @brief Processes a client address for DMA operations on 64-bit systems.
+ *
+ * This function transforms a client address for DMA operations on 64-bit
+ * systems. It performs user-supplied address transformations, cache
+ * manipulations, and checks the transformed address against the server's
+ * allowlist if registered.
+ *
+ * @param[in] server Pointer to the server context.
+ * @param[in] clientAddr The client address to be processed.
+ * @param[out] serverPtr Pointer to store the transformed server address.
+ * @param[in] len The length of the memory operation.
+ * @param[in] oper The DMA operation type (e.g., read or write).
+ * @param[in] flags Flags for the DMA operation.
+ * @return int Returns WH_ERROR_OK on success, WH_ERROR_BADARGS if the arguments
+ * are invalid, or a negative error code on failure.
+ */
 int wh_Server_DmaProcessClientAddress64(struct whServerContext_t* server,
                                         uint64_t clientAddr, void** serverPtr,
                                         uint64_t len, whServerDmaOper oper,
                                         whServerDmaFlags flags);
 
-/* Helper functions to copy data to/from client addresses that invoke the
- * appropriate callbacks and allowlist checks */
+/**
+ * @brief Copies data from a client address to a server address on 32-bit
+ * systems.
+ *
+ * This function performs a DMA read operation, copying data from a client
+ * address to a server address on 32-bit systems. It processes the client
+ * address, checks the server address against the allowlist, and performs the
+ * actual memory copy.
+ *
+ * @param[in] server Pointer to the server context.
+ * @param[out] serverPtr Pointer to the server memory where data will be copied.
+ * @param[in] clientAddr The client address from which data will be copied.
+ * @param[in] len The length of the data to be copied.
+ * @param[in] flags Flags for the DMA operation.
+ * @return int Returns WH_ERROR_OK on success, WH_ERROR_BADARGS if the arguments
+ * are invalid, or a negative error code on failure.
+ */
 int whServerDma_CopyFromClient32(struct whServerContext_t* server,
                                  void* serverPtr, uint32_t clientAddr,
                                  size_t len, whServerDmaFlags flags);
+
+/**
+ * @brief Copies data from a client address to a server address on 64-bit
+ * systems.
+ *
+ * This function performs a DMA read operation, copying data from a client
+ * address to a server address on 64-bit systems. It processes the client
+ * address, checks the server address against the allowlist, and performs the
+ * actual memory copy.
+ *
+ * @param[in] server Pointer to the server context.
+ * @param[out] serverPtr Pointer to the server memory where data will be copied.
+ * @param[in] clientAddr The client address from which data will be copied.
+ * @param[in] len The length of the data to be copied.
+ * @param[in] flags Flags for the DMA operation.
+ * @return int Returns WH_ERROR_OK on success, WH_ERROR_BADARGS if the arguments
+ * are invalid, or a negative error code on failure.
+ */
 int whServerDma_CopyFromClient64(struct whServerContext_t* server,
                                  void* serverPtr, uint64_t clientAddr,
                                  size_t len, whServerDmaFlags flags);
 
+/**
+ * @brief Copies data from a server address to a client address on 32-bit
+ * systems.
+ *
+ * This function performs a DMA write operation, copying data from a server
+ * address to a client address on 32-bit systems. It processes the client
+ * address, checks the server address against the allowlist, and performs the
+ * actual memory copy.
+ *
+ * @param[in] server Pointer to the server context.
+ * @param[in] clientAddr The client address to which data will be copied.
+ * @param[in] serverPtr Pointer to the server memory from which data will be
+ * copied.
+ * @param[in] len The length of the data to be copied.
+ * @param[in] flags Flags for the DMA operation.
+ * @return int Returns WH_ERROR_OK on success, WH_ERROR_BADARGS if the arguments
+ * are invalid, or a negative error code on failure.
+ */
 int whServerDma_CopyToClient32(struct whServerContext_t* server,
                                uint32_t clientAddr, void* serverPtr, size_t len,
                                whServerDmaFlags flags);
+
+/**
+ * @brief Copies data from a server address to a client address on 64-bit
+ * systems.
+ *
+ * This function performs a DMA write operation, copying data from a server
+ * address to a client address on 64-bit systems. It processes the client
+ * address, checks the server address against the allowlist, and performs the
+ * actual memory copy.
+ *
+ * @param[in] server Pointer to the server context.
+ * @param[in] clientAddr The client address to which data will be copied.
+ * @param[in] serverPtr Pointer to the server memory from which data will be
+ * copied.
+ * @param[in] len The length of the data to be copied.
+ * @param[in] flags Flags for the DMA operation.
+ * @return int Returns WH_ERROR_OK on success, WH_ERROR_BADARGS if the arguments
+ * are invalid, or a negative error code on failure.
+ */
 int whServerDma_CopyToClient64(struct whServerContext_t* server,
                                uint64_t clientAddr, void* serverPtr, size_t len,
                                whServerDmaFlags flags);
-
 #endif /* WOLFHSM_WH_SERVER_H_ */


### PR DESCRIPTION
- Add doxygen documentation for public client+server API
- clang-format

Right now it the doxygen is just present in the header. I can also put it in the `.c` file (my typical method) or can duplicate the header into a "documentation" version like wolfSSL does.