### PR TITLE
cancellation bugfixes and cleanups

### DIFF
--- a/src/wh_client.c
+++ b/src/wh_client.c
@@ -300,12 +300,15 @@ int wh_Client_DisableCancel(whClientContext* c)
 
 int wh_Client_CancelRequest(whClientContext* c)
 {
-    int ret = 0;
-    if (c == NULL || c->cancelCb == NULL)
+    if (c == NULL) {
         return WH_ERROR_BADARGS;
-    /* send the cancel request */
-    ret = c->cancelCb(c->comm->seq);
-    return ret;
+    }
+
+    if (c->cancelCb == NULL) {
+        return WH_ERROR_ABORTED;
+    }
+
+    return c->cancelCb(c->comm->seq);
 }
 
 int wh_Client_CancelResponse(whClientContext* c)

--- a/src/wh_client.c
+++ b/src/wh_client.c
@@ -308,6 +308,14 @@ int wh_Client_CancelRequest(whClientContext* c)
         return WH_ERROR_ABORTED;
     }
 
+    /* Since we aren't sending this request through the standard transport, we
+     * need to update the client context's last sent "kind" to prevent the Comm
+     * Client receive function from discarding the next response as an
+     * out-of-order/corrupted message. No need to update the sequence number/ID
+     * as it will not have been incremented by the cancel operation, as it is
+     * out-of-band */
+    c->last_req_kind = WH_MESSAGE_KIND(WH_MESSAGE_GROUP_CANCEL, 0);
+
     return c->cancelCb(c->comm->seq);
 }
 

--- a/src/wh_server.c
+++ b/src/wh_server.c
@@ -143,6 +143,15 @@ int wh_Server_GetCanceledSequence(whServerContext* server, uint16_t* outSeq)
     return 0;
 }
 
+int wh_Server_SetCanceledSequence(whServerContext* server, uint16_t cancelSeq)
+{
+    if (server == NULL) {
+        return WH_ERROR_BADARGS;
+    }
+    server->cancelSeq = cancelSeq;
+    return WH_ERROR_OK;
+}
+
 static int _wh_Server_HandleCommRequest(whServerContext* server,
         uint16_t magic, uint16_t action, uint16_t seq,
         uint16_t req_size, const void* req_packet,

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -621,7 +621,7 @@ int whTest_CryptoClientConfig(whClientConfig* config)
         goto exit;
     }
 
-    /* test CMAC cancelation */
+    /* test CMAC cancellation */
     if((ret = wh_Client_EnableCancel(client)) != 0) {
         WH_ERROR_PRINT("Failed to wh_Client_EnableCancel %d\n", ret);
         goto exit;
@@ -655,7 +655,7 @@ int whTest_CryptoClientConfig(whClientConfig* config)
 #ifndef WH_CFG_TEST_NO_CUSTOM_SERVERS
     serverDelay = 0;
 #endif
-    /* test cancelable request and response work for standard CMAC request with no cancelation */
+    /* test cancelable request and response work for standard CMAC request with no cancellation */
     if((ret = wc_InitCmac_ex(cmac, knownCmacKey, sizeof(knownCmacKey), WC_CMAC_AES, NULL, NULL, WOLFHSM_DEV_ID)) != 0) {
         WH_ERROR_PRINT("Failed to wc_InitCmac_ex %d\n", ret);
         goto exit;

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -64,17 +64,27 @@ enum {
         BUFFER_SIZE = 4096,
     };
 
-int serverDelay = 0;
 
 #define PLAINTEXT "mytextisbigplain"
 
+#ifndef WH_CFG_TEST_NO_CUSTOM_SERVERS
+/* Flag causing the server loop to sleep(1) */
+int serverDelay = 0;
+#endif
+
+#if defined(WH_CFG_TEST_POSIX)
+/* pointer to expose server context cancel sequence to the client cancel
+ * callback */
 static uint16_t* cancelSeqP;
 
-static int wh_Client_CancelCb(uint16_t seq)
+/* Test client cancel callback that directly sets the sequence to cancel in the
+ * server context */
+static int _cancelCb(uint16_t seq)
 {
     *cancelSeqP = seq;
     return 0;
 }
+#endif
 
 int whTest_CryptoClientConfig(whClientConfig* config)
 {
@@ -632,7 +642,7 @@ int whTest_CryptoClientConfig(whClientConfig* config)
     serverDelay = 1;
 #endif
     if((ret = wh_Client_Cancel(client)) != 0
-#ifndef WH_CFG_TEST_NO_CUSTOM_SERVERS
+#if defined(WH_CFG_TEST_NO_CUSTOM_SERVERS)
         && ret != WH_ERROR_CANCEL_LATE
 #endif
     ) {
@@ -730,8 +740,10 @@ int whTest_CryptoServerConfig(whServerConfig* config)
         return WH_ERROR_BADARGS;
     }
 
-    /* set cancelSeqP */
+#if defined(WH_CFG_TEST_POSIX)
+    /* expose server ctx to client cancel callback */
     cancelSeqP = &server->cancelSeq;
+#endif
 
     WH_TEST_RETURN_ON_FAIL(wh_Server_Init(server, config));
     WH_TEST_RETURN_ON_FAIL(wh_Server_SetConnected(server, am_connected));
@@ -837,7 +849,7 @@ static int wh_ClientServer_MemThreadTest(void)
     }};
     whClientConfig c_conf[1] = {{
        .comm = cc_conf,
-       .cancelCb = wh_Client_CancelCb,
+       .cancelCb = _cancelCb,
     }};
     /* Server configuration/contexts */
     whTransportServerCb         tscb[1]   = {WH_TRANSPORT_MEM_SERVER_CB};

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -620,7 +620,8 @@ int whTest_CryptoClientConfig(whClientConfig* config)
         WH_ERROR_PRINT("Failed to wh_Client_KeyErase %d\n", ret);
         goto exit;
     }
-    /* test cancelation */
+
+    /* test CMAC cancelation */
     if((ret = wh_Client_EnableCancel(client)) != 0) {
         WH_ERROR_PRINT("Failed to wh_Client_EnableCancel %d\n", ret);
         goto exit;
@@ -638,8 +639,10 @@ int whTest_CryptoClientConfig(whClientConfig* config)
         goto exit;
     }
 #ifndef WH_CFG_TEST_NO_CUSTOM_SERVERS
-    /* delay the server so scheduling doesn't interfere wih the timing */
+    /* delay the server so scheduling doesn't interfere with the timing */
     serverDelay = 1;
+
+    /* TODO: use hsm pause/resume functionality on real hardware */
 #endif
     if((ret = wh_Client_Cancel(client)) != 0
 #if defined(WH_CFG_TEST_NO_CUSTOM_SERVERS)
@@ -652,7 +655,7 @@ int whTest_CryptoClientConfig(whClientConfig* config)
 #ifndef WH_CFG_TEST_NO_CUSTOM_SERVERS
     serverDelay = 0;
 #endif
-    /* test cancelable request and resposne */
+    /* test cancelable request and response work for standard CMAC request with no cancelation */
     if((ret = wc_InitCmac_ex(cmac, knownCmacKey, sizeof(knownCmacKey), WC_CMAC_AES, NULL, NULL, WOLFHSM_DEV_ID)) != 0) {
         WH_ERROR_PRINT("Failed to wc_InitCmac_ex %d\n", ret);
         goto exit;

--- a/wolfhsm/wh_client.h
+++ b/wolfhsm/wh_client.h
@@ -200,7 +200,7 @@ int wh_Client_CommInit(whClientContext* c, uint32_t* out_clientid,
 int wh_Client_CommCloseRequest(whClientContext* c);
 
 /**
- * @brief Enables request cancelation.
+ * @brief Enables request cancellation.
  *
  * This function allows subsequent requests to be canceled, the responses that
  * are normally handled by automatically by wolfCrypt must be handled with a
@@ -212,9 +212,9 @@ int wh_Client_CommCloseRequest(whClientContext* c);
 int wh_Client_EnableCancel(whClientContext* c);
 
 /**
- * @brief Disables request cancelation.
+ * @brief Disables request cancellation.
  *
- * This function disables request cancelation, making wolfCrypt automatically
+ * This function disables request cancellation, making wolfCrypt automatically
  * handle responses again.
  *
  * @param[in] c Pointer to the client context.
@@ -226,7 +226,7 @@ int wh_Client_DisableCancel(whClientContext* c);
  * @brief Cancels the previous request, currently only supports CMAC. Async
  * Request
  *
- * This function sends a cancelation request to the server to cancel the
+ * This function sends a cancellation request to the server to cancel the
  * previous request made. Does not wait for the response which must be handled
  * seperately
  *
@@ -235,10 +235,10 @@ int wh_Client_DisableCancel(whClientContext* c);
  */
 int wh_Client_CancelRequest(whClientContext* c);
 /**
- * @brief Handles the response for a cancelation the previous request, currently
+ * @brief Handles the response for a cancellation the previous request, currently
  * only supports CMAC. Async response handler.
  *
- * This function handles the response for a request cancelation previously sent
+ * This function handles the response for a request cancellation previously sent
  * to the server. Blocks to wait for the response.
  *
  * @param[in] c Pointer to the client context.
@@ -249,7 +249,7 @@ int wh_Client_CancelResponse(whClientContext* c);
 /**
  * @brief Cancels the previous request, currently only supports CMAC.
  *
- * This function sends a cancelation request to the server and waits for the
+ * This function sends a cancellation request to the server and waits for the
  * response to cancel the previous request made.
  *
  * @param[in] c Pointer to the client context.
@@ -679,7 +679,7 @@ int wh_Client_AesCmacVerify(Cmac* cmac, const byte* check, word32 checkSz,
  * @brief Handle cancelable CMAC response.
  *
  * This function handles a CMAC operation response from the server when
- * cancelation has been enabled, since wolfCrypt won't automatically block and
+ * cancellation has been enabled, since wolfCrypt won't automatically block and
  * wait for the response.
  *
  * @param[in] c Pointer to the client context structure.

--- a/wolfhsm/wh_error.h
+++ b/wolfhsm/wh_error.h
@@ -35,7 +35,7 @@ enum WH_ERROR_ENUM {
     WH_ERROR_BADARGS        = -400, /* No side effects. Fix args. */
     WH_ERROR_NOTREADY       = -401, /* Retry function. */
     WH_ERROR_ABORTED        = -402, /* Function has fatally failed. Cleanup. */
-    WH_ERROR_CANCEL         = -403, /* Operation was cancled */
+    WH_ERROR_CANCEL         = -403, /* Operation was canceled */
     WH_ERROR_CANCEL_LATE    = -404, /* Cancel was processed too late */
 
     /* NVM-specific status returns */

--- a/wolfhsm/wh_message.h
+++ b/wolfhsm/wh_message.h
@@ -40,7 +40,7 @@ enum WH_MESSAGE_ENUM {
     WH_MESSAGE_GROUP_PKCS11         = 0x0600, /* PKCS11 protocol */
     WH_MESSAGE_GROUP_SHE            = 0x0700, /* SHE protocol */
     WH_MESSAGE_GROUP_COUNTER        = 0x0800, /* monotonic counters */
-    WH_MESSAGE_GROUP_CANCEL         = 0x0900, /* request cancelation */
+    WH_MESSAGE_GROUP_CANCEL         = 0x0900, /* request cancellation */
     WH_MESSAGE_GROUP_CUSTOM         = 0x1000, /* User-specified features */
 
     WH_MESSAGE_ACTION_MASK         = 0x00FF,  /* 255 subtypes per group*/

--- a/wolfhsm/wh_server.h
+++ b/wolfhsm/wh_server.h
@@ -277,7 +277,33 @@ int wh_Server_SetConnectedCb(void* s, whCommConnected connected);
 int wh_Server_GetConnected(whServerContext* server,
                            whCommConnected* out_connected);
 
+/**
+ * @brief Gets the canceled sequence number of the server.
+ *
+ * The canceled sequence number is the comms layer sequence number of the last
+ * canceled request. This number is set by the server port in response to an
+ * out-of-band signal from the client when the client wishes to cancel a
+ * request.
+ *
+ * @param[in] server Pointer to the server context.
+ * @param[out] outSeq Pointer to store the canceled sequence number.
+ * @return int Returns 0 on success, or WH_ERROR_BADARGS if the arguments are
+ * invalid
+ *
+ */
 int wh_Server_GetCanceledSequence(whServerContext* server, uint16_t* outSeq);
+
+
+/**
+ * @brief Sets the canceled sequence number of the server.
+ *
+ * The canceled sequence number is the comms layer sequence number of the last
+ * canceled request. This function should be used by the server port to set the
+ * canceled sequence number in response to an out-of-band signal from the
+ * client.
+ *
+ */
+int wh_Server_SetCanceledSequence(whServerContext* server, uint16_t cancelSeq);
 
 /**
  * @brief Handles incoming request messages and dispatches them to the


### PR DESCRIPTION
Fixes bugs in CMAC cancellation and adds a few housekeeping items

Notably:
- Server cancellation response was never correctly propagated to the client (multiple areas of code where this had to be fixed)
- Add helpers for server context field setting
- Add comments for non-obvious sections of code
- Spelling fixes
