### PR TITLE
Random lingering tricore cleanups

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    # List compiler version
+    - name: List compiler version
+      run: gcc --version
+
     # pull and build wolfssl
     - name: Checkout wolfssl
       uses: actions/checkout@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,19 +21,23 @@ jobs:
         repository: wolfssl/wolfssl
         path: wolfssl
 
-    # Build and test debug build with ASAN and NOCRYPTO 
+    # Build and test debug build with ASAN and NOCRYPTO
     - name: Build and test ASAN DEBUG NOCRYPTO
       run: cd test && make clean && make DEBUG=1 ASAN=1 NOCRYPTO=1 WOLFSSL_DIR=../wolfssl run
 
-    # Build and test debug build with ASAN 
+    # Build and test debug build with ASAN
     - name: Build and test ASAN DEBUG
       run: cd test && make clean && make DEBUG=1 ASAN=1 WOLFSSL_DIR=../wolfssl run
 
-    # Build and test debug build with SHE 
+    # Build and test debug build with SHE
     - name: Build and test SHE
       run: cd test && make clean && make SHE=1 WOLFSSL_DIR=../wolfssl run
 
     # Build and test standard build
     - name: Build and test
       run: cd test && make clean && make WOLFSSL_DIR=../wolfssl run
+
+    # Test structure padding
+    - name: Check structure padding
+      run: cd test && make clean && make checkpadding
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,18 +12,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
 
     # pull and build wolfssl
     - name: Checkout wolfssl
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
       with:
         repository: wolfssl/wolfssl
         path: wolfssl
 
     # Build and test debug build with ASAN and NOCRYPTO 
-    - name: Build and test ASAN DEBUG
-      run: cd test && make clean &&  make DEBUG=1 ASAN=1 NOCRYPTO=1 WOLFSSL_DIR=../wolfssl run
+    - name: Build and test ASAN DEBUG NOCRYPTO
+      run: cd test && make clean && make DEBUG=1 ASAN=1 NOCRYPTO=1 WOLFSSL_DIR=../wolfssl run
 
     # Build and test debug build with ASAN 
     - name: Build and test ASAN DEBUG
@@ -32,7 +32,7 @@ jobs:
     # Build and test debug build with SHE 
     - name: Build and test SHE
       run: cd test && make clean && make SHE=1 WOLFSSL_DIR=../wolfssl run
-          
+
     # Build and test standard build
     - name: Build and test
       run: cd test && make clean && make WOLFSSL_DIR=../wolfssl run

--- a/src/wh_client.c
+++ b/src/wh_client.c
@@ -489,12 +489,12 @@ int wh_Client_KeyCacheRequest_ex(whClientContext* c, uint32_t flags,
         packet->keyCacheReq.labelSz = labelSz;
         /* write label */
         if (labelSz > WOLFHSM_NVM_LABEL_LEN)
-            XMEMCPY(packet->keyCacheReq.label, label, WOLFHSM_NVM_LABEL_LEN);
+            memcpy(packet->keyCacheReq.label, label, WOLFHSM_NVM_LABEL_LEN);
         else
-            XMEMCPY(packet->keyCacheReq.label, label, labelSz);
+            memcpy(packet->keyCacheReq.label, label, labelSz);
     }
     /* write in */
-    XMEMCPY(packIn, in, inSz);
+    memcpy(packIn, in, inSz);
     /* write request */
     return wh_Client_SendRequest(c, WH_MESSAGE_GROUP_KEY, WH_KEY_CACHE,
             WOLFHSM_PACKET_STUB_SIZE + sizeof(packet->keyCacheReq) + inSz,
@@ -626,16 +626,16 @@ int wh_Client_KeyExportResponse(whClientContext* c, uint8_t* label,
                 ret = WH_ERROR_ABORTED;
             }
             else {
-                XMEMCPY(out, packOut, packet->keyExportRes.len);
+                memcpy(out, packOut, packet->keyExportRes.len);
                 *outSz = packet->keyExportRes.len;
             }
             if (label != NULL) {
                 if (labelSz > sizeof(packet->keyExportRes.label)) {
-                    XMEMCPY(label, packet->keyExportRes.label,
+                    memcpy(label, packet->keyExportRes.label,
                         WOLFHSM_NVM_LABEL_LEN);
                 }
                 else
-                    XMEMCPY(label, packet->keyExportRes.label, labelSz);
+                    memcpy(label, packet->keyExportRes.label, labelSz);
             }
         }
     }

--- a/src/wh_client.c
+++ b/src/wh_client.c
@@ -468,8 +468,6 @@ int wh_Client_CustomCbCheckRegistered(whClientContext* c, uint16_t id, int* resp
 }
 
 
-#ifndef WOLFHSM_NO_CRYPTO
-
 int wh_Client_KeyCacheRequest_ex(whClientContext* c, uint32_t flags,
     uint8_t* label, uint32_t labelSz, uint8_t* in, uint32_t inSz,
     uint16_t keyId)
@@ -945,6 +943,8 @@ int wh_Client_CounterDestroy(whClientContext* c, whNvmId counterId)
     return ret;
 }
 
+#ifndef WOLFHSM_NO_CRYPTO
+
 #ifdef HAVE_CURVE25519
 int wh_Client_SetKeyCurve25519(curve25519_key* key, whNvmId keyId)
 {
@@ -1019,5 +1019,5 @@ int wh_Client_AesCmacVerify(Cmac* cmac, const byte* check, word32 checkSz,
         ret = memcmp(out, check, outSz) == 0 ? 0 : 1;
     return ret;
 }
-#endif
+#endif /* WOLFSSL_CMAC */
 #endif  /* !WOLFHSM_NO_CRYPTO */

--- a/test/Makefile
+++ b/test/Makefile
@@ -49,7 +49,7 @@ endif
 
 # Support a NO CRYPTO build
 ifeq ($(NOCRYPTO),1)
-CFLAGS += -DWOLFHSM_NO_CRYPTO -Wpadded
+CFLAGS += -DWOLFHSM_NO_CRYPTO
 endif
 
 ifeq ($(SHE),1)
@@ -142,6 +142,7 @@ vpath %.c $(dir $(SRC_C))
 OBJS_ASM = $(addprefix $(BUILD_DIR)/, $(notdir $(SRC_ASM:.s=.o)))
 vpath %.s $(dir $(SRC_ASM))
 
+.PHONY: all clean run checkpadding
 
 build_app: $(BUILD_DIR) $(BUILD_DIR)/$(BIN).elf
 	@echo Build complete.
@@ -184,3 +185,7 @@ clean:
 run: build_app
 	./$(BUILD_DIR)/$(BIN).elf
 
+checkpadding:
+	@echo "Checking for padding issues with -Wpadded"
+	$(CMD_ECHO) $(CC) -Wpadded $(CFLAGS) $(DEF) $(INC) -c \
+	    -o $(BUILD_DIR)/wh_test_check_struct_padding.o wh_test_check_struct_padding.c

--- a/test/wh_test_check_struct_padding.c
+++ b/test/wh_test_check_struct_padding.c
@@ -1,0 +1,120 @@
+#ifndef WH_TEST_CHECK_STRUCT_PADDING_H_
+#define WH_TEST_CHECK_STRUCT_PADDING_H_
+
+/* For each included file, define an instance of every struct for which we want
+ * to check padding. Then, when this file is compiled with -Wpadded it will
+ * generate an error if padding is wrong */
+
+
+#include "wolfhsm/wh_message_comm.h"
+whMessageComm_ErrorResponse whMessageComm_ErrorResponse_test;
+whMessageCommLenData        whMessageCommLenData_test;
+whMessageCommInitRequest    whMessageCommInitRequest_test;
+whMessageCommInitResponse   whMessageCommInitResponse_test;
+whMessageCommInfo           whMessageCommInfo_test;
+
+#include "wolfhsm/wh_message_customcb.h"
+whMessageCustomCb_Request  whMessageCustomCb_Request_test;
+whMessageCustomCb_Response whMessageCustomCb_Response_test;
+
+#include "wolfhsm/wh_message_nvm.h"
+whMessageNvm_SimpleResponse        whMessageNvm_SimpleResponse_test;
+whMessageNvm_InitRequest           whMessageNvm_InitRequest_test;
+whMessageNvm_InitResponse          whMessageNvm_InitResponse_test;
+whMessageNvm_GetAvailableResponse  whMessageNvm_GetAvailableResponse_test;
+whMessageNvm_AddObjectRequest      whMessageNvm_AddObjectRequest_test;
+whMessageNvm_ListRequest           whMessageNvm_ListRequest_test;
+whMessageNvm_ListResponse          whMessageNvm_ListResponse_test;
+whMessageNvm_GetMetadataRequest    whMessageNvm_GetMetadataRequest_test;
+whMessageNvm_GetMetadataResponse   whMessageNvm_GetMetadataResponse_test;
+whMessageNvm_DestroyObjectsRequest whMessageNvm_DestroyObjectsRequest_test;
+whMessageNvm_ReadRequest           whMessageNvm_ReadRequest_test;
+whMessageNvm_ReadResponse          whMessageNvm_ReadResponse_test;
+whMessageNvm_AddObjectDma32Request whMessageNvm_AddObjectDma32Request_test;
+whMessageNvm_ReadDma32Request      whMessageNvm_ReadDma32Request_test;
+whMessageNvm_AddObjectDma64Request whMessageNvm_AddObjectDma64Request_test;
+whMessageNvm_ReadDma64Request      whMessageNvm_ReadDma64Request_test;
+
+#include "wolfhsm/wh_packet.h"
+whPacket whPacket_test;
+/* Test every variant of the nested union */
+wh_Packet_version_exchange           versionExchange;
+wh_Packet_cipher_any_req             cipherAnyReq;
+wh_Packet_cipher_aescbc_req          cipherAesCbcReq;
+wh_Packet_cipher_aesgcm_req          cipherAesGcmReq;
+wh_Packet_pk_any_req                 pkAnyReq;
+wh_Packet_pk_rsakg_req               pkRsakgReq;
+wh_Packet_pk_rsa_req                 pkRsaReq;
+wh_Packet_pk_rsa_get_size_req        pkRsaGetSizeReq;
+wh_Packet_pk_eckg_req                pkEckgReq;
+wh_Packet_pk_ecdh_req                pkEcdhReq;
+wh_Packet_pk_ecc_sign_req            pkEccSignReq;
+wh_Packet_pk_ecc_verify_req          pkEccVerifyReq;
+wh_Packet_pk_ecc_check_req           pkEccCheckReq;
+wh_Packet_pk_curve25519kg_req        pkCurve25519kgReq;
+wh_Packet_pk_curve25519kg_res        pkCurve25519kgRes;
+wh_Packet_pk_curve25519_req          pkCurve25519Req;
+wh_Packet_pk_curve25519_res          pkCurve25519Res;
+wh_Packet_rng_req                    rngReq;
+wh_Packet_cmac_req                   cmacReq;
+wh_Packet_key_cache_req              keyCacheReq;
+wh_Packet_key_evict_req              keyEvictReq;
+wh_Packet_key_commit_req             keyCommitReq;
+wh_Packet_key_export_req             keyExportReq;
+wh_Packet_key_erase_req              keyEraseReq;
+wh_Packet_counter_init_req           counterInitReq;
+wh_Packet_counter_increment_req      counterIncrementReq;
+wh_Packet_counter_read_req           counterReadReq;
+wh_Packet_counter_destroy_req        counterDestroyReq;
+wh_Packet_cipher_aescbc_res          cipherAesCbcRes;
+wh_Packet_cipher_aesgcm_res          cipherAesGcmRes;
+wh_Packet_pk_rsakg_res               pkRsakgRes;
+wh_Packet_pk_rsa_res                 pkRsaRes;
+wh_Packet_pk_rsa_get_size_res        pkRsaGetSizeRes;
+wh_Packet_pk_eckg_res                pkEckgRes;
+wh_Packet_pk_ecdh_res                pkEcdhRes;
+wh_Packet_pk_ecc_sign_res            pkEccSignRes;
+wh_Packet_pk_ecc_verify_res          pkEccVerifyRes;
+wh_Packet_pk_ecc_check_res           pkEccCheckRes;
+wh_Packet_rng_res                    rngRes;
+wh_Packet_cmac_res                   cmacRes;
+wh_Packet_key_cache_res              keyCacheRes;
+wh_Packet_key_evict_res              keyEvictRes;
+wh_Packet_key_commit_res             keyCommitRes;
+wh_Packet_key_export_res             keyExportRes;
+wh_Packet_key_erase_res              keyEraseRes;
+wh_Packet_counter_init_res           counterInitRes;
+wh_Packet_counter_increment_res      counterIncrementRes;
+wh_Packet_counter_read_res           counterReadRes;
+#ifdef WOLFHSM_SHE_EXTENSION
+wh_Packet_she_set_uid_req            sheSetUidReq;
+wh_Packet_she_secure_boot_init_req   sheSecureBootInitReq;
+wh_Packet_she_secure_boot_init_res   sheSecureBootInitRes;
+wh_Packet_she_secure_boot_update_req sheSecureBootUpdateReq;
+wh_Packet_she_secure_boot_update_res sheSecureBootUpdateRes;
+wh_Packet_she_secure_boot_finish_res sheSecureBootFinishRes;
+wh_Packet_she_get_status_res         sheGetStatusRes;
+wh_Packet_she_load_key_req           sheLoadKeyReq;
+wh_Packet_she_load_key_res           sheLoadKeyRes;
+wh_Packet_she_load_plain_key_req     sheLoadPlainKeyReq;
+wh_Packet_she_export_ram_key_res     sheExportRamKeyRes;
+wh_Packet_she_init_rng_res           sheInitRngRes;
+wh_Packet_she_rnd_res                sheRndRes;
+wh_Packet_she_extend_seed_req        sheExtendSeedReq;
+wh_Packet_she_extend_seed_res        sheExtendSeedRes;
+wh_Packet_she_enc_ecb_req            sheEncEcbReq;
+wh_Packet_she_enc_ecb_res            sheEncEcbRes;
+wh_Packet_she_enc_cbc_req            sheEncCbcReq;
+wh_Packet_she_enc_cbc_res            sheEncCbcRes;
+wh_Packet_she_enc_ecb_req            sheDecEcbReq;
+wh_Packet_she_enc_ecb_res            sheDecEcbRes;
+wh_Packet_she_enc_cbc_req            sheDecCbcReq;
+wh_Packet_she_enc_cbc_res            sheDecCbcRes;
+wh_Packet_she_gen_mac_req            sheGenMacReq;
+wh_Packet_she_gen_mac_res            sheGenMacRes;
+wh_Packet_she_verify_mac_req         sheVerifyMacReq;
+wh_Packet_she_verify_mac_res         sheVerifyMacRes;
+#endif /* WOLFHSM_SHE_EXTENSION */
+
+
+#endif /* WH_TEST_CHECK_STRUCT_PADDING_H_ */

--- a/test/wh_test_clientserver.h
+++ b/test/wh_test_clientserver.h
@@ -19,6 +19,9 @@
 #ifndef WH_TEST_CLIENTSERVER_H_
 #define WH_TEST_CLIENTSERVER_H_
 
+#include "wolfhsm/wh_server.h"
+#include "wolfhsm/wh_client.h"
+
 /*
  * Runs the client/server async tests in a single thread using a memory
  * transport backend.

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -106,7 +106,6 @@ int whTest_CryptoClientConfig(whClientConfig* config)
         0x17, 0xad, 0x2b, 0x41, 0x7b, 0xe6, 0x6c, 0x37, 0x10};
     uint8_t knownCmacTag[] = {0x51, 0xf0, 0xbe, 0xbf, 0x7e, 0x3b, 0x9d, 0x92,
         0xfc, 0x49, 0x74, 0x17, 0x79, 0x36, 0x3c, 0xfe};
-    uint32_t counter;
 
     XMEMCPY(plainText, PLAINTEXT, sizeof(plainText));
 
@@ -602,67 +601,7 @@ int whTest_CryptoClientConfig(whClientConfig* config)
         goto exit;
     }
     printf("CMAC SUCCESS\n");
-    /* test counters */
-    keyId = 1;
-    if ((ret = wh_Client_CounterReset(client, keyId, &counter)) != 0 || counter != 0) {
-        WH_ERROR_PRINT("Failed to wh_Client_CounterReset %d\n", ret);
-        goto exit;
-    }
-    if ((ret = wh_Client_CounterIncrement(client, keyId, &counter)) != 0 || counter != 1) {
-        WH_ERROR_PRINT("Failed to wh_Client_CounterIncrement %d\n", ret);
-        goto exit;
-    }
-    if ((ret = wh_Client_CounterRead(client, keyId, &counter)) != 0 || counter != 1) {
-        WH_ERROR_PRINT("Failed to wh_Client_CounterRead %d\n", ret);
-        goto exit;
-    }
-    if ((ret = wh_Client_CounterReset(client, keyId, &counter)) != 0 || counter != 0) {
-        WH_ERROR_PRINT("Failed to wh_Client_CounterReset %d\n", ret);
-        goto exit;
-    }
-    /* test saturation */
-    counter = 0xffffffff;
-    if ((ret = wh_Client_CounterInit(client, keyId, &counter)) != 0 || counter != 0xffffffff) {
-        WH_ERROR_PRINT("Failed to wh_Client_CounterInit %d\n", ret);
-        goto exit;
-    }
-    if ((ret = wh_Client_CounterIncrement(client, keyId, &counter)) != 0 || counter != 0xffffffff) {
-        WH_ERROR_PRINT("Failed to wh_Client_CounterIncrement %d\n", ret);
-        goto exit;
-    }
-    /* verify increment isn't using new nvm slots */
-    if ((ret = wh_Client_CounterReset(client, keyId, &counter)) != 0 || counter != 0) {
-        WH_ERROR_PRINT("Failed to wh_Client_CounterReset %d\n", ret);
-        goto exit;
-    }
-    for (i = 0; i < 64; i++) {
-        if ((ret = wh_Client_CounterIncrement(client, keyId, &counter)) != 0 || counter != i + 1) {
-            WH_ERROR_PRINT("Failed to wh_Client_CounterIncrement %d\n", ret);
-            goto exit;
-        }
-    }
-    /* destroy counter */
-    if ((ret = wh_Client_CounterDestroy(client, keyId)) != 0) {
-        WH_ERROR_PRINT("Failed to wh_Client_CounterDestroy %d\n", ret);
-        goto exit;
-    }
-    /* verify reset and destroy work and don't leak slots */
-    for (i = 0; i < 64; i++) {
-        if ((ret = wh_Client_CounterReset(client, (whNvmId)i + 1, &counter)) != 0 || counter != 0) {
-            WH_ERROR_PRINT("Failed to wh_Client_CounterReset %d\n", ret);
-            goto exit;
-        }
-        if ((ret = wh_Client_CounterDestroy(client, (whNvmId)i + 1)) != 0) {
-            WH_ERROR_PRINT("Failed to wh_Client_CounterDestroy %d\n", ret);
-            goto exit;
-        }
-    }
-    /* fail to read destroyed counter */
-    if ((ret = wh_Client_CounterRead(client, keyId, &counter)) != WH_ERROR_NOTFOUND) {
-        WH_ERROR_PRINT("Failed to wh_Client_CounterRead %d\n", ret);
-        goto exit;
-    }
-    printf("COUNTER SUCCESS\n");
+
 #ifdef WH_CFG_TEST_VERBOSE
     {
         int32_t  server_rc       = 0;

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -530,6 +530,7 @@ int whTest_CryptoClientConfig(whClientConfig* config)
         ret = -1;
         goto exit;
     }
+    printf("CURVE25519 SUCCESS\n");
     /* test cmac */
     if((ret = wc_InitCmac_ex(cmac, knownCmacKey, sizeof(knownCmacKey), WC_CMAC_AES, NULL, NULL, WOLFHSM_DEV_ID)) != 0) {
         WH_ERROR_PRINT("Failed to wc_InitCmac_ex %d\n", ret);

--- a/wolfhsm/wh_client.h
+++ b/wolfhsm/wh_client.h
@@ -615,7 +615,7 @@ int wh_Client_AesCmacVerify(Cmac* cmac, const byte* check, word32 checkSz,
  * @return int Returns 0 on success or a negative error code on failure.
  */
 int wh_Client_SetKeyCmac(Cmac* key, whNvmId keyId);
-#endif
+#endif /* ! WOLFHSM_NO_CRYPTO */
 
 /* Counter functions */
 int wh_Client_CounterInitRequest(whClientContext* c, whNvmId counterId,

--- a/wolfhsm/wh_common.h
+++ b/wolfhsm/wh_common.h
@@ -35,7 +35,7 @@
 /** Resource allocations */
 enum WOLFHSM_NUM_ENUM {
     WOLFHSM_NUM_COUNTERS = 8,       /* Number of non-volatile 32-bit counters */
-    WOLFHSM_NUM_RAMKEYS = 16,        /* Number of RAM keys */
+    WOLFHSM_NUM_RAMKEYS = 8,        /* Number of RAM keys */
     WOLFHSM_NUM_NVMOBJECTS = 32,    /* Number of NVM objects in the directory */
     WOLFHSM_NUM_MANIFESTS = 8,      /* Number of compiletime manifests */
     WOLFHSM_KEYCACHE_BUFSIZE = 1200, /* Size in bytes of key cache buffer  */

--- a/wolfhsm/wh_message_comm.h
+++ b/wolfhsm/wh_message_comm.h
@@ -27,6 +27,7 @@
 #define WOLFHSM_WH_MESSAGE_COMM_H_
 
 #include <stdint.h>
+#include "wolfhsm/wh_comm.h"
 
 /* Comm component message kinds */
 enum WH_MESSAGE_COMM_ACTION_ENUM {


### PR DESCRIPTION
- Decreased `WOLFHSM_NUM_RAMKEYS` from 16 to 8 for smaller defaults
- Moved counter tests to `wh_test_clientserver.c`
- No longer protecting client counter and keymgr APIs with `WOLFHSM_NO_CRYPTO` (that macro should only mean we aren't building with wolfcrypt suppport)
- Removes use of `XMEMCPY` from functions that are used when `WOLFHSM_NO_CRYPTO` is defined. This is a temporary workaround, but right now since `XMEMCPY` is defined in `user_settings.h`, which is not included when `WOLFHSM_NO_CRYPTO` is defined, then we get compiler errors. If we want `XMEMCPY` and `Xwhatever()` to be a thing in wolfHSM we are going to need to do a little bit of work around settings/configuration to make that possible when decoupled from wolfCrypt.
- Added missing includes and a missing printf 