### PR TITLE
dummy names for anonymous structures/unions

### DIFF
--- a/wolfhsm/wh_comm.h
+++ b/wolfhsm/wh_comm.h
@@ -47,7 +47,7 @@
  * (whHeader) followed immediately by variable-length data between 0 and
  * DATA_LEN bytes.
  */
-enum {
+enum WH_COMM_ENUM {
     WH_COMM_HEADER_LEN = 8,    /* whCommHeader */
     WH_COMM_DATA_LEN = 1280,
     WH_COMM_MTU = (WH_COMM_HEADER_LEN + WH_COMM_DATA_LEN),
@@ -81,7 +81,7 @@ typedef struct {
 /* static_assert(sizeof_whHeader == WH_COMM_HEADER_LEN,
                  "Size of whCommHeader doesn't match WH_COMM_HEADER_LEN") */
 
-enum {
+enum WH_COMM_AUX_ENUM {
     WH_COMM_AUX_REQ_NORMAL      = 0x0000, /* Normal request. No session */
     /* Request Aux values 1-0xFFFE are session ids */
     WH_COMM_AUX_REQ_NORESP      = 0xFFFF, /* Async request without response*/

--- a/wolfhsm/wh_common.h
+++ b/wolfhsm/wh_common.h
@@ -33,7 +33,7 @@
 #define WOLFHSM_DIGEST_STUB 8
 
 /** Resource allocations */
-enum {
+enum WOLFHSM_NUM_ENUM {
     WOLFHSM_NUM_COUNTERS = 8,       /* Number of non-volatile 32-bit counters */
     WOLFHSM_NUM_RAMKEYS = 16,        /* Number of RAM keys */
     WOLFHSM_NUM_NVMOBJECTS = 32,    /* Number of NVM objects in the directory */
@@ -94,7 +94,7 @@ typedef uint16_t whNvmAccess;
 typedef uint16_t whNvmFlags;
 
 /* HSM NVM metadata structure */
-enum {
+enum WOLFHSM_NVM_ENUM {
     WOLFHSM_NVM_LABEL_LEN = 24,
     WOLFHSM_NVM_METADATA_LEN = 32,
     WOLFHSM_NVM_MAX_OBJECT_SIZE = 65535,

--- a/wolfhsm/wh_error.h
+++ b/wolfhsm/wh_error.h
@@ -28,7 +28,7 @@
 /* Consider reusing wolfssl or wolfcrypt errors here */
 
 
-enum {
+enum WH_ERROR_ENUM {
     WH_ERROR_OK             = 0,    /* Success, no error. */
 
     /* General errors */

--- a/wolfhsm/wh_message.h
+++ b/wolfhsm/wh_message.h
@@ -26,7 +26,7 @@
 #define WOLFHSM_WH_MESSAGE_H_
 
 /* Message groups and kind */
-enum {
+enum WH_MESSAGE_ENUM {
     WH_MESSAGE_KIND_NONE            = 0x0000, /* No message kind. Invalid */
 
     WH_MESSAGE_GROUP_MASK           = 0xFF00, /* 255 groups */
@@ -46,7 +46,7 @@ enum {
 };
 
 /* keystore actions */
-enum {
+enum WH_KEY_ENUM {
     WH_KEY_CACHE,
     WH_KEY_EVICT,
     WH_KEY_EXPORT,
@@ -55,7 +55,7 @@ enum {
 };
 
 /* SHE actions */
-enum {
+enum WH_SHE_ENUM {
     WH_SHE_SET_UID,
     WH_SHE_SECURE_BOOT_INIT,
     WH_SHE_SECURE_BOOT_UPDATE,

--- a/wolfhsm/wh_message_comm.h
+++ b/wolfhsm/wh_message_comm.h
@@ -29,7 +29,7 @@
 #include <stdint.h>
 
 /* Comm component message kinds */
-enum {
+enum WH_MESSAGE_COMM_ACTION_ENUM {
     WH_MESSAGE_COMM_ACTION_NONE      = 0x00,
     WH_MESSAGE_COMM_ACTION_INIT      = 0x01,
     WH_MESSAGE_COMM_ACTION_KEEPALIVE = 0x02,
@@ -78,7 +78,7 @@ int wh_MessageComm_TranslateInitResponse(uint16_t magic,
         whMessageCommInitResponse* dest);
 
 /* Info request/response data */
-enum {
+enum WOLFHSM_INFO_ENUM {
     WOLFHSM_INFO_VERSION_LEN = 8,
     WOLFHSM_INFO_BUILD_LEN   = 8,
 };

--- a/wolfhsm/wh_message_nvm.h
+++ b/wolfhsm/wh_message_nvm.h
@@ -30,7 +30,7 @@
 #include "wolfhsm/wh_message.h"
 #include "wolfhsm/wh_nvm.h"
 
-enum {
+enum WH_MESSAGE_NVM_ACTION_ENUM {
     WH_MESSAGE_NVM_ACTION_INIT              = 0x1,
     WH_MESSAGE_NVM_ACTION_CLEANUP           = 0x2,
     WH_MESSAGE_NVM_ACTION_GETAVAILABLE      = 0x3,
@@ -45,7 +45,7 @@ enum {
     WH_MESSAGE_NVM_ACTION_READDMA64         = 0x28,
 };
 
-enum {
+enum WH_MESSAGE_NVM_MAX_ENUM {
     /* must be odd for struct whMessageNvm_DestroyObjectsRequest  alignment */
     WH_MESSAGE_NVM_MAX_DESTROY_OBJECTS_COUNT = 9,
     WH_MESSAGE_NVM_MAX_ADD_OBJECT_LEN =

--- a/wolfhsm/wh_nvm.h
+++ b/wolfhsm/wh_nvm.h
@@ -42,7 +42,7 @@
 #include "wolfhsm/wh_common.h"  /* For whNvm types */
 
 
-enum {
+enum WH_NVM_IDS {
     WH_NVM_INVALID_ID = 0,
 };
 

--- a/wolfhsm/wh_server.h
+++ b/wolfhsm/wh_server.h
@@ -54,12 +54,12 @@ typedef struct CacheSlot {
     uint8_t       buffer[WOLFHSM_KEYCACHE_BUFSIZE];
 } CacheSlot;
 
-typedef struct {
+typedef struct crypto_context {
     int devId;
 #ifndef WC_NO_RNG
     WC_RNG rng[1];
 #endif
-    union {
+    union crypto_context_cryptoctx {
 #ifndef NO_AES
         Aes aes[1];
 #endif
@@ -76,7 +76,7 @@ typedef struct {
         Cmac cmac[1];
 #endif
     };
-    union {
+    union crypto_context_pubkey {
 #ifdef HAVE_ECC
         ecc_key eccPublic[1];
 #endif


### PR DESCRIPTION
doxybook (the program we use to render doxygen to a nice-looking website) can't handle unnamed enums or unions. David provided this patch that will allow it to render. Normally I'd say we shouldn't change our code just to accommodate an external (buggy) tool, but it would require us to create separate headers for doc purposes which are easy to get out of sync, and in this case the changes are pretty innocuous. I like our code having the doxygen in it, so I say it is worth it in this small case.