### PR TITLE
cleanups/fixes from tricore integration

### DIFF
--- a/src/wh_client_she.c
+++ b/src/wh_client_she.c
@@ -48,12 +48,12 @@ int wh_Client_ShePreProgramKey(whClientContext* c, whNvmId keyId,
     whNvmFlags flags, uint8_t* key, whNvmSize keySz)
 {
     int ret;
-    int outRc;
+    int32_t outRc;
     uint8_t label[WOLFHSM_NVM_LABEL_LEN];
     memset(label, 0, sizeof(label));
     ((whSheMetadata*)label)->flags = flags;
     ret = wh_Client_NvmAddObject(c, MAKE_WOLFHSM_KEYID(WOLFHSM_KEYTYPE_SHE,
-        c->comm->client_id, keyId), 0, 0, sizeof(label), label, keySz, key, &outRc);
+        c->comm->client_id, keyId), 0, 0, sizeof(label), label, keySz, key, (int32_t*)&outRc);
     if (ret == 0)
         ret = outRc;
     return ret;

--- a/src/wh_client_she.c
+++ b/src/wh_client_she.c
@@ -21,6 +21,8 @@
  *
  */
 
+#ifdef WOLFHSM_SHE_EXTENSION
+
 #include <stdint.h>
 #include <stdlib.h>  /* For NULL */
 #include <string.h>  /* For memset, memcpy */
@@ -38,7 +40,9 @@
 
 #include "wolfhsm/wh_packet.h"
 #include "wolfhsm/wh_client.h"
+
 #include "wolfhsm/wh_server_she.h"
+
 
 int wh_Client_ShePreProgramKey(whClientContext* c, whNvmId keyId,
     whNvmFlags flags, uint8_t* key, whNvmSize keySz)
@@ -882,3 +886,5 @@ int wh_Client_SheVerifyMac(whClientContext* c, uint8_t keyId, uint8_t* message,
     }
     return ret;
 }
+
+#endif /* WOLFHSM_SHE_EXTENSION */

--- a/src/wh_she_common.c
+++ b/src/wh_she_common.c
@@ -22,12 +22,11 @@
  */
 /* System libraries */
 
+#ifdef WOLFHSM_SHE_EXTENSION
+
 #include <stdint.h>
 #include <stdlib.h>  /* For NULL */
 #include <string.h>  /* For memset, memcpy */
-
-/* TODO replace with our own to host function */
-#include <arpa/inet.h>
 
 #include "wolfssl/wolfcrypt/settings.h"
 #include "wolfssl/wolfcrypt/types.h"
@@ -38,11 +37,14 @@
 
 #include "wolfhsm/wh_common.h"
 #include "wolfhsm/wh_error.h"
+#include "wolfhsm/wh_utils.h"
 
 static const uint8_t WOLFHSM_SHE_KEY_UPDATE_ENC_C[] = {0x01, 0x01, 0x53, 0x48, 0x45,
     0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xB0};
 static const uint8_t WOLFHSM_SHE_KEY_UPDATE_MAC_C[] = {0x01, 0x02, 0x53, 0x48, 0x45,
     0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xB0};
+
+
 
 static int wh_AesMp16(uint8_t* in, word32 inSz, uint8_t* out)
 {
@@ -128,7 +130,7 @@ int wh_SheGenerateLoadableKey(uint8_t keyId,
         /* set the counter, flags and key */
         XMEMSET(messageTwo, 0, WOLFHSM_SHE_M2_SZ);
         XMEMCPY(messageTwo + WOLFHSM_SHE_KEY_SZ, key, WOLFHSM_SHE_KEY_SZ);
-        *((uint32_t*)messageTwo) = (htonl(count) << 4);
+        *((uint32_t*)messageTwo) = (wh_Utils_htonl(count) << 4);
         ret = wc_AesInit(aes, NULL, INVALID_DEVID);
     }
     /* encrypt M2 with K1 */
@@ -187,7 +189,7 @@ int wh_SheGenerateLoadableKey(uint8_t keyId,
     if (ret == 0) {
         XMEMSET(messageFour, 0, WOLFHSM_SHE_M4_SZ);
         /* set counter, pad with 1 bit */
-        *((uint32_t*)(messageFour + WOLFHSM_SHE_KEY_SZ)) = (htonl(count) << 4);
+        *((uint32_t*)(messageFour + WOLFHSM_SHE_KEY_SZ)) = (wh_Utils_htonl(count) << 4);
         messageFour[WOLFHSM_SHE_KEY_SZ + 3] |= 0x08;
         /* encrypt the new counter */
         ret = wc_AesEncryptDirect(aes, messageFour + WOLFHSM_SHE_KEY_SZ,
@@ -214,3 +216,6 @@ int wh_SheGenerateLoadableKey(uint8_t keyId,
     }
     return ret;
 }
+
+#endif /* WOLFHSM_SHE_EXTENSION */
+

--- a/src/wh_she_common.c
+++ b/src/wh_she_common.c
@@ -167,7 +167,7 @@ int wh_SheGenerateLoadableKey(uint8_t keyId,
     /* get the digest */
     if (ret == 0) {
         field = AES_BLOCK_SIZE;
-        ret = wc_CmacFinal(cmac, messageThree, &field);
+        ret = wc_CmacFinal(cmac, messageThree, (word32*)&field);
     }
     if (ret == 0) {
         /* copy the ram key to kdfInput */
@@ -211,7 +211,7 @@ int wh_SheGenerateLoadableKey(uint8_t keyId,
     /* cmac messageFour using K4 as the cmac key */
     if (ret == 0) {
         field = AES_BLOCK_SIZE;
-        ret = wc_AesCmacGenerate_ex(cmac, messageFive, &field, messageFour,
+        ret = wc_AesCmacGenerate_ex(cmac, messageFive, (word32*)&field, messageFour,
             WOLFHSM_SHE_M4_SZ, tmpKey, WOLFHSM_SHE_KEY_SZ, NULL, INVALID_DEVID);
     }
     return ret;

--- a/src/wh_utils.c
+++ b/src/wh_utils.c
@@ -1,0 +1,32 @@
+#include "wolfhsm/wh_utils.h"
+
+static int isLittleEndian() {
+    unsigned int x = 1; /* 0x00000001 */
+    char *c = (char*)&x;
+    return (int)*c;
+}
+
+/* Converts a 32-bit value from host to network byte order */
+uint32_t wh_Utils_htonl(uint32_t hostlong) {
+    if (isLittleEndian()) {
+        return ((hostlong & 0x000000FF) << 24) | ((hostlong & 0x0000FF00) << 8)
+            | ((hostlong & 0x00FF0000) >> 8) | ((hostlong & 0xFF000000) >> 24);
+    }
+    return hostlong; /* No conversion needed if not little endian */
+}
+
+uint32_t wh_Utils_ntohl(uint32_t networklong) {
+    /* same operation */
+    return wh_Utils_htonl(networklong);
+}
+
+
+int wh_Utils_memeqzero(uint8_t* buffer, uint32_t size)
+{
+    while (size > 1) {
+        size--;
+        if (buffer[size] != 0)
+            return 0;
+    }
+    return 1;
+}

--- a/test/Makefile
+++ b/test/Makefile
@@ -88,6 +88,7 @@ endif
 
 # wolfHSM source files
 SRC_C += \
+            $(WOLFHSM_DIR)/src/wh_utils.c \
             $(WOLFHSM_DIR)/src/wh_client.c \
             $(WOLFHSM_DIR)/src/wh_client_nvm.c \
             $(WOLFHSM_DIR)/src/wh_client_cryptocb.c \

--- a/test/wh_test_clientserver.c
+++ b/test/wh_test_clientserver.c
@@ -600,6 +600,13 @@ int whTest_ClientServerSequential(void)
     WH_TEST_ASSERT_RETURN(WH_ERROR_NOTREADY ==
                           wh_Server_HandleRequestMessage(server));
 
+    /* Send the comm init message so server can obtain client ID */
+    WH_TEST_RETURN_ON_FAIL(wh_Client_CommInitRequest(client));
+    WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(server));
+    WH_TEST_RETURN_ON_FAIL(wh_Client_CommInitResponse(client, &client_id, &server_id));
+    WH_TEST_ASSERT_RETURN(client_id == client->comm->client_id);
+
+
     for (counter = 0; counter < REPEAT_COUNT; counter++) {
 
         /* Prepare echo test */
@@ -1020,6 +1027,11 @@ int whTest_ClientCfg(whClientConfig* clientCfg)
     uint32_t reclaim_size = 0;
     whNvmId avail_objects = 0;
     whNvmId reclaim_objects = 0;
+
+    /* Init client/server comms */
+    WH_TEST_RETURN_ON_FAIL(wh_Client_CommInit(client, &client_id, &server_id));
+    WH_TEST_ASSERT_RETURN(client_id == client->comm->client_id);
+
 
     for (counter = 0; counter < REPEAT_COUNT; counter++) {
 

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -105,8 +105,6 @@ int whTest_CryptoClientConfig(whClientConfig* config)
         0x17, 0xad, 0x2b, 0x41, 0x7b, 0xe6, 0x6c, 0x37, 0x10};
     uint8_t knownCmacTag[] = {0x51, 0xf0, 0xbe, 0xbf, 0x7e, 0x3b, 0x9d, 0x92,
         0xfc, 0x49, 0x74, 0x17, 0x79, 0x36, 0x3c, 0xfe};
-    uint32_t outClientId = 0;
-    uint32_t outServerId = 0;
 
     XMEMCPY(plainText, PLAINTEXT, sizeof(plainText));
 
@@ -115,7 +113,7 @@ int whTest_CryptoClientConfig(whClientConfig* config)
     }
 
     WH_TEST_RETURN_ON_FAIL(wh_Client_Init(client, config));
-    WH_TEST_RETURN_ON_FAIL(wh_Client_CommInit(client, &outClientId, &outServerId));
+    WH_TEST_RETURN_ON_FAIL(wh_Client_CommInit(client, NULL, NULL));
 
 #ifdef WH_CFG_TEST_VERBOSE
     {
@@ -187,7 +185,7 @@ int whTest_CryptoClientConfig(whClientConfig* config)
     /* test cache with duplicate keyId for a different user */
     WH_TEST_RETURN_ON_FAIL(wh_Client_CommClose(client));
     client->comm->client_id = 2;
-    WH_TEST_RETURN_ON_FAIL(wh_Client_CommInit(client, &outClientId, &outServerId));
+    WH_TEST_RETURN_ON_FAIL(wh_Client_CommInit(client, NULL, NULL));
     XMEMSET(cipherText, 0xff, sizeof(cipherText));
     /* first check that evicting the other clients key fails */
     if ((ret = wh_Client_KeyEvict(client, keyId)) != WH_ERROR_NOTFOUND) {
@@ -216,7 +214,7 @@ int whTest_CryptoClientConfig(whClientConfig* config)
     /* switch back and verify original key */
     WH_TEST_RETURN_ON_FAIL(wh_Client_CommClose(client));
     client->comm->client_id = 1;
-    WH_TEST_RETURN_ON_FAIL(wh_Client_CommInit(client, &outClientId, &outServerId));
+    WH_TEST_RETURN_ON_FAIL(wh_Client_CommInit(client, NULL, NULL));
     outLen = sizeof(keyEnd);
     if ((ret = wh_Client_KeyExport(client, keyId, labelEnd, sizeof(labelEnd), keyEnd, &outLen)) != 0) {
         WH_ERROR_PRINT("Failed to wh_Client_KeyExport %d\n", ret);

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -117,6 +117,27 @@ int whTest_CryptoClientConfig(whClientConfig* config)
     WH_TEST_RETURN_ON_FAIL(wh_Client_Init(client, config));
     WH_TEST_RETURN_ON_FAIL(wh_Client_CommInit(client, &outClientId, &outServerId));
 
+#ifdef WH_CFG_TEST_VERBOSE
+    {
+        int32_t  server_rc       = 0;
+        whNvmId  avail_objects   = 0;
+        whNvmId  reclaim_objects = 0;
+        uint32_t avail_size      = 0;
+        uint32_t reclaim_size    = 0;
+
+        WH_TEST_RETURN_ON_FAIL(
+            ret = wh_Client_NvmGetAvailable(client, &server_rc, &avail_size,
+                                            &avail_objects, &reclaim_size,
+                                            &reclaim_objects));
+
+        printf("PRE-CRYPTO TEST: NvmGetAvailable:%d, server_rc:%d avail_size:%d "
+               "avail_objects:%d, reclaim_size:%d reclaim_objects:%d\n",
+               ret, (int)server_rc, (int)avail_size, (int)avail_objects,
+               (int)reclaim_size, (int)reclaim_objects);
+    }
+#endif /* WH_CFG_TEST_VERBOSE */
+
+
     memset(labelStart, 0xff, sizeof(labelStart));
 
     /* test rng */
@@ -441,11 +462,11 @@ int whTest_CryptoClientConfig(whClientConfig* config)
         goto exit;
     }
     outLen = 32;
-    if((ret = wc_ecc_shared_secret(eccPrivate, eccPublic, (byte*)cipherText, &outLen)) != 0) {
+    if((ret = wc_ecc_shared_secret(eccPrivate, eccPublic, (byte*)cipherText, (word32*)&outLen)) != 0) {
         printf("Failed to wc_ecc_shared_secret %d\n", ret);
         goto exit;
     }
-    if((ret = wc_ecc_shared_secret(eccPublic, eccPrivate, (byte*)finalText, &outLen)) != 0) {
+    if((ret = wc_ecc_shared_secret(eccPublic, eccPrivate, (byte*)finalText, (word32*)&outLen)) != 0) {
         printf("Failed to wc_ecc_shared_secret %d\n", ret);
         goto exit;
     }
@@ -457,7 +478,7 @@ int whTest_CryptoClientConfig(whClientConfig* config)
         goto exit;
     }
     outLen = 32;
-    if((ret = wc_ecc_sign_hash((void*)cipherText, sizeof(cipherText), (void*)finalText, &outLen, rng, eccPrivate)) != 0) {
+    if((ret = wc_ecc_sign_hash((void*)cipherText, sizeof(cipherText), (void*)finalText, (word32*)&outLen, rng, eccPrivate)) != 0) {
         printf("Failed to wc_ecc_sign_hash %d\n", ret);
         goto exit;
     }
@@ -513,7 +534,7 @@ int whTest_CryptoClientConfig(whClientConfig* config)
         goto exit;
     }
     outLen = sizeof(knownCmacTag);
-    if((ret = wc_CmacFinal(cmac, (byte*)cipherText, &outLen)) != 0) {
+    if((ret = wc_CmacFinal(cmac, (byte*)cipherText, (word32*)&outLen)) != 0) {
         WH_ERROR_PRINT("Failed to wc_CmacFinal %d\n", ret);
         goto exit;
     }
@@ -533,7 +554,7 @@ int whTest_CryptoClientConfig(whClientConfig* config)
         goto exit;
     }
     outLen = sizeof(knownCmacTag);
-    if((ret = wh_Client_AesCmacGenerate(cmac, (byte*)cipherText, &outLen, (byte*)knownCmacMessage, sizeof(knownCmacMessage), keyId, NULL)) != 0) {
+    if((ret = wh_Client_AesCmacGenerate(cmac, (byte*)cipherText, (word32*)&outLen, (byte*)knownCmacMessage, sizeof(knownCmacMessage), keyId, NULL)) != 0) {
         WH_ERROR_PRINT("Failed to wh_Client_AesCmacGenerate %d\n", ret);
         goto exit;
     }
@@ -570,6 +591,32 @@ int whTest_CryptoClientConfig(whClientConfig* config)
         WH_ERROR_PRINT("Failed to wh_Client_KeyExport %d\n", ret);
         goto exit;
     }
+    /* test finished, erase key */
+    if ((ret = wh_Client_KeyErase(client, keyId)) != 0) {
+        WH_ERROR_PRINT("Failed to wh_Client_KeyErase %d\n", ret);
+        goto exit;
+    }
+
+#ifdef WH_CFG_TEST_VERBOSE
+    {
+        int32_t  server_rc       = 0;
+        whNvmId  avail_objects   = 0;
+        whNvmId  reclaim_objects = 0;
+        uint32_t avail_size      = 0;
+        uint32_t reclaim_size    = 0;
+
+        WH_TEST_RETURN_ON_FAIL(
+            ret = wh_Client_NvmGetAvailable(client, &server_rc, &avail_size,
+                                            &avail_objects, &reclaim_size,
+                                            &reclaim_objects));
+
+        printf("POST-CRYPTO TEST: NvmGetAvailable:%d, server_rc:%d avail_size:%d "
+               "avail_objects:%d, reclaim_size:%d reclaim_objects:%d\n",
+               ret, (int)server_rc, (int)avail_size, (int)avail_objects,
+               (int)reclaim_size, (int)reclaim_objects);
+    }
+#endif /* WH_CFG_TEST_VERBOSE */
+
     ret = 0;
 exit:
     wc_curve25519_free(curve25519PrivateKey);

--- a/test/wh_test_she.c
+++ b/test/wh_test_she.c
@@ -63,7 +63,7 @@ enum {
 /* Helper function to destroy a SHE key so the unit tests don't
  * leak NVM objects across invocations. Necessary, as SHE doesn't expose a
  * destroy key API since SHE keys are supposed to be fixed hardware keys */
-static int _destroyShePreProgrammedKey(whClientContext* client, whNvmId clientSheKeyId)
+static int _destroySheKey(whClientContext* client, whNvmId clientSheKeyId)
 {
     int rc = 0;
     int32_t serverRc = 0;
@@ -341,28 +341,28 @@ int whTest_SheClientConfig(whClientConfig* config)
     }
 
     /* destroy "pre-programmed" keys so we don't leak NVM */
-    if ((ret = _destroyShePreProgrammedKey(client, WOLFHSM_SHE_BOOT_MAC_KEY_ID)) != 0) {
-        WH_ERROR_PRINT("Failed to _destroyShePreProgrammedKey, ret=%d\n", ret);
+    if ((ret = _destroySheKey(client, WOLFHSM_SHE_BOOT_MAC_KEY_ID)) != 0) {
+        WH_ERROR_PRINT("Failed to _destroySheKey, ret=%d\n", ret);
         goto exit;
     }
-    if ((ret = _destroyShePreProgrammedKey(client, WOLFHSM_SHE_BOOT_MAC)) != 0) {
-        WH_ERROR_PRINT("Failed to _destroyShePreProgrammedKey, ret=%d\n", ret);
+    if ((ret = _destroySheKey(client, WOLFHSM_SHE_BOOT_MAC)) != 0) {
+        WH_ERROR_PRINT("Failed to _destroySheKey, ret=%d\n", ret);
         goto exit;
     }
-    if ((ret = _destroyShePreProgrammedKey(client, WOLFHSM_SHE_SECRET_KEY_ID)) != 0) {
-        WH_ERROR_PRINT("Failed to _destroyShePreProgrammedKey, ret=%d\n", ret);
+    if ((ret = _destroySheKey(client, WOLFHSM_SHE_SECRET_KEY_ID)) != 0) {
+        WH_ERROR_PRINT("Failed to _destroySheKey, ret=%d\n", ret);
         goto exit;
     }
-    if ((ret = _destroyShePreProgrammedKey(client, WOLFHSM_SHE_PRNG_SEED_ID)) != 0) {
-        WH_ERROR_PRINT("Failed to _destroyShePreProgrammedKey, ret=%d\n", ret);
+    if ((ret = _destroySheKey(client, WOLFHSM_SHE_PRNG_SEED_ID)) != 0) {
+        WH_ERROR_PRINT("Failed to _destroySheKey, ret=%d\n", ret);
         goto exit;
     }
-    if ((ret = _destroyShePreProgrammedKey(client, WOLFHSM_SHE_MASTER_ECU_KEY_ID)) != 0) {
-        WH_ERROR_PRINT("Failed to _destroyShePreProgrammedKey, ret=%d\n", ret);
+    if ((ret = _destroySheKey(client, WOLFHSM_SHE_MASTER_ECU_KEY_ID)) != 0) {
+        WH_ERROR_PRINT("Failed to _destroySheKey, ret=%d\n", ret);
         goto exit;
     }
-    if ((ret = _destroyShePreProgrammedKey(client, SHE_TEST_VECTOR_KEY_ID)) != 0) {
-        WH_ERROR_PRINT("Failed to _destroyShePreProgrammedKey, ret=%d\n", ret);
+    if ((ret = _destroySheKey(client, SHE_TEST_VECTOR_KEY_ID)) != 0) {
+        WH_ERROR_PRINT("Failed to _destroySheKey, ret=%d\n", ret);
         goto exit;
     }
     printf("SHE CMAC SUCCESS\n");

--- a/test/wh_test_she.c
+++ b/test/wh_test_she.c
@@ -43,6 +43,7 @@
 #include "wolfhsm/wh_client.h"
 #include "wolfhsm/wh_client_she.h"
 #include "wolfhsm/wh_transport_mem.h"
+#include "wolfhsm/wh_common.h"
 
 #include "wh_test_common.h"
 
@@ -59,6 +60,23 @@ enum {
         BUFFER_SIZE = 4096,
     };
 
+/* Helper function to destroy a SHE key so the unit tests don't
+ * leak NVM objects across invocations. Necessary, as SHE doesn't expose a
+ * destroy key API since SHE keys are supposed to be fixed hardware keys */
+static int _destroyShePreProgrammedKey(whClientContext* client, whNvmId clientSheKeyId)
+{
+    int rc = 0;
+    int32_t serverRc = 0;
+
+    whNvmId id = MAKE_WOLFHSM_KEYID(WOLFHSM_KEYTYPE_SHE, client->comm->client_id, clientSheKeyId);
+
+    rc = wh_Client_NvmDestroyObjects(client, 1, &id, 0, NULL, &serverRc);
+    if (rc == WH_ERROR_OK) {
+        rc = serverRc;
+    }
+
+    return rc;
+}
 
 int whTest_SheClientConfig(whClientConfig* config)
 {
@@ -115,6 +133,7 @@ int whTest_SheClientConfig(whClientConfig* config)
     uint8_t messageFive[WOLFHSM_SHE_M5_SZ];
     uint32_t outClientId = 0;
     uint32_t outServerId = 0;
+    const uint32_t SHE_TEST_VECTOR_KEY_ID = 4;
 
     if (config == NULL) {
         return WH_ERROR_BADARGS;
@@ -122,6 +141,26 @@ int whTest_SheClientConfig(whClientConfig* config)
 
     WH_TEST_RETURN_ON_FAIL(wh_Client_Init(client, config));
     WH_TEST_RETURN_ON_FAIL(wh_Client_CommInit(client, &outClientId, &outServerId));
+
+#ifdef WH_CFG_TEST_VERBOSE
+    {
+        int32_t  server_rc       = 0;
+        whNvmId  avail_objects   = 0;
+        whNvmId  reclaim_objects = 0;
+        uint32_t avail_size      = 0;
+        uint32_t reclaim_size    = 0;
+
+        WH_TEST_RETURN_ON_FAIL(
+            ret = wh_Client_NvmGetAvailable(client, &server_rc, &avail_size,
+                                            &avail_objects, &reclaim_size,
+                                            &reclaim_objects));
+
+        printf("PRE-SHE TEST: NvmGetAvailable:%d, server_rc:%d avail_size:%d "
+               "avail_objects:%d, reclaim_size:%d reclaim_objects:%d\n",
+               ret, (int)server_rc, (int)avail_size, (int)avail_objects,
+               (int)reclaim_size, (int)reclaim_objects);
+    }
+#endif /* WH_CFG_TEST_VERBOSE */
 
     /* generate a new cmac key */
     if ((ret = wc_InitRng_ex(rng, NULL, WOLFHSM_DEV_ID)) != 0) {
@@ -204,7 +243,7 @@ int whTest_SheClientConfig(whClientConfig* config)
     }
     /* load the vector master ecu key */
     if ((ret = wh_SheGenerateLoadableKey(WOLFHSM_SHE_MASTER_ECU_KEY_ID, WOLFHSM_SHE_SECRET_KEY_ID, 1, 0, sheUid, vectorMasterEcuKey, secretKey, messageOne, messageTwo, messageThree, messageFour, messageFive)) != 0) {
-        WH_ERROR_PRINT("Failed to wh_Client_ShePreProgramKey %d\n", ret);
+        WH_ERROR_PRINT("Failed to wh_Client_SheGenerateLoadableKey %d\n", ret);
         goto exit;
     }
     if ((ret = wh_Client_SheLoadKey(client, messageOne, messageTwo, messageThree, outMessageFour, outMessageFive)) != 0) {
@@ -212,8 +251,8 @@ int whTest_SheClientConfig(whClientConfig* config)
         goto exit;
     }
     /* verify that our helper function output matches the vector */
-    if ((ret = wh_SheGenerateLoadableKey(4, WOLFHSM_SHE_MASTER_ECU_KEY_ID, 1, 0, sheUid, vectorRawKey, vectorMasterEcuKey, messageOne, messageTwo, messageThree, messageFour, messageFive)) != 0) {
-        WH_ERROR_PRINT("Failed to wh_Client_ShePreProgramKey %d\n", ret);
+    if ((ret = wh_SheGenerateLoadableKey(SHE_TEST_VECTOR_KEY_ID, WOLFHSM_SHE_MASTER_ECU_KEY_ID, 1, 0, sheUid, vectorRawKey, vectorMasterEcuKey, messageOne, messageTwo, messageThree, messageFour, messageFive)) != 0) {
+        WH_ERROR_PRINT("Failed to wh_Client_SheGenerateLoadableKey %d\n", ret);
         goto exit;
     }
     if (memcmp(messageOne, vectorMessageOne, sizeof(vectorMessageOne)) != 0 ||
@@ -300,7 +339,55 @@ int whTest_SheClientConfig(whClientConfig* config)
         WH_ERROR_PRINT("SHE CMAC FAILED TO VERIFY\n");
         goto exit;
     }
+
+    /* destroy "pre-programmed" keys so we don't leak NVM */
+    if ((ret = _destroyShePreProgrammedKey(client, WOLFHSM_SHE_BOOT_MAC_KEY_ID)) != 0) {
+        WH_ERROR_PRINT("Failed to _destroyShePreProgrammedKey, ret=%d\n", ret);
+        goto exit;
+    }
+    if ((ret = _destroyShePreProgrammedKey(client, WOLFHSM_SHE_BOOT_MAC)) != 0) {
+        WH_ERROR_PRINT("Failed to _destroyShePreProgrammedKey, ret=%d\n", ret);
+        goto exit;
+    }
+    if ((ret = _destroyShePreProgrammedKey(client, WOLFHSM_SHE_SECRET_KEY_ID)) != 0) {
+        WH_ERROR_PRINT("Failed to _destroyShePreProgrammedKey, ret=%d\n", ret);
+        goto exit;
+    }
+    if ((ret = _destroyShePreProgrammedKey(client, WOLFHSM_SHE_PRNG_SEED_ID)) != 0) {
+        WH_ERROR_PRINT("Failed to _destroyShePreProgrammedKey, ret=%d\n", ret);
+        goto exit;
+    }
+    if ((ret = _destroyShePreProgrammedKey(client, WOLFHSM_SHE_MASTER_ECU_KEY_ID)) != 0) {
+        WH_ERROR_PRINT("Failed to _destroyShePreProgrammedKey, ret=%d\n", ret);
+        goto exit;
+    }
+    if ((ret = _destroyShePreProgrammedKey(client, SHE_TEST_VECTOR_KEY_ID)) != 0) {
+        WH_ERROR_PRINT("Failed to _destroyShePreProgrammedKey, ret=%d\n", ret);
+        goto exit;
+    }
     printf("SHE CMAC SUCCESS\n");
+
+#ifdef WH_CFG_TEST_VERBOSE
+    {
+        int32_t  server_rc       = 0;
+        whNvmId  avail_objects   = 0;
+        whNvmId  reclaim_objects = 0;
+        uint32_t avail_size      = 0;
+        uint32_t reclaim_size    = 0;
+
+        WH_TEST_RETURN_ON_FAIL(
+            ret = wh_Client_NvmGetAvailable(client, &server_rc, &avail_size,
+                                            &avail_objects, &reclaim_size,
+                                            &reclaim_objects));
+
+        printf("POST-SHE TEST: NvmGetAvailable:%d, server_rc:%d avail_size:%d "
+               "avail_objects:%d, reclaim_size:%d reclaim_objects:%d\n",
+               ret, (int)server_rc, (int)avail_size, (int)avail_objects,
+               (int)reclaim_size, (int)reclaim_objects);
+    }
+#endif /* WH_CFG_TEST_VERBOSE */
+
+
 exit:
     /* Tell server to close */
     WH_TEST_RETURN_ON_FAIL(wh_Client_CommClose(client));

--- a/test/wh_test_she.c
+++ b/test/wh_test_she.c
@@ -122,7 +122,6 @@ int whTest_SheClientConfig(whClientConfig* config)
 
     WH_TEST_RETURN_ON_FAIL(wh_Client_Init(client, config));
     WH_TEST_RETURN_ON_FAIL(wh_Client_CommInit(client, &outClientId, &outServerId));
-    WH_TEST_ASSERT_RETURN(outClientId == client->comm->client_id);
 
     /* generate a new cmac key */
     if ((ret = wc_InitRng_ex(rng, NULL, WOLFHSM_DEV_ID)) != 0) {

--- a/test/wh_test_she.h
+++ b/test/wh_test_she.h
@@ -2,5 +2,6 @@
 #define WH_TEST_SHE_H_
 
 int whTest_She(void);
+int whTest_SheClientConfig(whClientConfig* config);
 
 #endif /* WH_TEST_SHE_H_ */

--- a/wolfhsm/wh_utils.h
+++ b/wolfhsm/wh_utils.h
@@ -1,0 +1,13 @@
+#ifndef WH_UTILS_H_
+#define WH_UTILS_H_
+
+#include <stdint.h>
+
+uint32_t wh_Utils_htonl(uint32_t hostlong);
+uint32_t wh_Utils_ntohl(uint32_t networklong);
+
+int wh_Utils_memeqzero(uint8_t* buffer, uint32_t size);
+
+
+
+#endif /* WH_UTILS_H_ */


### PR DESCRIPTION
- lingering typecast fixes for wolfCrypt types 
- adds SHE macro protection 
- adds comm init call to unit tests 
- remove hard-coded client ID in SHE server test
- Adds custom `htonl`/`ntohl`/`memeq` to new utils module
- Fix "leaked" NVM objects in crypto and SHE tests