### PR TITLE
refactor the HSM server and keystore to handle a

### DIFF
--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -55,9 +55,9 @@ static int hsmCacheKeyRsa(whServerContext* server, RsaKey* key, whKeyId* outId)
     /* wc_RsaKeyToDer doesn't have a length check option so we need to just pass
      * the big key size if compiled */
 #ifdef WOLFHSM_SEPARATE_BIG_CACHE
-    uint16_t keySz = WOLFHSM_CFG_SERVER_KEYCACHE_BIG_BUFSIZE;
+    const uint16_t keySz = WOLFHSM_CFG_SERVER_KEYCACHE_BIG_BUFSIZE;
 #else
-    uint16_t keySz = WOLFHSM_CFG_SERVER_KEYCACHE_BUFSIZE;
+    const uint16_t keySz = WOLFHSM_CFG_SERVER_KEYCACHE_BUFSIZE;
 #endif
     whKeyId keyId = WH_KEYTYPE_CRYPTO;
     /* get a free slot */
@@ -214,8 +214,9 @@ static int hsmCacheKeyCurve25519(whServerContext* server, curve25519_key* key,
     word32 privSz = CURVE25519_KEYSIZE;
     word32 pubSz = CURVE25519_KEYSIZE;
     whKeyId keyId = WH_KEYTYPE_CRYPTO;
+    const uint16_t keySz = CURVE25519_KEYSIZE * 2;
     /* get a free slot */
-    ret = hsmCacheFindSlotAndZero(server, CURVE25519_KEYSIZE * 2, &cacheBuf,
+    ret = hsmCacheFindSlotAndZero(server, keySz, &cacheBuf,
         &cacheMeta);
     if (ret == 0)
         ret = hsmGetUniqueId(server, &keyId);
@@ -227,7 +228,7 @@ static int hsmCacheKeyCurve25519(whServerContext* server, curve25519_key* key,
     if (ret == 0) {
         /* set meta */
         cacheMeta->id = keyId;
-        cacheMeta->len = CURVE25519_KEYSIZE * 2;
+        cacheMeta->len = keySz;
         /* export keyId */
         *outId = keyId;
     }

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -49,25 +49,30 @@
 #ifndef NO_RSA
 static int hsmCacheKeyRsa(whServerContext* server, RsaKey* key, whKeyId* outId)
 {
+    uint8_t* cacheBuf;
+    whNvmMetadata* cacheMeta;
     int ret = 0;
-    int slotIdx = 0;
+    /* wc_RsaKeyToDer doesn't have a length check option so we need to just pass
+     * the big key size if compiled */
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+    uint16_t keySz = WOLFHSM_CFG_SERVER_KEYCACHE_BIG_BUFSIZE;
+#else
+    uint16_t keySz = WOLFHSM_CFG_SERVER_KEYCACHE_BUFSIZE;
+#endif
     whKeyId keyId = WH_KEYTYPE_CRYPTO;
     /* get a free slot */
-    ret = slotIdx = hsmCacheFindSlot(server);
-    if (ret >= 0) {
+    ret = hsmCacheFindSlotAndZero(server, keySz, &cacheBuf, &cacheMeta);
+    if (ret == 0)
         ret = hsmGetUniqueId(server, &keyId);
-    }
     if (ret == 0) {
         /* export key */
         /* TODO: Fix wolfCrypto to allow KeyToDer when KEY_GEN is NOT set */
-        XMEMSET((uint8_t*)&server->cache[slotIdx], 0, sizeof(whServerCacheSlot));
-        ret = wc_RsaKeyToDer(key, server->cache[slotIdx].buffer,
-            WOLFHSM_CFG_SERVER_KEYCACHE_BUFSIZE);
+        ret = wc_RsaKeyToDer(key, cacheBuf, keySz);
     }
     if (ret > 0) {
         /* set meta */
-        server->cache[slotIdx].meta->id = keyId;
-        server->cache[slotIdx].meta->len = ret;
+        cacheMeta->id = keyId;
+        cacheMeta->len = ret;
         /* export keyId */
         *outId = keyId;
         ret = 0;
@@ -77,21 +82,21 @@ static int hsmCacheKeyRsa(whServerContext* server, RsaKey* key, whKeyId* outId)
 
 static int hsmLoadKeyRsa(whServerContext* server, RsaKey* key, whKeyId keyId)
 {
+    uint8_t* cacheBuf;
+    whNvmMetadata* cacheMeta;
     int ret = 0;
-    int slotIdx = 0;
     uint32_t idx = 0;
-    uint32_t size;
     keyId |= (WH_KEYTYPE_CRYPTO | (server->comm->client_id << 8));
     /* freshen the key */
-    ret = slotIdx = hsmFreshenKey(server, keyId);
+    ret = hsmFreshenKey(server, keyId, &cacheBuf, &cacheMeta);
     /* decode the key */
-    if (ret >= 0) {
-        size = WOLFHSM_CFG_SERVER_KEYCACHE_BUFSIZE;
-        ret = wc_RsaPrivateKeyDecode(server->cache[slotIdx].buffer, (word32*)&idx, key,
-            size);
+    if (ret == 0) {
+        ret = wc_RsaPrivateKeyDecode(cacheBuf, (word32*)&idx, key,
+            cacheMeta->len);
     }
     return ret;
 }
+
 #ifdef WOLFSSL_KEY_GEN
 static int hsmCryptoRsaKeyGen(whServerContext* server, whPacket* packet,
     uint16_t* size)
@@ -99,7 +104,8 @@ static int hsmCryptoRsaKeyGen(whServerContext* server, whPacket* packet,
     int ret;
     whKeyId keyId = WH_KEYID_ERASED;
     /* init the rsa key */
-    ret = wc_InitRsaKey_ex(server->crypto->algoCtx.rsa, NULL, server->crypto->devId);
+    ret = wc_InitRsaKey_ex(server->crypto->algoCtx.rsa, NULL,
+        server->crypto->devId);
     /* make the rsa key with the given params */
     if (ret == 0) {
 #ifdef DEBUG_CRYPTOCB_VERBOSE
@@ -139,7 +145,8 @@ static int hsmCryptoRsaFunction(whServerContext* server, whPacket* packet,
     byte* in = (uint8_t*)(&packet->pkRsaReq + 1);
     byte* out = (uint8_t*)(&packet->pkRsaRes + 1);
     /* init rsa key */
-    ret = wc_InitRsaKey_ex(server->crypto->algoCtx.rsa, NULL, server->crypto->devId);
+    ret = wc_InitRsaKey_ex(server->crypto->algoCtx.rsa, NULL,
+        server->crypto->devId);
     /* load the key from the keystore */
     if (ret == 0) {
         ret = hsmLoadKeyRsa(server, server->crypto->algoCtx.rsa,
@@ -176,7 +183,8 @@ static int hsmCryptoRsaGetSize(whServerContext* server, whPacket* packet,
 {
     int ret;
     /* init rsa key */
-    ret = wc_InitRsaKey_ex(server->crypto->algoCtx.rsa, NULL, server->crypto->devId);
+    ret = wc_InitRsaKey_ex(server->crypto->algoCtx.rsa, NULL,
+        server->crypto->devId);
     /* load the key from the keystore */
     if (ret == 0) {
         ret = hsmLoadKeyRsa(server, server->crypto->algoCtx.rsa,
@@ -200,27 +208,26 @@ static int hsmCryptoRsaGetSize(whServerContext* server, whPacket* packet,
 static int hsmCacheKeyCurve25519(whServerContext* server, curve25519_key* key,
     whKeyId* outId)
 {
+    uint8_t* cacheBuf;
+    whNvmMetadata* cacheMeta;
     int ret;
-    int slotIdx = 0;
     word32 privSz = CURVE25519_KEYSIZE;
     word32 pubSz = CURVE25519_KEYSIZE;
     whKeyId keyId = WH_KEYTYPE_CRYPTO;
     /* get a free slot */
-    ret = slotIdx = hsmCacheFindSlot(server);
-    if (ret >= 0) {
+    ret = hsmCacheFindSlotAndZero(server, CURVE25519_KEYSIZE * 2, &cacheBuf,
+        &cacheMeta);
+    if (ret == 0)
         ret = hsmGetUniqueId(server, &keyId);
-    }
     if (ret == 0) {
-        XMEMSET((uint8_t*)&server->cache[slotIdx], 0, sizeof(whServerCacheSlot));
         /* export key */
-        ret = wc_curve25519_export_key_raw(key,
-            server->cache[slotIdx].buffer + CURVE25519_KEYSIZE, &privSz,
-            server->cache[slotIdx].buffer, &pubSz);
+        ret = wc_curve25519_export_key_raw(key, cacheBuf + CURVE25519_KEYSIZE,
+            &privSz, cacheBuf, &pubSz);
     }
     if (ret == 0) {
         /* set meta */
-        server->cache[slotIdx].meta->id = keyId;
-        server->cache[slotIdx].meta->len = CURVE25519_KEYSIZE * 2;
+        cacheMeta->id = keyId;
+        cacheMeta->len = CURVE25519_KEYSIZE * 2;
         /* export keyId */
         *outId = keyId;
     }
@@ -230,22 +237,21 @@ static int hsmCacheKeyCurve25519(whServerContext* server, curve25519_key* key,
 static int hsmLoadKeyCurve25519(whServerContext* server, curve25519_key* key,
     whKeyId keyId)
 {
+    uint8_t* cacheBuf;
+    whNvmMetadata* cacheMeta;
     int ret = 0;
-    int slotIdx = 0;
     uint32_t privSz = CURVE25519_KEYSIZE;
     uint32_t pubSz = CURVE25519_KEYSIZE;
     keyId |= WH_KEYTYPE_CRYPTO;
     /* freshen the key */
-    ret = slotIdx = hsmFreshenKey(server, keyId);
+    ret = hsmFreshenKey(server, keyId, &cacheBuf, &cacheMeta);
     /* decode the key */
-    if (ret >= 0) {
-        ret = wc_curve25519_import_public(server->cache[slotIdx].buffer,
-            (word32)pubSz, key);
-    }
+    if (ret == 0)
+        ret = wc_curve25519_import_public(cacheBuf, (word32)pubSz, key);
     /* only import private if what we got back holds 2 keys */
-    if (ret == 0 && server->cache[slotIdx].meta->len == CURVE25519_KEYSIZE * 2) {
-        ret = wc_curve25519_import_private(
-            server->cache[slotIdx].buffer + pubSz, (word32)privSz, key);
+    if (ret == 0 && cacheMeta->len == CURVE25519_KEYSIZE * 2) {
+        ret = wc_curve25519_import_private( cacheBuf + pubSz, (word32)privSz,
+            key);
     }
     return ret;
 }
@@ -266,8 +272,8 @@ static int hsmCryptoCurve25519KeyGen(whServerContext* server, whPacket* packet,
     }
     /* cache the generated key */
     if (ret == 0) {
-        ret = hsmCacheKeyCurve25519(server, server->crypto->algoCtx.curve25519Private,
-            &keyId);
+        ret = hsmCacheKeyCurve25519(server,
+            server->crypto->algoCtx.curve25519Private, &keyId);
     }
     /* set the assigned id */
     wc_curve25519_free(server->crypto->algoCtx.curve25519Private);
@@ -331,8 +337,9 @@ static int hsmCryptoCurve25519(whServerContext* server, whPacket* packet,
 #ifdef HAVE_ECC
 static int hsmCacheKeyEcc(whServerContext* server, ecc_key* key, whKeyId* outId)
 {
+    uint8_t* cacheBuf;
+    whNvmMetadata* cacheMeta;
     int ret;
-    int slotIdx = 0;
     word32 qxLen = 0;
     word32 qyLen = 0;
     word32 qdLen = 0;
@@ -341,22 +348,21 @@ static int hsmCacheKeyEcc(whServerContext* server, ecc_key* key, whKeyId* outId)
     byte* qyBuf = NULL;
     byte* qdBuf = NULL;
     /* get a free slot */
-    ret = slotIdx = hsmCacheFindSlot(server);
-    if (ret >= 0) {
+    ret = hsmCacheFindSlotAndZero(server, qxLen + qyLen + qdLen, &cacheBuf,
+        &cacheMeta);
+    if (ret == 0)
         ret = hsmGetUniqueId(server, &keyId);
-    }
     /* export key */
     if (ret == 0) {
-        XMEMSET((uint8_t*)&server->cache[slotIdx], 0, sizeof(whServerCacheSlot));
         if (key->type != ECC_PRIVATEKEY_ONLY) {
             qxLen = qyLen = key->dp->size;
-            qxBuf = server->cache[slotIdx].buffer;
+            qxBuf = cacheBuf;
             qyBuf = qxBuf + qxLen;
         }
         if (key->type == ECC_PRIVATEKEY_ONLY || key->type == ECC_PRIVATEKEY) {
             qdLen = key->dp->size;
             if (key->type == ECC_PRIVATEKEY_ONLY) {
-                qdBuf = server->cache[slotIdx].buffer;
+                qdBuf = cacheBuf;
             }
             else {
                 qdBuf = qyBuf + qyLen;
@@ -367,8 +373,8 @@ static int hsmCacheKeyEcc(whServerContext* server, ecc_key* key, whKeyId* outId)
     }
     if (ret == 0) {
         /* set meta */
-        server->cache[slotIdx].meta->id = keyId;
-        server->cache[slotIdx].meta->len = qxLen + qyLen + qdLen;
+        cacheMeta->id = keyId;
+        cacheMeta->len = qxLen + qyLen + qdLen;
         /* export keyId */
         *outId = keyId;
     }
@@ -378,8 +384,9 @@ static int hsmCacheKeyEcc(whServerContext* server, ecc_key* key, whKeyId* outId)
 static int hsmLoadKeyEcc(whServerContext* server, ecc_key* key, uint16_t keyId,
     int curveId)
 {
+    uint8_t* cacheBuf;
+    whNvmMetadata* cacheMeta;
     int ret;
-    int slotIdx = 0;
     int curveIdx;
     word32 qxLen = 0;
     word32 qyLen = 0;
@@ -390,7 +397,7 @@ static int hsmLoadKeyEcc(whServerContext* server, ecc_key* key, uint16_t keyId,
     byte* qdBuf = NULL;
     keyId |= WH_KEYTYPE_CRYPTO;
     /* freshen the key */
-    ret = slotIdx = hsmFreshenKey(server, keyId);
+    ret = hsmFreshenKey(server, keyId, &cacheBuf, &cacheMeta);
     /* get the size by curveId */
     if (ret >= 0) {
         ret = curveIdx = wc_ecc_get_curve_idx(curveId);
@@ -402,20 +409,20 @@ static int hsmLoadKeyEcc(whServerContext* server, ecc_key* key, uint16_t keyId,
     if (ret >= 0) {
         /* determine which buffers should be set by size, wc_ecc_import_unsigned
          * will set the key type accordingly */
-        if (server->cache[slotIdx].meta->len == keySz * 3) {
+        if (cacheMeta->len == keySz * 3) {
             qxLen = qyLen = qdLen = keySz;
-            qxBuf = server->cache[slotIdx].buffer;
+            qxBuf = cacheBuf;
             qyBuf = qxBuf + qxLen;
             qdBuf = qyBuf + qyLen;
         }
-        else if (server->cache[slotIdx].meta->len == keySz * 2) {
+        else if (cacheMeta->len == keySz * 2) {
             qxLen = qyLen = keySz;
-            qxBuf = server->cache[slotIdx].buffer;
+            qxBuf = cacheBuf;
             qyBuf = qxBuf + qxLen;
         }
         else {
             qxLen = qyLen = qdLen = keySz;
-            qdBuf = server->cache[slotIdx].buffer;
+            qdBuf = cacheBuf;
         }
         ret = wc_ecc_import_unsigned(key, qxBuf, qyBuf, qdBuf, curveId);
     }
@@ -437,8 +444,10 @@ static int hsmCryptoEcKeyGen(whServerContext* server, whPacket* packet,
             packet->pkEckgReq.curveId);
     }
     /* cache the generated key */
-    if (ret == 0)
-        ret = hsmCacheKeyEcc(server, server->crypto->algoCtx.eccPrivate, &keyId);
+    if (ret == 0) {
+        ret = hsmCacheKeyEcc(server, server->crypto->algoCtx.eccPrivate,
+            &keyId);
+    }
     /* set the assigned id */
     wc_ecc_free(server->crypto->algoCtx.eccPrivate);
     if (ret == 0) {
@@ -468,8 +477,10 @@ static int hsmCryptoEcdh(whServerContext* server, whPacket* packet,
             packet->pkEcdhReq.privateKeyId, packet->pkEcdhReq.curveId);
     }
     /* set rng */
-    if (ret == 0)
-        ret = wc_ecc_set_rng(server->crypto->algoCtx.eccPrivate, server->crypto->rng);
+    if (ret == 0) {
+        ret = wc_ecc_set_rng(server->crypto->algoCtx.eccPrivate,
+            server->crypto->rng);
+    }
     /* load the public key */
     if (ret == 0) {
         ret = hsmLoadKeyEcc(server, server->crypto->pubKey.eccPublic,
@@ -540,7 +551,8 @@ static int hsmCryptoEcdsaVerify(whServerContext* server, whPacket* packet,
     /* verify the signature */
     if (ret == 0) {
         ret = wc_ecc_verify_hash(sig, packet->pkEccVerifyReq.sigSz, hash,
-            packet->pkEccVerifyReq.hashSz, &res, server->crypto->pubKey.eccPublic);
+            packet->pkEccVerifyReq.hashSz, &res,
+            server->crypto->pubKey.eccPublic);
     }
     wc_ecc_free(server->crypto->pubKey.eccPublic);
     if (ret == 0) {
@@ -603,8 +615,10 @@ static int hsmCryptoAesCbc(whServerContext* server, whPacket* packet,
         }
     }
     /* init key with possible hardware */
-    if (ret == 0)
-        ret = wc_AesInit(server->crypto->algoCtx.aes, NULL, server->crypto->devId);
+    if (ret == 0) {
+        ret = wc_AesInit(server->crypto->algoCtx.aes, NULL,
+            server->crypto->devId);
+    }
     /* load the key */
     if (ret == 0) {
         ret = wc_AesSetKey(server->crypto->algoCtx.aes, key,
@@ -662,8 +676,10 @@ static int hsmCryptoAesGcm(whServerContext* server, whPacket* packet,
         }
     }
     /* init key with possible hardware */
-    if (ret == 0)
-        ret = wc_AesInit(server->crypto->algoCtx.aes, NULL, server->crypto->devId);
+    if (ret == 0) {
+        ret = wc_AesInit(server->crypto->algoCtx.aes, NULL,
+            server->crypto->devId);
+    }
     /* load the key */
     if (ret == 0) {
         ret = wc_AesGcmSetKey(server->crypto->algoCtx.aes, key,
@@ -681,8 +697,8 @@ static int hsmCryptoAesGcm(whServerContext* server, whPacket* packet,
             /* copy authTagSz since it will be overwritten */
             packet->cipherAesGcmRes.authTagSz =
                 packet->cipherAesGcmReq.authTagSz;
-            ret = wc_AesGcmEncrypt(server->crypto->algoCtx.aes, out, in, len, iv,
-                packet->cipherAesGcmReq.ivSz, authTag,
+            ret = wc_AesGcmEncrypt(server->crypto->algoCtx.aes, out, in, len,
+                iv, packet->cipherAesGcmReq.ivSz, authTag,
                 packet->cipherAesGcmReq.authTagSz, authIn,
                 packet->cipherAesGcmReq.authInSz);
         }
@@ -724,6 +740,9 @@ static int hsmCryptoCmac(whServerContext* server, whPacket* packet,
     byte* key = in + packet->cmacReq.inSz;
     byte* out = (uint8_t*)(&packet->cmacRes + 1);
     whNvmMetadata meta[1] = {{0}};
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+    uint8_t moveToBigCache = 0;
+#endif
     /* do oneshot if all fields are present */
     if (packet->cmacReq.inSz != 0 && packet->cmacReq.keySz != 0 &&
         packet->cmacReq.outSz != 0) {
@@ -753,6 +772,9 @@ static int hsmCryptoCmac(whServerContext* server, whPacket* packet,
              * overwrite the existing key on exit */
             if (len == AES_128_KEY_SIZE || len == AES_192_KEY_SIZE ||
                 len == AES_256_KEY_SIZE) {
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+                moveToBigCache = 1;
+#endif
                 XMEMCPY(tmpKey, (uint8_t*)server->crypto->algoCtx.cmac, len);
                 /* type is not a part of the update call, assume AES */
                 ret = wc_InitCmac_ex(server->crypto->algoCtx.cmac, tmpKey, len,
@@ -807,6 +829,12 @@ static int hsmCryptoCmac(whServerContext* server, whPacket* packet,
                 keyId = WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
                     server->comm->client_id, packet->cmacReq.keyId);
             }
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+            /* evict the aes sized key in the normal cache */
+            if (moveToBigCache == 1) {
+                ret = hsmEvictKey(server, keyId);
+            }
+#endif
             meta->id = keyId;
             meta->len = sizeof(server->crypto->algoCtx.cmac);
             ret = hsmCacheKey(server, meta, (uint8_t*)server->crypto->algoCtx.cmac);

--- a/src/wh_server_keystore.c
+++ b/src/wh_server_keystore.c
@@ -510,7 +510,7 @@ int hsmEvictKey(whServerContext* server, whNvmId keyId)
 
 int hsmCommitKey(whServerContext* server, whNvmId keyId)
 {
-    uint32_t* slotCommited;
+    uint8_t* slotCommited;
     uint8_t* slotBuf;
     whNvmMetadata* slotMeta;
     int i;
@@ -534,7 +534,7 @@ int hsmCommitKey(whServerContext* server, whNvmId keyId)
     if (i >= WOLFHSM_CFG_SERVER_KEYCACHE_COUNT) {
         for (i = 0; i < WOLFHSM_CFG_SERVER_KEYCACHE_BIG_COUNT; i++) {
             if (server->bigCache[i].meta->id == keyId) {
-                slotCommited = &server->cache[i].commited;
+                slotCommited = &server->bigCache[i].commited;
                 slotBuf = server->bigCache[i].buffer;
                 slotMeta = server->bigCache[i].meta;
                 break;

--- a/src/wh_server_keystore.c
+++ b/src/wh_server_keystore.c
@@ -65,6 +65,16 @@ int hsmGetUniqueId(whServerContext* server, whNvmId* outId)
         /* try again if match */
         if (i < WOLFHSM_CFG_SERVER_KEYCACHE_COUNT)
             continue;
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+        /* check against big cache keys */
+        for (i = 0; i < WOLFHSM_CFG_SERVER_KEYCACHE_BIG_COUNT; i++) {
+            if (buildId == server->bigCache[i].meta->id)
+                break;
+        }
+        /* try again if match */
+        if (i < WOLFHSM_CFG_SERVER_KEYCACHE_BIG_COUNT)
+            continue;
+#endif
         /* if keyId exists */
         ret = wh_Nvm_List(server->nvm, WH_NVM_ACCESS_ANY,
             WH_NVM_FLAGS_ANY, buildId, &keyCount,
@@ -82,32 +92,78 @@ int hsmGetUniqueId(whServerContext* server, whNvmId* outId)
     return ret;
 }
 
-/* return the index of a free slot */
-int hsmCacheFindSlot(whServerContext* server)
+/* find an available slot for the size, return the slots buffer and meta */
+int hsmCacheFindSlotAndZero(whServerContext* server, uint16_t keySz,
+    uint8_t** outBuf, whNvmMetadata** outMeta)
 {
     int i;
     int foundIndex = -1;
-    for (i = 0; i < WOLFHSM_CFG_SERVER_KEYCACHE_COUNT; i++) {
-        /* check for empty slot or rewrite slot */
-        if (foundIndex == -1 && server->cache[i].meta->id ==
-            WH_KEYID_ERASED) {
-            foundIndex = i;
-            break;
-        }
+    if (server == NULL || (keySz > WOLFHSM_CFG_SERVER_KEYCACHE_BUFSIZE
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+        && keySz > WOLFHSM_CFG_SERVER_KEYCACHE_BIG_BUFSIZE
+#endif
+        )) {
+        return WH_ERROR_BADARGS;
     }
-    /* if no empty slots, check for a commited key we can evict */
-    if (foundIndex == -1) {
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+    if (keySz <= WOLFHSM_CFG_SERVER_KEYCACHE_BUFSIZE)
+#endif
+    {
         for (i = 0; i < WOLFHSM_CFG_SERVER_KEYCACHE_COUNT; i++) {
-            if (server->cache[i].commited == 1) {
+            /* check for empty slot or rewrite slot */
+            if (foundIndex == -1 && server->cache[i].meta->id ==
+                WH_KEYID_ERASED) {
                 foundIndex = i;
                 break;
             }
         }
+        /* if no empty slots, check for a commited key we can evict */
+        if (foundIndex == -1) {
+            for (i = 0; i < WOLFHSM_CFG_SERVER_KEYCACHE_COUNT; i++) {
+                if (server->cache[i].commited == 1) {
+                    foundIndex = i;
+                    break;
+                }
+            }
+        }
+        /* zero the cache slot and set the output buffers */
+        if (foundIndex >= 0) {
+            XMEMSET(&server->cache[foundIndex], 0, sizeof(whServerCacheSlot));
+            *outBuf = server->cache[foundIndex].buffer;
+            *outMeta = server->cache[foundIndex].meta;
+        }
     }
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+    else {
+        for (i = 0; i < WOLFHSM_CFG_SERVER_KEYCACHE_BIG_COUNT; i++) {
+            /* check for empty slot or rewrite slot */
+            if (foundIndex == -1 && server->bigCache[i].meta->id ==
+                WH_KEYID_ERASED) {
+                foundIndex = i;
+                break;
+            }
+        }
+        /* if no empty slots, check for a commited key we can evict */
+        if (foundIndex == -1) {
+            for (i = 0; i < WOLFHSM_CFG_SERVER_KEYCACHE_BIG_COUNT; i++) {
+                if (server->bigCache[i].commited == 1) {
+                    foundIndex = i;
+                    break;
+                }
+            }
+        }
+        if (foundIndex >= 0) {
+            XMEMSET(&server->bigCache[foundIndex], 0,
+                sizeof(whServerBigCacheSlot));
+            *outBuf = server->bigCache[foundIndex].buffer;
+            *outMeta = server->bigCache[foundIndex].meta;
+        }
+    }
+#endif /* WOLFHSM_SEPARATE_BIG_CACHE */
     /* return error if we are out of cache slots */
     if (foundIndex == -1)
         return WH_ERROR_NOSPACE;
-    return foundIndex;
+    return 0;
 }
 
 int hsmCacheKey(whServerContext* server, whNvmMetadata* meta, uint8_t* in)
@@ -117,53 +173,107 @@ int hsmCacheKey(whServerContext* server, whNvmMetadata* meta, uint8_t* in)
     /* make sure id is valid */
     if (server == NULL || meta == NULL || in == NULL ||
         (meta->id & WH_KEYID_MASK) == WH_KEYID_ERASED ||
-        meta->len > WOLFHSM_CFG_SERVER_KEYCACHE_BUFSIZE) {
+        (meta->len > WOLFHSM_CFG_SERVER_KEYCACHE_BUFSIZE
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+        && meta->len > WOLFHSM_CFG_SERVER_KEYCACHE_BIG_BUFSIZE
+#endif
+        )) {
         return WH_ERROR_BADARGS;
     }
     /* apply client_id */
     meta->id |= (server->comm->client_id << 8);
-    for (i = 0; i < WOLFHSM_CFG_SERVER_KEYCACHE_COUNT; i++) {
-        /* check for empty slot or rewrite slot */
-        if ((foundIndex == -1 &&
-            (server->cache[i].meta->id & WH_KEYID_MASK) ==
-            WH_KEYID_ERASED) ||
-            server->cache[i].meta->id == meta->id) {
-            foundIndex = i;
-        }
-    }
-    /* if no empty slots, check for a commited key we can evict */
-    if (foundIndex == -1) {
+    /* check if we need to use big cache instead */
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+    if (meta->len <= WOLFHSM_CFG_SERVER_KEYCACHE_BUFSIZE)
+#endif
+    {
         for (i = 0; i < WOLFHSM_CFG_SERVER_KEYCACHE_COUNT; i++) {
-            if (server->cache[i].commited == 1) {
+            /* check for empty slot or rewrite slot */
+            if ((foundIndex == -1 &&
+                (server->cache[i].meta->id & WH_KEYID_MASK) ==
+                WH_KEYID_ERASED) ||
+                server->cache[i].meta->id == meta->id) {
                 foundIndex = i;
-                break;
             }
         }
+        /* if no empty slots, check for a commited key we can evict */
+        if (foundIndex == -1) {
+            for (i = 0; i < WOLFHSM_CFG_SERVER_KEYCACHE_COUNT; i++) {
+                if (server->cache[i].commited == 1) {
+                    foundIndex = i;
+                    break;
+                }
+            }
+        }
+        /* write key if slot found */
+        if (foundIndex != -1) {
+            XMEMCPY((uint8_t*)server->cache[foundIndex].buffer, in, meta->len);
+            XMEMCPY((uint8_t*)server->cache[foundIndex].meta, (uint8_t*)meta,
+                sizeof(whNvmMetadata));
+            /* check if the key is already commited */
+            if (wh_Nvm_GetMetadata(server->nvm, meta->id, meta) ==
+                WH_ERROR_NOTFOUND) {
+                server->cache[foundIndex].commited = 0;
+            }
+            else
+                server->cache[foundIndex].commited = 1;
+        }
     }
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+    /* try big key cache, don't put small keys into big cache if full */
+    else {
+        for (i = 0; i < WOLFHSM_CFG_SERVER_KEYCACHE_BIG_COUNT; i++) {
+            /* check for empty slot or rewrite slot */
+            if ((foundIndex == -1 &&
+                (server->bigCache[i].meta->id & WH_KEYID_MASK) ==
+                WH_KEYID_ERASED) ||
+                server->bigCache[i].meta->id == meta->id) {
+                foundIndex = i;
+            }
+        }
+        /* if no empty slots, check for a commited key we can evict */
+        if (foundIndex == -1) {
+            for (i = 0; i < WOLFHSM_CFG_SERVER_KEYCACHE_BIG_COUNT; i++) {
+                if (server->bigCache[i].commited == 1) {
+                    foundIndex = i;
+                    break;
+                }
+            }
+        }
+        /* write key if slot found */
+        if (foundIndex != -1) {
+            XMEMCPY((uint8_t*)server->bigCache[foundIndex].buffer, in,
+                meta->len);
+            XMEMCPY((uint8_t*)server->bigCache[foundIndex].meta, (uint8_t*)meta,
+                sizeof(whNvmMetadata));
+            /* check if the key is already commited */
+            if (wh_Nvm_GetMetadata(server->nvm, meta->id, meta) ==
+                WH_ERROR_NOTFOUND) {
+                server->bigCache[foundIndex].commited = 0;
+            }
+            else
+                server->bigCache[foundIndex].commited = 1;
+        }
+    }
+#endif /* WOLFHSM_SEPARATE_BIG_CACHE */
     /* return error if we are out of cache slots */
     if (foundIndex == -1)
         return WH_ERROR_NOSPACE;
-    /* write key if slot found */
-    XMEMCPY((uint8_t*)server->cache[foundIndex].buffer, in, meta->len);
-    XMEMCPY((uint8_t*)server->cache[foundIndex].meta, (uint8_t*)meta,
-        sizeof(whNvmMetadata));
-    /* check if the key is already commited */
-    if (wh_Nvm_GetMetadata(server->nvm, meta->id, meta) == WH_ERROR_NOTFOUND)
-        server->cache[foundIndex].commited = 0;
-    else
-        server->cache[foundIndex].commited = 1;
     return 0;
 }
 
 /* try to put the specified key into cache if it isn't already, return index */
-int hsmFreshenKey(whServerContext* server, whKeyId keyId)
+int hsmFreshenKey(whServerContext* server, whKeyId keyId, uint8_t** outBuf,
+    whNvmMetadata** outMeta)
 {
     int ret = 0;
     int i;
     int foundIndex = -1;
-    uint32_t outSz = WOLFHSM_CFG_SERVER_KEYCACHE_BUFSIZE;
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+    int foundBigIndex = -1;
+#endif
     whNvmMetadata meta[1];
-    if (server == NULL || keyId == WH_KEYID_ERASED)
+    if (server == NULL || (keyId & WH_KEYID_MASK) == WH_KEYID_ERASED)
         return WH_ERROR_BADARGS;
     /* apply client_id */
     keyId |= (server->comm->client_id << 8);
@@ -173,12 +283,42 @@ int hsmFreshenKey(whServerContext* server, whKeyId keyId)
             server->cache[i].meta->id == WH_KEYID_ERASED) ||
             server->cache[i].meta->id == keyId) {
             foundIndex = i;
-            if (server->cache[i].meta->id == keyId)
-                return i;
+            if (server->cache[i].meta->id == keyId) {
+                *outBuf = server->cache[i].buffer;
+                *outMeta = server->cache[i].meta;
+                return 0;
+            }
         }
     }
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+    /* check if the key is in the big cache */
+    if (foundIndex != -1) {
+        for (i = 0; i < WOLFHSM_CFG_SERVER_KEYCACHE_BIG_COUNT; i++) {
+            /* check for empty slot or rewrite slot */
+            if ((foundBigIndex == -1 &&
+                server->bigCache[i].meta->id == WH_KEYID_ERASED) ||
+                server->bigCache[i].meta->id == keyId) {
+                foundBigIndex = i;
+                if (server->bigCache[i].meta->id == keyId) {
+                    *outBuf = server->bigCache[i].buffer;
+                    *outMeta = server->bigCache[i].meta;
+                    return 0;
+                }
+            }
+        }
+    }
+#endif /* WOLFHSM_SEPARATE_BIG_CACHE */
+    /* try to read the metadata, we need to see len so we know which cache to
+     * check */
+    ret = wh_Nvm_GetMetadata(server->nvm, keyId, meta);
+    if (ret != 0)
+        return ret;
     /* if no empty slots, check for a commited key we can evict */
-    if (foundIndex == -1) {
+    if (foundIndex == -1
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+        && meta->len <= WOLFHSM_CFG_SERVER_KEYCACHE_BUFSIZE
+#endif
+    ) {
         for (i = 0; i < WOLFHSM_CFG_SERVER_KEYCACHE_COUNT; i++) {
             if (server->cache[i].commited == 1) {
                 foundIndex = i;
@@ -186,21 +326,58 @@ int hsmFreshenKey(whServerContext* server, whKeyId keyId)
             }
         }
     }
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+    else if (meta->len <= WOLFHSM_CFG_SERVER_KEYCACHE_BIG_BUFSIZE &&
+        foundBigIndex == -1) {
+        for (i = 0; i < WOLFHSM_CFG_SERVER_KEYCACHE_BIG_COUNT; i++) {
+            if (server->bigCache[i].commited == 1) {
+                foundBigIndex = i;
+                break;
+            }
+        }
+    }
+#endif
     /* return error if we are out of cache slots */
-    if (foundIndex == -1)
+    if (foundIndex == -1
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+        && foundBigIndex == -1
+#endif
+    ) {
         return WH_ERROR_NOSPACE;
-    /* try to read the metadata */
-    ret = wh_Nvm_GetMetadata(server->nvm, keyId, meta);
-    if (ret == 0) {
+    }
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+    if (foundIndex != -1)
+#endif
+    {
         /* set meta */
         XMEMCPY((uint8_t*)server->cache[foundIndex].meta, (uint8_t*)meta,
             sizeof(meta));
         /* read the object */
-        ret = wh_Nvm_Read(server->nvm, keyId, 0, outSz,
+        ret = wh_Nvm_Read(server->nvm, keyId, 0,
+            WOLFHSM_CFG_SERVER_KEYCACHE_BUFSIZE,
             server->cache[foundIndex].buffer);
+        if (ret == 0) {
+            *outBuf = server->cache[foundIndex].buffer;
+            *outMeta = server->cache[foundIndex].meta;
+        }
     }
-    /* return index */
-    return foundIndex;
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+    else {
+        /* set meta */
+        XMEMCPY((uint8_t*)server->bigCache[foundBigIndex].meta, (uint8_t*)meta,
+            sizeof(meta));
+        /* read the object */
+        ret = wh_Nvm_Read(server->nvm, keyId, 0,
+            WOLFHSM_CFG_SERVER_KEYCACHE_BIG_BUFSIZE,
+            server->bigCache[foundBigIndex].buffer);
+        if (ret == 0) {
+            *outBuf = server->bigCache[foundBigIndex].buffer;
+            *outMeta = server->bigCache[foundBigIndex].meta;
+        }
+    }
+#endif
+    /* return read result */
+    return ret;
 }
 
 int hsmReadKey(whServerContext* server, whKeyId keyId, whNvmMetadata* outMeta,
@@ -236,6 +413,27 @@ int hsmReadKey(whServerContext* server, whKeyId keyId, whNvmMetadata* outMeta,
             return 0;
         }
     }
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+    /* check the big cache */
+    for (i = 0; i < WOLFHSM_CFG_SERVER_KEYCACHE_BIG_COUNT; i++) {
+        /* copy the meta and key before returning */
+        if (server->bigCache[i].meta->id == keyId) {
+            /* check outSz */
+            if (server->bigCache[i].meta->len > *outSz)
+                return WH_ERROR_NOSPACE;
+            if (outMeta != NULL) {
+                XMEMCPY((uint8_t*)outMeta, (uint8_t*)server->bigCache[i].meta,
+                    sizeof(whNvmMetadata));
+            }
+            if (out != NULL) {
+                XMEMCPY(out, server->bigCache[i].buffer,
+                    server->bigCache[i].meta->len);
+            }
+            *outSz = server->bigCache[i].meta->len;
+            return 0;
+        }
+    }
+#endif /* WOLFHSM_SEPARATE_BIG_CACHE */
     /* try to read the metadata */
     ret = wh_Nvm_GetMetadata(server->nvm, keyId, meta);
     if (ret == 0) {
@@ -288,36 +486,72 @@ int hsmEvictKey(whServerContext* server, whNvmId keyId)
             break;
         }
     }
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+    /* find key in big cache */
+    if (i >= WOLFHSM_CFG_SERVER_KEYCACHE_COUNT) {
+        for (i = 0; i < WOLFHSM_CFG_SERVER_KEYCACHE_BIG_COUNT; i++) {
+            /* mark key as erased */
+            if (server->bigCache[i].meta->id == keyId) {
+                server->bigCache[i].meta->id = WH_KEYID_ERASED;
+                break;
+            }
+        }
+        /* if the key wasn't found return an error */
+        if (i >= WOLFHSM_CFG_SERVER_KEYCACHE_BIG_COUNT)
+            ret = WH_ERROR_NOTFOUND;
+    }
+#else /* WOLFHSM_SEPARATE_BIG_CACHE */
     /* if the key wasn't found return an error */
     if (i >= WOLFHSM_CFG_SERVER_KEYCACHE_COUNT)
         ret = WH_ERROR_NOTFOUND;
+#endif /* !WOLFHSM_SEPARATE_BIG_CACHE */
     return ret;
 }
 
 int hsmCommitKey(whServerContext* server, whNvmId keyId)
 {
+    uint32_t* slotCommited;
+    uint8_t* slotBuf;
+    whNvmMetadata* slotMeta;
     int i;
     int ret = 0;
-    whServerCacheSlot* cacheSlot;
     /* make sure id is valid */
-    if (server == NULL || keyId == WH_KEYID_ERASED)
+    if (server == NULL || (keyId & WH_KEYID_MASK) == WH_KEYID_ERASED)
         return WH_ERROR_BADARGS;
     /* apply client_id */
     keyId |= (server->comm->client_id << 8);
     /* find key in cache */
     for (i = 0; i < WOLFHSM_CFG_SERVER_KEYCACHE_COUNT; i++) {
         if (server->cache[i].meta->id == keyId) {
-            cacheSlot = &server->cache[i];
+            slotCommited = &server->cache[i].commited;
+            slotBuf = server->cache[i].buffer;
+            slotMeta = server->cache[i].meta;
             break;
         }
     }
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+    /* find key in big cache */
+    if (i >= WOLFHSM_CFG_SERVER_KEYCACHE_COUNT) {
+        for (i = 0; i < WOLFHSM_CFG_SERVER_KEYCACHE_BIG_COUNT; i++) {
+            if (server->bigCache[i].meta->id == keyId) {
+                slotCommited = &server->cache[i].commited;
+                slotBuf = server->bigCache[i].buffer;
+                slotMeta = server->bigCache[i].meta;
+                break;
+            }
+        }
+        if (i >= WOLFHSM_CFG_SERVER_KEYCACHE_BIG_COUNT)
+            return WH_ERROR_NOTFOUND;
+    }
+#else /* WOLFHSM_SEPARATE_BIG_CACHE */
     if (i >= WOLFHSM_CFG_SERVER_KEYCACHE_COUNT)
         return WH_ERROR_NOTFOUND;
+#endif /* !WOLFHSM_SEPARATE_BIG_CACHE */
     /* add object */
-    ret = wh_Nvm_AddObjectWithReclaim(server->nvm, cacheSlot->meta,
-        cacheSlot->meta->len, cacheSlot->buffer);
+    ret = wh_Nvm_AddObjectWithReclaim(server->nvm, slotMeta, slotMeta->len,
+        slotBuf);
     if (ret == 0)
-        cacheSlot->commited = 1;
+        *slotCommited = 1;
     return ret;
 }
 
@@ -335,6 +569,17 @@ int hsmEraseKey(whServerContext* server, whNvmId keyId)
             break;
         }
     }
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+    if (i >= WOLFHSM_CFG_SERVER_KEYCACHE_COUNT) {
+        /* remove the key from the big cache if present */
+        for (i = 0; i < WOLFHSM_CFG_SERVER_KEYCACHE_BIG_COUNT; i++) {
+            if (server->bigCache[i].meta->id == keyId) {
+                server->bigCache[i].meta->id = WH_KEYID_ERASED;
+                break;
+            }
+        }
+    }
+#endif /* WOLFHSM_SEPARATE_BIG_CACHE */
     /* destroy the object */
     return wh_Nvm_DestroyObjects(server->nvm, 1, &keyId);
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -60,6 +60,9 @@ ifeq ($(SHE),1)
 CFLAGS += -DWOLFHSM_CFG_SHE_EXTENSION
 endif
 
+# seperate big keys
+CFLAGS += -DWOLFHSM_SEPARATE_BIG_CACHE
+
 # Assembly source files
 SRC_ASM +=
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -60,9 +60,6 @@ ifeq ($(SHE),1)
 CFLAGS += -DWOLFHSM_CFG_SHE_EXTENSION
 endif
 
-# seperate big keys
-CFLAGS += -DWOLFHSM_SEPARATE_BIG_CACHE
-
 # Assembly source files
 SRC_ASM +=
 

--- a/wolfhsm/wh_server.h
+++ b/wolfhsm/wh_server.h
@@ -60,7 +60,7 @@ typedef struct whServerContext_t whServerContext;
 #ifndef WOLFHSM_CFG_NO_CRYPTO
 /** Server crypto context and resource allocation */
 typedef struct whServerCacheSlot {
-    uint32_t        commited;
+    uint8_t        commited;
     whNvmMetadata   meta[1];
     uint8_t         buffer[WOLFHSM_CFG_SERVER_KEYCACHE_BUFSIZE];
 } whServerCacheSlot;

--- a/wolfhsm/wh_server.h
+++ b/wolfhsm/wh_server.h
@@ -65,13 +65,11 @@ typedef struct whServerCacheSlot {
     uint8_t         buffer[WOLFHSM_CFG_SERVER_KEYCACHE_BUFSIZE];
 } whServerCacheSlot;
 
-#ifdef WOLFHSM_SEPARATE_BIG_CACHE
 typedef struct whServerBigCacheSlot {
     uint8_t       commited;
     whNvmMetadata meta[1];
     uint8_t       buffer[WOLFHSM_CFG_SERVER_KEYCACHE_BIG_BUFSIZE];
 } whServerBigCacheSlot;
-#endif
 
 typedef struct whServerCryptoContext {
     int devId;
@@ -209,9 +207,7 @@ struct whServerContext_t {
 #ifndef WOLFHSM_CFG_NO_CRYPTO
     whServerCryptoContext*  crypto;
     whServerCacheSlot       cache[WOLFHSM_CFG_SERVER_KEYCACHE_COUNT];
-#ifdef WOLFHSM_SEPARATE_BIG_CACHE
     whServerBigCacheSlot    bigCache[WOLFHSM_CFG_SERVER_KEYCACHE_BIG_COUNT];
-#endif
 #ifdef WOLFHSM_CFG_SHE_EXTENSION
     whServerSheContext* she;
 #endif

--- a/wolfhsm/wh_server.h
+++ b/wolfhsm/wh_server.h
@@ -65,6 +65,14 @@ typedef struct whServerCacheSlot {
     uint8_t         buffer[WOLFHSM_CFG_SERVER_KEYCACHE_BUFSIZE];
 } whServerCacheSlot;
 
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+typedef struct whServerBigCacheSlot {
+    uint8_t       commited;
+    whNvmMetadata meta[1];
+    uint8_t       buffer[WOLFHSM_CFG_SERVER_KEYCACHE_BIG_BUFSIZE];
+} whServerBigCacheSlot;
+#endif
+
 typedef struct whServerCryptoContext {
     int devId;
 #ifndef WC_NO_RNG
@@ -199,8 +207,11 @@ struct whServerContext_t {
     whNvmContext* nvm;
     whCommServer  comm[1];
 #ifndef WOLFHSM_CFG_NO_CRYPTO
-    whServerCryptoContext* crypto;
+    whServerCryptoContext*  crypto;
     whServerCacheSlot       cache[WOLFHSM_CFG_SERVER_KEYCACHE_COUNT];
+#ifdef WOLFHSM_SEPARATE_BIG_CACHE
+    whServerBigCacheSlot    bigCache[WOLFHSM_CFG_SERVER_KEYCACHE_BIG_COUNT];
+#endif
 #ifdef WOLFHSM_CFG_SHE_EXTENSION
     whServerSheContext* she;
 #endif

--- a/wolfhsm/wh_server_keystore.h
+++ b/wolfhsm/wh_server_keystore.h
@@ -32,9 +32,11 @@
 #include "wolfhsm/wh_server.h"
 
 int hsmGetUniqueId(whServerContext* server, whNvmId* outId);
-int hsmCacheFindSlot(whServerContext* server);
+int hsmCacheFindSlotAndZero(whServerContext* server, uint16_t keySz,
+    uint8_t** outBuf, whNvmMetadata** outMeta);
 int hsmCacheKey(whServerContext* server, whNvmMetadata* meta, uint8_t* in);
-int hsmFreshenKey(whServerContext* server, whKeyId keyId);
+int hsmFreshenKey(whServerContext* server, whKeyId keyId, uint8_t** outBuf,
+    whNvmMetadata** outMeta);
 int hsmReadKey(whServerContext* server, whKeyId keyId, whNvmMetadata* outMeta,
     uint8_t* out, uint32_t* outSz);
 int hsmEvictKey(whServerContext* server, uint16_t keyId);

--- a/wolfhsm/wh_settings.h
+++ b/wolfhsm/wh_settings.h
@@ -94,9 +94,19 @@
 #define WOLFHSM_CFG_SERVER_KEYCACHE_COUNT  8
 #endif
 
+/* Number of big RAM keys */
+#ifndef WOLFHSM_CFG_SERVER_KEYCACHE_BIG_COUNT
+#define WOLFHSM_CFG_SERVER_KEYCACHE_BIG_COUNT  1
+#endif
+
 /* Size in bytes of each key cache buffer  */
 #ifndef WOLFHSM_CFG_SERVER_KEYCACHE_BUFSIZE
-#define WOLFHSM_CFG_SERVER_KEYCACHE_BUFSIZE 1200
+#define WOLFHSM_CFG_SERVER_KEYCACHE_BUFSIZE 256
+#endif
+
+/* Size in bytes of each big key cache buffer  */
+#ifndef WOLFHSM_CFG_SERVER_KEYCACHE_BIG_BUFSIZE
+#define WOLFHSM_CFG_SERVER_KEYCACHE_BIG_BUFSIZE 1200
 #endif
 
 /* Custom request shared defs */


### PR DESCRIPTION
seperate cache for larger keys so customers with limited memory can still store a limited number of large keys alongside their smaller keys.