### PR TITLE
quick cleanups

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    # List host CPU info
+    - name: Host CPU info
+      run: cat /proc/cpuinfo
+
     # List compiler version
     - name: List compiler version
       run: gcc --version
@@ -24,6 +28,10 @@ jobs:
       with:
         repository: wolfssl/wolfssl
         path: wolfssl
+
+    # Build and test standard build
+    - name: Build and test
+      run: cd test && make clean && make WOLFSSL_DIR=../wolfssl run
 
     # Build and test debug build with ASAN and NOCRYPTO
     - name: Build and test ASAN DEBUG NOCRYPTO
@@ -36,10 +44,6 @@ jobs:
     # Build and test debug build with SHE
     - name: Build and test SHE
       run: cd test && make clean && make SHE=1 WOLFSSL_DIR=../wolfssl run
-
-    # Build and test standard build
-    - name: Build and test
-      run: cd test && make clean && make WOLFSSL_DIR=../wolfssl run
 
     # Test structure padding
     - name: Check structure padding

--- a/test/README.md
+++ b/test/README.md
@@ -1,7 +1,7 @@
 # Testing
 
 wolfHSM unit tests need to be portable and platform-agnostic (e.g. no system dependencies) such that they are  able to run on a bare-metal system.
-One notable exception is for tests that use the POSIX API (sockets, pthreads, etc.), which must be conditionally compiled in with the `WH_CFG_POSIX_TEST` preprocessor macro.
+One notable exception is for tests that use the POSIX API (sockets, pthreads, etc.), which must be conditionally compiled in with the `WOLFHSM_CFG_TEST_POSIX` preprocessor macro.
 
 ##  Running Tests
 Tests for each module should be defined in their own source file and export their API in a corresponding header. Tests are run by the main test driver in `wh_test.c`.

--- a/test/wh_test.c
+++ b/test/wh_test.c
@@ -61,7 +61,7 @@ int whTest_Unit(void)
 }
 
 
-#if !defined(WH_CFG_TEST_UNIT_NO_MAIN)
+#if !defined(WOLFHSM_CFG_TEST_UNIT_NO_MAIN)
 
 int main(void)
 {

--- a/test/wh_test.c
+++ b/test/wh_test.c
@@ -40,6 +40,7 @@
 
 int whTest_Unit(void)
 {
+    printf("Enter unit tests\n");
     /* Component Tests */
     WH_TEST_ASSERT(0 == whTest_Flash_RamSim());
     WH_TEST_ASSERT(0 == whTest_NvmFlash());

--- a/test/wh_test_clientserver.c
+++ b/test/wh_test_clientserver.c
@@ -723,16 +723,20 @@ int whTest_ClientServerSequential(void)
             &lifecycle_state,
             &nvm_state));
     printf("Server Info: \n - Version:%s\n - Build:%s\n", version, build);
-    printf(" - cfg_comm_data_len:%u\n", cfg_comm_data_len);
-    printf(" - cfg_nvm_object_count:%u\n", cfg_nvm_object_count);
-    printf(" - cfg_server_keycache_count:%u\n", cfg_server_keycache_count);
-    printf(" - cfg_server_keycache_bufsize:%u\n", cfg_server_keycache_bufsize);
-    printf(" - cfg_server_customcb_count:%u\n", cfg_server_customcb_count);
-    printf(" - cfg_server_dmaaddr_count:%u\n", cfg_server_dmaaddr_count);
-    printf(" - debug_state:%u\n", debug_state);
-    printf(" - boot_state:%u\n", boot_state);
-    printf(" - lifecycle_state:%u\n", lifecycle_state);
-    printf(" - nvm_state:%u\n", nvm_state);
+    printf(" - cfg_comm_data_len:%u\n", (unsigned int)cfg_comm_data_len);
+    printf(" - cfg_nvm_object_count:%u\n", (unsigned int)cfg_nvm_object_count);
+    printf(" - cfg_server_keycache_count:%u\n",
+           (unsigned int)cfg_server_keycache_count);
+    printf(" - cfg_server_keycache_bufsize:%u\n",
+           (unsigned int)cfg_server_keycache_bufsize);
+    printf(" - cfg_server_customcb_count:%u\n",
+           (unsigned int)cfg_server_customcb_count);
+    printf(" - cfg_server_dmaaddr_count:%u\n",
+           (unsigned int)cfg_server_dmaaddr_count);
+    printf(" - debug_state:%u\n", (unsigned int)debug_state);
+    printf(" - boot_state:%u\n", (unsigned int)boot_state);
+    printf(" - lifecycle_state:%u\n", (unsigned int)lifecycle_state);
+    printf(" - nvm_state:%u\n", (unsigned int)nvm_state);
 
     for (counter = 0; counter < REPEAT_COUNT; counter++) {
 

--- a/test/wh_test_comm.c
+++ b/test/wh_test_comm.c
@@ -291,7 +291,7 @@ static void* _whCommServerTask(void* cf)
             WH_TEST_ASSERT_MSG((ret == WH_ERROR_NOTREADY) || (0 == ret),
                                "Server RecvRequest: ret=%d", ret);
 
-#if defined(WH_CONFIG_TEST_VERBOSE)
+#if defined(WOLFHSM_CFG_TEST_VERBOSE)
            if(ret != WH_ERROR_NOTREADY) {
                printf("Server RecvRequest:%d, flags %x, type:%x, seq:%d, len:%d, "
                    "%s\n",
@@ -315,7 +315,7 @@ static void* _whCommServerTask(void* cf)
             WH_TEST_ASSERT_MSG((ret == WH_ERROR_NOTREADY) || (0 == ret),
                                "Server SendResponse: ret=%d", ret);
 
-#if defined(WH_CONFIG_TEST_VERBOSE)
+#if defined(WOLFHSM_CFG_TEST_VERBOSE)
             if(ret != WH_ERROR_NOTREADY) {
                 printf("Server SendResponse:%d, flags %x, type:%x, seq:%d, len:%d, "
                    "%s\n",

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -64,7 +64,7 @@ enum {
 
 #define PLAINTEXT "mytextisbigplain"
 
-#ifndef WH_CFG_TEST_NO_CUSTOM_SERVERS
+#ifndef WOLFHSM_CFG_TEST_NO_CUSTOM_SERVERS
 /* Flag causing the server loop to sleep(1) */
 int serverDelay = 0;
 #endif
@@ -192,8 +192,8 @@ int whTest_CryptoClientConfig(whClientConfig* config)
         goto exit;
     }
 
-#ifndef WH_CFG_TEST_NO_CUSTOM_SERVERS
-    /* WH_CFG_TEST_NO_CUSTOM_SERVERS protects the client test code that expects to
+#ifndef WOLFHSM_CFG_TEST_NO_CUSTOM_SERVERS
+    /* WOLFHSM_CFG_TEST_NO_CUSTOM_SERVERS protects the client test code that expects to
      * interop with the custom server (also defined in this file), so that this
      * test can be run against a standard server app
      *
@@ -244,7 +244,7 @@ int whTest_CryptoClientConfig(whClientConfig* config)
         WH_ERROR_PRINT("KEY CACHE/EXPORT FAILED TO MATCH\n");
         goto exit;
     }
-#endif /* !WH_CFG_TEST_NO_CUSTOM_SERVERS */
+#endif /* !WOLFHSM_CFG_TEST_NO_CUSTOM_SERVERS */
 
     /* evict for original client */
     if ((ret = wh_Client_KeyEvict(client, keyId)) != 0) {
@@ -638,21 +638,21 @@ int whTest_CryptoClientConfig(whClientConfig* config)
         WH_ERROR_PRINT("Failed to wc_CmacUpdate %d\n", ret);
         goto exit;
     }
-#ifndef WH_CFG_TEST_NO_CUSTOM_SERVERS
+#ifndef WOLFHSM_CFG_TEST_NO_CUSTOM_SERVERS
     /* delay the server so scheduling doesn't interfere with the timing */
     serverDelay = 1;
 
     /* TODO: use hsm pause/resume functionality on real hardware */
 #endif
     if((ret = wh_Client_Cancel(client)) != 0
-#if defined(WH_CFG_TEST_NO_CUSTOM_SERVERS)
+#if defined(WOLFHSM_CFG_TEST_NO_CUSTOM_SERVERS)
         && ret != WH_ERROR_CANCEL_LATE
 #endif
     ) {
         WH_ERROR_PRINT("Failed to wh_Client_Cancel %d\n", ret);
         goto exit;
     }
-#ifndef WH_CFG_TEST_NO_CUSTOM_SERVERS
+#ifndef WOLFHSM_CFG_TEST_NO_CUSTOM_SERVERS
     serverDelay = 0;
 #endif
     /* test cancelable request and response work for standard CMAC request with no cancellation */
@@ -735,7 +735,7 @@ int whTest_CryptoServerConfig(whServerConfig* config)
     whServerContext server[1] = {0};
     whCommConnected am_connected = WH_COMM_CONNECTED;
     int ret = 0;
-#ifndef WH_CFG_TEST_NO_CUSTOM_SERVERS
+#ifndef WOLFHSM_CFG_TEST_NO_CUSTOM_SERVERS
     int userChange = 0;
 #endif
 
@@ -753,7 +753,7 @@ int whTest_CryptoServerConfig(whServerConfig* config)
     server->comm->client_id = 1;
 
     while(am_connected == WH_COMM_CONNECTED) {
-#ifndef WH_CFG_TEST_NO_CUSTOM_SERVERS
+#ifndef WOLFHSM_CFG_TEST_NO_CUSTOM_SERVERS
         while (serverDelay) {
 #ifdef WOLFHSM_CFG_TEST_POSIX
             sleep(1);
@@ -768,7 +768,7 @@ int whTest_CryptoServerConfig(whServerConfig* config)
         }
         wh_Server_GetConnected(server, &am_connected);
 
-#ifndef WH_CFG_TEST_NO_CUSTOM_SERVERS
+#ifndef WOLFHSM_CFG_TEST_NO_CUSTOM_SERVERS
         /* keep alive for 2 user changes */
         if (am_connected != WH_COMM_CONNECTED && userChange < 2) {
             if (userChange == 0)
@@ -779,7 +779,7 @@ int whTest_CryptoServerConfig(whServerConfig* config)
             am_connected = WH_COMM_CONNECTED;
             WH_TEST_RETURN_ON_FAIL(wh_Server_SetConnected(server, am_connected));
         }
-#endif /* !WH_CFG_TEST_NO_CUSTOM_SERVERS */
+#endif /* !WOLFHSM_CFG_TEST_NO_CUSTOM_SERVERS */
     }
 
     if ((ret == 0) || (ret == WH_ERROR_NOTREADY)) {

--- a/test/wolfhsm_cfg.h
+++ b/test/wolfhsm_cfg.h
@@ -39,5 +39,8 @@
 #define WOLFHSM_CFG_SERVER_DMAADDR_COUNT 8
 #define WOLFHSM_CFG_SERVER_CUSTOMCB_COUNT 6
 
+/* Test specific configuration */
+#define WOLFHSM_CFG_TEST_NO_CUSTOM_SERVERS
+
 
 #endif /* WOLFHSM_CFG_H_ */

--- a/wolfhsm/wh_client.h
+++ b/wolfhsm/wh_client.h
@@ -727,7 +727,7 @@ int wh_Client_SetKeyIdCurve25519(curve25519_key* key, whNvmId keyId);
  * set by either the crypto callback layer or wh_Client_SetKeyCurve25519.
  *
  * @param[in] key Pointer to the Curve25519 key structure.
- * @param[out] keyId Pointer to the key ID to return.
+ * @param[out] outId Pointer to the key ID to return.
  * @return int Returns 0 on success or a negative error code on failure.
  */
 int wh_Client_GetKeyIdCurve25519(curve25519_key* key, whNvmId* outId);
@@ -754,7 +754,7 @@ int wh_Client_SetKeyIdEcc(ecc_key* key, whNvmId keyId);
  * set by either the crypto callback layer or wh_Client_SetKeyIdEcc.
  *
  * @param[in] key Pointer to the Ecc key structure.
- * @param[out] keyId Pointer to the key ID to return.
+ * @param[out] outId Pointer to the key ID to return.
  * @return int Returns 0 on success or a negative error code on failure.
  */
 int wh_Client_GetKeyIdEcc(ecc_key* key, whNvmId* outId);
@@ -781,7 +781,7 @@ int wh_Client_SetKeyIdRsa(RsaKey* key, whNvmId keyId);
  * set by either the crypto callback layer or wh_Client_SetKeyRsa.
  *
  * @param[in] key Pointer to the RSA key structure.
- * @param[out] keyId Pointer to the key ID to return.
+ * @param[out] outId Pointer to the key ID to return.
  * @return int Returns 0 on success or a negative error code on failure.
  */
 int wh_Client_GetKeyIdRsa(RsaKey* key, whNvmId* outId);
@@ -795,7 +795,7 @@ int wh_Client_GetKeyIdRsa(RsaKey* key, whNvmId* outId);
  * On the server side, this key ID is used to reference the key stored in the
  * HSM
  *
- * @param[in] aes Pointer to the AES key structure.
+ * @param[in] key Pointer to the AES key structure.
  * @param[in] keyId Key ID to be associated with the AES key.
  * @return int Returns 0 on success or a negative error code on failure.
  */
@@ -808,7 +808,7 @@ int wh_Client_SetKeyIdAes(Aes* key, whNvmId keyId);
  * set by either the crypto callback layer or wh_Client_SetKeyAes.
  *
  * @param[in] key Pointer to the AES key structure.
- * @param[out] keyId Pointer to the key ID to return.
+ * @param[out] outId Pointer to the key ID to return.
  * @return int Returns 0 on success or a negative error code on failure.
  */
 int wh_Client_GetKeyIdAes(Aes* key, whNvmId* outId);
@@ -866,7 +866,7 @@ int wh_Client_AesCmacVerify(Cmac* cmac, const byte* check, word32 checkSz,
  * @param[in] cmac Pointer to the CMAC key structure.
  * @param[out] out Buffer to store the CMAC result, only required after
  *    wc_CmacFinal.
- * @param[in/out] outSz Pointer to the size of the out buffer in bytes, will be
+ * @param[in,out] outSz Pointer to the size of the out buffer in bytes, will be
  *    set to the size returned by the server on return.
  * @return int Returns 0 on success, or a negative error code on failure.
  */
@@ -893,7 +893,7 @@ int wh_Client_SetKeyIdCmac(Cmac* key, whNvmId keyId);
  * set by either the crypto callback layer or wh_Client_SetKeyCmac.
  *
  * @param[in] key Pointer to the CMAC key structure.
- * @param[out] keyId Pointer to the key ID to return.
+ * @param[out] outId Pointer to the key ID to return.
  * @return int Returns 0 on success or a negative error code on failure.
  */
 int wh_Client_GetKeyIdCmac(Cmac* key, whNvmId* outId);
@@ -913,7 +913,7 @@ int wh_Client_CounterInitResponse(whClientContext* c, uint32_t* counter);
  *
  * @param[in] c Pointer to the whClientContext structure.
  * @param[in] counterId counter ID to be associated with the counter.
- * @param[in/out] counter Value to initialize the counter with, retruns with
+ * @param[in,out] counter Value to initialize the counter with, returns with
  * the value set by the HSM for confirmation.
  * @return int Returns 0 on success or a negative error code on failure.
  */


### PR DESCRIPTION
- Fix/workaround for hanging CI tests by disabling custom server logic (@jpbland1 this needs to be fixed, as it was causing the hang). 
- fixes a few macros that were skipped in the last rename PR
- fixes compiler warning in test printfs
- fixes doxygen error that is breaking wolfSSL documentation CI
