### PR TITLE
static check for structure unionization

### DIFF
--- a/src/wh_client.c
+++ b/src/wh_client.c
@@ -33,7 +33,7 @@
 #include "wolfhsm/wh_comm.h"
 
 #ifndef WOLFHSM_NO_CRYPTO
-#include "wolfhsm/wh_cryptocb.h"
+#include "wolfhsm/wh_client_cryptocb.h"
 #include "wolfssl/wolfcrypt/settings.h"
 #include "wolfssl/wolfcrypt/error-crypt.h"
 #include "wolfssl/wolfcrypt/wc_port.h"

--- a/src/wh_client_cryptocb.c
+++ b/src/wh_client_cryptocb.c
@@ -54,17 +54,17 @@
 #include "wolfhsm/wh_message.h"
 #include "wolfhsm/wh_client_cryptocb.h"
 
+/* wolfHSM crypto callback assumes wc_CryptoInfo struct is unionized */
+#if !defined(HAVE_ANONYMOUS_INLINE_AGGREGATES) \
+    || ( defined(HAVE_ANONYMOUS_INLINE_AGGREGATES) \
+         && HAVE_ANONYMOUS_INLINE_AGGREGATES==0  )
+#error "wolfHSM needs wolfCrypt built with HAVE_ANONYMOUS_INLINE_AGGREGATES=1"
+#endif
+
+
+
 int wolfHSM_CryptoCb(int devId, wc_CryptoInfo* info, void* inCtx)
 {
-#if 0
-    uint32_t field;
-    uint8_t* key;
-    uint8_t* iv;
-    uint8_t* authIn;
-    uint8_t* authTag;
-    uint8_t* sig;
-    uint8_t* hash;
-#endif
     int ret = CRYPTOCB_UNAVAILABLE;
     whClientContext* ctx = inCtx;
     uint8_t rawPacket[WH_COMM_DATA_LEN];

--- a/src/wh_client_cryptocb.c
+++ b/src/wh_client_cryptocb.c
@@ -52,7 +52,7 @@
 #include "wolfhsm/wh_error.h"
 #include "wolfhsm/wh_client.h"
 #include "wolfhsm/wh_message.h"
-#include "wolfhsm/wh_cryptocb.h"
+#include "wolfhsm/wh_client_cryptocb.h"
 
 int wolfHSM_CryptoCb(int devId, wc_CryptoInfo* info, void* inCtx)
 {

--- a/wolfhsm/wh_client_cryptocb.h
+++ b/wolfhsm/wh_client_cryptocb.h
@@ -36,8 +36,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
  */
-#ifndef WOLFHSM_CRYPTOCB_H
-#define WOLFHSM_CRYPTOCB_H
+#ifndef WOLFHSM_CLIENT_CRYPTOCB_H_
+#define WOLFHSM_CLIENT_CRYPTOCB_H_
 
 #ifdef __cplusplus
     extern "C" {
@@ -52,4 +52,4 @@ int wolfHSM_CryptoCb(int devId, wc_CryptoInfo* info, void* ctx);
     } /* extern "C" */
 #endif
 
-#endif /* !WOLFHSM_CRYPTOCB_H */
+#endif /* !WOLFHSM_CLIENT_CRYPTOCB_H_ */


### PR DESCRIPTION
- Adds a compile-time check for wolfCrypt's `HAVE_ANONYMOUS_INLINE_AGGREGATES` macro to ensure the `wc_CryptoInfo` structure used in our client crypto callback is unionized. This is required as we assume it is in a few different places
- Renames client crypto callback header file to match the source file