### PR TITLE
Fix settings include file order in SHE module

### DIFF
--- a/src/wh_she_common.c
+++ b/src/wh_she_common.c
@@ -22,6 +22,9 @@
  */
 /* System libraries */
 
+/* Pick up compile-time configuration */
+#include "wolfhsm/wh_settings.h"
+
 #ifdef WOLFHSM_CFG_SHE_EXTENSION
 
 #include <stdint.h>
@@ -32,7 +35,6 @@
 #include "wolfhsm/wh_error.h"
 #include "wolfhsm/wh_utils.h"
 
-#include "wolfhsm/wh_she_common.h"
 
 typedef struct {
     uint32_t count;

--- a/src/wh_she_crypto.c
+++ b/src/wh_she_crypto.c
@@ -21,6 +21,8 @@
  *
  */
 
+/* Pick up compile-time configuration */
+#include "wolfhsm/wh_settings.h"
 
 #ifdef WOLFHSM_CFG_SHE_EXTENSION
 #ifndef WOLFHSM_CFG_NO_CRYPTO


### PR DESCRIPTION
Another quick fix required by tricore integration: add wh_settings.h include outside macro protection for SHE source code, so it can conditionally compile in/out remainder of code