### PR TITLE
Fix memtransport, move debug prints to utils

### DIFF
--- a/src/wh_client_cryptocb.c
+++ b/src/wh_client_cryptocb.c
@@ -162,8 +162,8 @@ int wh_Client_CryptoCb(int devId, wc_CryptoInfo* info, void* inCtx)
                     info->cipher.aescbc.aes->devKey, info->cipher.aescbc.aes->keylen,
                     info->cipher.aescbc.in, info->cipher.aescbc.sz,
                     info->cipher.aescbc.out, info->cipher.enc, ret);
-            _hexdump("  In:", in, packet->cipherAesCbcReq.sz);
-            _hexdump("  Key:", key, packet->cipherAesCbcReq.keyLen);
+            wh_Utils_Hexdump("  In:", in, packet->cipherAesCbcReq.sz);
+            wh_Utils_Hexdump("  Key:", key, packet->cipherAesCbcReq.keyLen);
 #endif /* DEBUG_CRYPTOCB */
 
             /* read response */
@@ -179,7 +179,7 @@ int wh_Client_CryptoCb(int devId, wc_CryptoInfo* info, void* inCtx)
                     ret = packet->rc;
                 else {
 #ifdef DEBUG_CRYPTOCB_VERBOSE
-                    _hexdump("  Out:", out, packet->cipherAesCbcRes.sz);
+                    wh_Utils_Hexdump("  Out:", out, packet->cipherAesCbcRes.sz);
 #endif /* DEBUG_CRYPTOCB */
                     /* copy the response out */
                     XMEMCPY(info->cipher.aescbc.out, out,
@@ -967,9 +967,9 @@ static int _xferSha256BlockAndUpdateDigest(whClientContext* ctx,
 
 #ifdef DEBUG_CRYPTOCB_VERBOSE
     printf("[client] send SHA256 Req:\n");
-    _hexdump("[client] inBlock: ", req->inBlock, WC_SHA256_BLOCK_SIZE);
+    wh_Utils_Hexdump("[client] inBlock: ", req->inBlock, WC_SHA256_BLOCK_SIZE);
     if (req->resumeState.hiLen != 0 || req->resumeState.loLen != 0) {
-        _hexdump("  [client] resumeHash: ", req->resumeState.hash,
+        wh_Utils_Hexdump("  [client] resumeHash: ", req->resumeState.hash,
                  (isLastBlock) ? req->lastBlockLen : WC_SHA256_BLOCK_SIZE);
         printf("  [client] hiLen: %u, loLen: %u\n", req->resumeState.hiLen,
                req->resumeState.loLen);
@@ -1000,7 +1000,7 @@ static int _xferSha256BlockAndUpdateDigest(whClientContext* ctx,
             sha256->loLen = packet->hashSha256Res.loLen;
 #ifdef DEBUG_CRYPTOCB_VERBOSE
             printf("[client] Client SHA256 Res recv:\n");
-            _hexdump("[client] hash: ", (uint8_t*)sha256->digest,
+            wh_Utils_Hexdump("[client] hash: ", (uint8_t*)sha256->digest,
                      WC_SHA256_DIGEST_SIZE);
 #endif /* DEBUG_CRYPTOCB_VERBOSE */
         }

--- a/src/wh_client_cryptocb.c
+++ b/src/wh_client_cryptocb.c
@@ -21,18 +21,21 @@
  *
  */
 
-#include <stdint.h>
-
 /* Pick up compile-time configuration */
 #include "wolfhsm/wh_settings.h"
 
-#include "wolfhsm/wh_client.h"
-#include "wolfhsm/wh_comm.h"
-#include "wolfhsm/wh_packet.h"
-#include "wolfhsm/wh_error.h"
-#include "wolfhsm/wh_message.h"
 
 #ifndef WOLFHSM_CFG_NO_CRYPTO
+
+#include <stdint.h>
+
+#include "wolfhsm/wh_common.h"
+#include "wolfhsm/wh_error.h"
+#include "wolfhsm/wh_utils.h"
+#include "wolfhsm/wh_comm.h"
+#include "wolfhsm/wh_packet.h"
+#include "wolfhsm/wh_message.h"
+#include "wolfhsm/wh_client.h"
 
 #include "wolfssl/wolfcrypt/settings.h"
 #include "wolfssl/wolfcrypt/types.h"
@@ -45,23 +48,6 @@
 
 #include "wolfhsm/wh_client_cryptocb.h"
 
-#if defined(DEBUG_CRYPTOCB) || defined(DEBUG_CRYPTOCB_VERBOSE)
-#include <stdio.h>
-#endif
-
-#ifdef DEBUG_CRYPTOCB_VERBOSE
-static void _hexdump(const char* initial,uint8_t* ptr, size_t size)
-{
-    if(initial != NULL)
-        printf("%s",initial);
-    while(size > 0) {
-        printf ("%02X ", *ptr);
-        ptr++;
-        size --;
-    }
-    printf("\n");
-}
-#endif
 
 #ifndef NO_SHA256
 static int _handleSha256(int devId, wc_CryptoInfo* info, void* inCtx,

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -24,27 +24,30 @@
 /* Pick up compile-time configuration */
 #include "wolfhsm/wh_settings.h"
 
+#ifndef WOLFHSM_CFG_NO_CRYPTO
+
 /* System libraries */
 #include <stdint.h>
 #include <stddef.h>  /* For NULL */
 #include <string.h>  /* For memset, memcpy */
 
-#ifndef WOLFHSM_CFG_NO_CRYPTO
-
 #include "wolfssl/wolfcrypt/settings.h"
 #include "wolfssl/wolfcrypt/types.h"
 #include "wolfssl/wolfcrypt/error-crypt.h"
+#include "wolfssl/wolfcrypt/rsa.h"
+#include "wolfssl/wolfcrypt/curve25519.h"
+#include "wolfssl/wolfcrypt/ecc.h"
+#include "wolfssl/wolfcrypt/aes.h"
+#include "wolfssl/wolfcrypt/sha256.h"
+#include "wolfssl/wolfcrypt/cmac.h"
 
 #include "wolfhsm/wh_error.h"
 #include "wolfhsm/wh_packet.h"
+#include "wolfhsm/wh_utils.h"
 #include "wolfhsm/wh_server_keystore.h"
 #include "wolfhsm/wh_server_crypto.h"
 
 #include "wolfhsm/wh_server.h"
-
-#if defined(DEBUG_CRYPTOCB) || defined(DEBUG_CRYPTOCB_VERBOSE)
-#include <stdio.h>
-#endif
 
 #ifndef NO_RSA
 static int hsmCacheKeyRsa(whServerContext* server, RsaKey* key, whKeyId* outId)

--- a/src/wh_transport_mem.c
+++ b/src/wh_transport_mem.c
@@ -30,6 +30,7 @@
 #include <stdint.h>
 
 #include "wolfhsm/wh_error.h"
+#include "wolfhsm/wh_utils.h"
 #include "wolfhsm/wh_comm.h"
 
 #include "wolfhsm/wh_transport_mem.h"
@@ -51,7 +52,7 @@ int wh_TransportMem_Init(void* c, const void* cf,
         return WH_ERROR_BADARGS;
     }
 
-    memset(context, 0, sizeof(*context));
+    wh_Utils_memset_flush(context, 0, sizeof(*context));
     context->req            = (whTransportMemCsr*)config->req;
     context->req_size       = config->req_size;
     context->req_data       = (void*)(context->req + 1);
@@ -61,6 +62,8 @@ int wh_TransportMem_Init(void* c, const void* cf,
     context->resp_data      = (void*)(context->resp + 1);
 
     context->initialized = 1;
+    XMEMFENCE();
+
     return WH_ERROR_OK;
 }
 
@@ -72,8 +75,8 @@ int wh_TransportMem_InitClear(void* c, const void* cf,
     int rc = wh_TransportMem_Init(c, cf, connectcb, connectcb_arg);
     if (rc == WH_ERROR_OK) {
         /* Zero the buffers */
-        memset((void*)context->req, 0, context->req_size);
-        memset((void*)context->resp, 0, context->resp_size);
+        wh_Utils_memset_flush((void*)context->req, 0, context->req_size);
+        wh_Utils_memset_flush((void*)context->resp, 0, context->resp_size);
     }
     return rc;
 }
@@ -93,6 +96,8 @@ int wh_TransportMem_Cleanup(void* c)
 int wh_TransportMem_SendRequest(void* c, uint16_t len, const void* data)
 {
     whTransportMemContext* context = c;
+    volatile whTransportMemCsr* ctx_req = context->req;
+    volatile whTransportMemCsr* ctx_resp = context->resp;
     whTransportMemCsr resp;
     whTransportMemCsr req;
 
@@ -101,9 +106,13 @@ int wh_TransportMem_SendRequest(void* c, uint16_t len, const void* data)
         return WH_ERROR_BADARGS;
     }
 
-    /* Read current CSR's */
-    resp.u64 = context->resp->u64;
-    req.u64 = context->req->u64;
+    /* Read current CSR's. ctx_req does not need to be invalidated */
+    XMEMFENCE();
+    XCACHEINVLD(ctx_resp);
+    XCACHEINVLD(ctx_req);
+
+    resp.u64 = ctx_resp->u64;
+    req.u64 = ctx_req->u64;
 
     /* Has server completed with previous request */
     if (req.s.notify != resp.s.notify) {
@@ -111,13 +120,20 @@ int wh_TransportMem_SendRequest(void* c, uint16_t len, const void* data)
     }
 
     if ((data != NULL) && (len != 0)) {
-        memcpy((void*)context->req_data, data, len);
+        wh_Utils_memcpy_flush((void*)context->req_data, data, len);
     }
+
+    /* Ensure the memcpy is complete */
+    XMEMFENCE();
+
     req.s.len = len;
     req.s.notify++;
 
     /* Write the new CSR's */
-    context->req->u64 = req.u64;
+    ctx_req->u64 = req.u64;
+    /*Ensure the update to the CSR is complete */
+    XMEMFENCE();
+    XCACHEFLUSH(ctx_req);
 
     return 0;
 }
@@ -125,6 +141,8 @@ int wh_TransportMem_SendRequest(void* c, uint16_t len, const void* data)
 int wh_TransportMem_RecvRequest(void* c, uint16_t *out_len, void* data)
 {
     whTransportMemContext* context = c;
+    volatile whTransportMemCsr* ctx_req = context->req;
+    volatile whTransportMemCsr* ctx_resp = context->resp;
     whTransportMemCsr req;
     whTransportMemCsr resp;
 
@@ -133,9 +151,11 @@ int wh_TransportMem_RecvRequest(void* c, uint16_t *out_len, void* data)
         return WH_ERROR_BADARGS;
     }
 
-    /* Read current request CSR's */
-    req.u64 = context->req->u64;
-    resp.u64 = context->resp->u64;
+    /* Read current request CSR's. ctx_resp does not need to be invalidated */
+    XMEMFENCE();
+    XCACHEINVLD(ctx_req);
+    req.u64 = ctx_req->u64;
+    resp.u64 = ctx_resp->u64;
 
     /* Check to see if a new request has arrived */
     if(req.s.notify == resp.s.notify) {
@@ -143,7 +163,7 @@ int wh_TransportMem_RecvRequest(void* c, uint16_t *out_len, void* data)
     }
 
     if ((data != NULL) && (req.s.len != 0)) {
-        memcpy(data, context->req_data, req.s.len);
+        wh_Utils_memcpy_invalidate(data, context->req_data, req.s.len);
     }
     if (out_len != NULL) {
         *out_len = req.s.len;
@@ -155,6 +175,8 @@ int wh_TransportMem_RecvRequest(void* c, uint16_t *out_len, void* data)
 int wh_TransportMem_SendResponse(void* c, uint16_t len, const void* data)
 {
     whTransportMemContext* context = c;
+    volatile whTransportMemCsr* ctx_req = context->req;
+    volatile whTransportMemCsr* ctx_resp = context->resp;
     whTransportMemCsr req;
     whTransportMemCsr resp;
 
@@ -163,18 +185,26 @@ int wh_TransportMem_SendResponse(void* c, uint16_t len, const void* data)
         return WH_ERROR_BADARGS;
     }
 
-    /* Read both CSR's */
-    req.u64 = context->req->u64;
-    resp.u64 = context->resp->u64;
+    /* Read both CSR's. ctx_resp does not need to be invalidated */
+    XMEMFENCE();
+    XCACHEINVLD(ctx_req);
+    req.u64 = ctx_req->u64;
+    resp.u64 = ctx_resp->u64;
 
     if ((data != NULL) && (len != 0)) {
-        memcpy(context->resp_data, data, len);
+        wh_Utils_memcpy_flush(context->resp_data, data, len);
     }
+    /* Ensure the memcpy is complete */
+    XMEMFENCE();
+
     resp.s.len = len;
     resp.s.notify = req.s.notify;
 
-    /* Write the new CSR's */
-    context->resp->u64 = resp.u64;
+   /* Write the new CSR's */
+    ctx_resp->u64 = resp.u64;
+    /*Ensure the update to the CSR is complete */
+    XMEMFENCE();
+    XCACHEFLUSH(ctx_resp);
 
     return 0;
 }
@@ -182,6 +212,8 @@ int wh_TransportMem_SendResponse(void* c, uint16_t len, const void* data)
 int wh_TransportMem_RecvResponse(void* c, uint16_t *out_len, void* data)
 {
     whTransportMemContext* context = c;
+    volatile whTransportMemCsr* ctx_req = context->req;
+    volatile whTransportMemCsr* ctx_resp = context->resp;
     whTransportMemCsr req;
     whTransportMemCsr resp;
 
@@ -190,9 +222,11 @@ int wh_TransportMem_RecvResponse(void* c, uint16_t *out_len, void* data)
         return WH_ERROR_BADARGS;
     }
 
-    /* Read both CSR's */
-    req.u64 = context->req->u64;
-    resp.u64 = context->resp->u64;
+    /* Read both CSR's. ctx_req does not need to be invalidated */
+    XMEMFENCE();
+    XCACHEINVLD(ctx_resp);
+    req.u64 = ctx_req->u64;
+    resp.u64 = ctx_resp->u64;
 
     /* Check to see if the current response is the different than the request */
     if(resp.s.notify != req.s.notify) {
@@ -200,7 +234,7 @@ int wh_TransportMem_RecvResponse(void* c, uint16_t *out_len, void* data)
     }
 
     if ((data != NULL) && (resp.s.len != 0)) {
-        memcpy(data, context->resp_data, resp.s.len);
+        wh_Utils_memcpy_invalidate(data, context->resp_data, resp.s.len);
     }
 
     if (out_len != NULL) {

--- a/src/wh_transport_mem.c
+++ b/src/wh_transport_mem.c
@@ -123,9 +123,6 @@ int wh_TransportMem_SendRequest(void* c, uint16_t len, const void* data)
         wh_Utils_memcpy_flush((void*)context->req_data, data, len);
     }
 
-    /* Ensure the memcpy is complete */
-    XMEMFENCE();
-
     req.s.len = len;
     req.s.notify++;
 
@@ -194,8 +191,6 @@ int wh_TransportMem_SendResponse(void* c, uint16_t len, const void* data)
     if ((data != NULL) && (len != 0)) {
         wh_Utils_memcpy_flush(context->resp_data, data, len);
     }
-    /* Ensure the memcpy is complete */
-    XMEMFENCE();
 
     resp.s.len = len;
     resp.s.notify = req.s.notify;

--- a/src/wh_transport_mem.c
+++ b/src/wh_transport_mem.c
@@ -109,8 +109,6 @@ int wh_TransportMem_SendRequest(void* c, uint16_t len, const void* data)
     /* Read current CSR's. ctx_req does not need to be invalidated */
     XMEMFENCE();
     XCACHEINVLD(ctx_resp);
-    XCACHEINVLD(ctx_req);
-
     resp.u64 = ctx_resp->u64;
     req.u64 = ctx_req->u64;
 

--- a/src/wh_utils.c
+++ b/src/wh_utils.c
@@ -28,6 +28,10 @@
 #include <stddef.h> /* For size_t */
 #include <string.h> /* For memset/cpy */
 
+#if defined(DEBUG_CRYPTOCB) || defined(DEBUG_CRYPTOCB_VERBOSE)
+#include <stdio.h>
+#endif
+
 #include "wolfhsm/wh_utils.h"
 
 /** Byteswap functions */
@@ -132,12 +136,8 @@ void* wh_Utils_memcpy_flush(void* dst, const void* src , size_t n)
 }
 
 
-#if defined(DEBUG_CRYPTOCB) || defined(DEBUG_CRYPTOCB_VERBOSE)
-#include <stdio.h>
-#endif
-
 #ifdef DEBUG_CRYPTOCB_VERBOSE
-void _hexdump(const char* initial, uint8_t* ptr, size_t size)
+void wh_Utils_Hexdump(const char* initial, uint8_t* ptr, size_t size)
 {
 #define HEXDUMP_BYTES_PER_LINE 16
     int count = 0;

--- a/src/wh_utils.c
+++ b/src/wh_utils.c
@@ -114,7 +114,9 @@ void* wh_Utils_CacheFlush(void* p, size_t n)
 
 void* wh_Utils_memset_flush(void* p, int c, size_t n)
 {
-    return XCACHEFLUSHBLK(memset(p, c, n), n);
+    memset(p, c, n);
+    XMEMFENCE();
+    return XCACHEFLUSHBLK(p, n);
 }
 
 void* wh_Utils_memcpy_invalidate(void* dst, const void* src, size_t n)
@@ -124,8 +126,9 @@ void* wh_Utils_memcpy_invalidate(void* dst, const void* src, size_t n)
 
 void* wh_Utils_memcpy_flush(void* dst, const void* src , size_t n)
 {
-    XCACHEFLUSHBLK(memcpy(dst,src,n), n);
-    return dst;
+    memcpy(dst,src,n);
+    XMEMFENCE();
+    return XCACHEFLUSHBLK(dst, n);
 }
 
 

--- a/src/wh_utils.c
+++ b/src/wh_utils.c
@@ -114,17 +114,18 @@ void* wh_Utils_CacheFlush(void* p, size_t n)
 
 void* wh_Utils_memset_flush(void* p, int c, size_t n)
 {
-    return wh_Utils_CacheFlush(memset(p, c, n), n);
+    return XCACHEFLUSHBLK(memset(p, c, n), n);
 }
 
 void* wh_Utils_memcpy_invalidate(void* dst, const void* src, size_t n)
 {
-    return memcpy(dst,wh_Utils_CacheInvalidate(src,n),n);
+    return memcpy(dst, XCACHEINVLDBLK(src, n), n);
 }
 
 void* wh_Utils_memcpy_flush(void* dst, const void* src , size_t n)
 {
-    return wh_Utils_CacheFlush(memcpy(dst,src,n),n);
+    XCACHEFLUSHBLK(memcpy(dst,src,n), n);
+    return dst;
 }
 
 

--- a/wolfhsm/wh_settings.h
+++ b/wolfhsm/wh_settings.h
@@ -51,6 +51,32 @@
  *  WOLFHSM_CFG_SERVER_DMAADDR_COUNT - Number of DMA address regions
  *      Default: 10
  *
+ *
+ *  Overridable porting functions:
+ *
+ *  XMEMFENCE() - Create a sequential memory consistency sync point.  Note this
+ *                is compiler specific and generates hardware specific fence
+ *                instructions. Default works for modern gcc and clang
+ *      Default: __atomic_thread_fence(__ATOMIC_SEQ_CST)
+ *
+ *  XCACHELINE - Size in bytes of a cache line
+ *      Default: 32
+ *
+ *  #ifndef XCACHEFLUSH(ptr) - Flush the cache line uncluding ptr
+ *      DefaultL (void)(ptr)
+ *
+ *  #ifndef XCACHEFLUSHBLK(ptr, n) - Flush the cache lines starting at ptr for
+ *                                   at least n bytes
+ *      DefaultL wh_Utils_CacheFlush(ptr, n)
+ *
+ *  #ifndef XCACHEINVLD(ptr) - Invalidate the cache line uncluding ptr
+ *      DefaultL (void)(ptr)
+ *
+ *  #ifndef XCACHEINVLDBLK(ptr, n) - Invalidate the cache lines starting at ptr
+ *                                   for at least n bytes
+ *      DefaultL wh_Utils_CacheInvalidate(ptr, n)
+ *
+ *
  */
 
 #ifndef WOLFHSM_WH_SETTINGS_H_
@@ -141,5 +167,39 @@
 
 #endif /* !WOLFHSM_CFG_NO_CRYPTO */
 
+/** Cache flushing and memory fencing synchronization primitives */
+/* Create a full sequential memory fence to ensure compiler memory ordering */
+#ifndef XMEMFENCE
+#define XMEMFENCE() __atomic_thread_fence(__ATOMIC_SEQ_CST)
+#endif
+
+/* Return cacheline size */
+#ifndef XCACHELINE
+#define XCACHELINE (32)
+#endif
+
+/* Flush the cache line at _p. Used after writing to ensure the memory is
+ * consistent. */
+#ifndef XCACHEFLUSH
+#define XCACHEFLUSH(_p) (void)(_p)
+/* PPC32: __asm__ volatile ("dcbf 0, %0" : : "r" (_p): "memory") */
+#endif
+
+/* Flush the cache lines starting at _p for at least _n bytes. */
+#ifndef XCACHEFLUSHBLK
+#define XCACHEFLUSHBLK(_p, _n) wh_Utils_CacheFlush((_p), (_n))
+#endif
+
+/* Invalidate the cache line at _p. Used prior to reading to ensure
+ * freshness. */
+#ifndef XCACHEINVLD
+#define XCACHEINVLD(_p) (void)(_p)
+/* PPC32: __asm__ volatile ("dcbi 0, %0" : : "r" (_p): "memory") */
+#endif
+
+/* Invalidate the cache lines starting  at _p for at least _n bytes. */
+#ifndef XCACHEINVLDBLK
+#define XCACHEINVLDBLK(_p, _n) wh_Utils_CacheInvalidate((_p), (_n))
+#endif
 
 #endif /* !WOLFHSM_WH_SETTINGS_H_ */

--- a/wolfhsm/wh_settings.h
+++ b/wolfhsm/wh_settings.h
@@ -173,7 +173,7 @@
 #ifndef XMEMFENCE
 #if defined(__GCC__) || defined(__clang__)
 #define XMEMFENCE() __atomic_thread_fence(__ATOMIC_SEQ_CST)
-/* PPC32: __asm__ volatile ("sync" : : : "memory")
+/* PPC32: __asm__ volatile ("sync" : : : "memory") */
 #else
 #define XMEMFENCE() do { } while (0)
 #warning "wolfHSM memory transports should have a functional XMEMFENCE"

--- a/wolfhsm/wh_settings.h
+++ b/wolfhsm/wh_settings.h
@@ -57,7 +57,8 @@
  *  XMEMFENCE() - Create a sequential memory consistency sync point.  Note this
  *                is compiler specific and generates hardware specific fence
  *                instructions. Default works for modern gcc and clang
- *      Default: __atomic_thread_fence(__ATOMIC_SEQ_CST)
+ *      Default: (gcc or clang) __atomic_thread_fence(__ATOMIC_SEQ_CST)
+ *               (other) do {} while (0)
  *
  *  XCACHELINE - Size in bytes of a cache line
  *      Default: 32
@@ -170,7 +171,12 @@
 /** Cache flushing and memory fencing synchronization primitives */
 /* Create a full sequential memory fence to ensure compiler memory ordering */
 #ifndef XMEMFENCE
+#if defined(__GCC__) || defined(__clang__)
 #define XMEMFENCE() __atomic_thread_fence(__ATOMIC_SEQ_CST)
+#else
+#define XMEMFENCE() do {} while 0
+#warning "wolfHSM memory transports should have a functional XMEMFENCE"
+#endif
 #endif
 
 /* Return cacheline size */

--- a/wolfhsm/wh_settings.h
+++ b/wolfhsm/wh_settings.h
@@ -173,8 +173,9 @@
 #ifndef XMEMFENCE
 #if defined(__GCC__) || defined(__clang__)
 #define XMEMFENCE() __atomic_thread_fence(__ATOMIC_SEQ_CST)
+/* PPC32: __asm__ volatile ("sync" : : : "memory")
 #else
-#define XMEMFENCE() do {} while 0
+#define XMEMFENCE() do { } while (0)
 #warning "wolfHSM memory transports should have a functional XMEMFENCE"
 #endif
 #endif

--- a/wolfhsm/wh_transport_mem.h
+++ b/wolfhsm/wh_transport_mem.h
@@ -122,8 +122,8 @@ typedef union whTransportMemCsr_t {
 } whTransportMemCsr;
 
 typedef struct {
-    volatile whTransportMemCsr* req;
-    volatile whTransportMemCsr* resp;
+    whTransportMemCsr* req;
+    whTransportMemCsr* resp;
     void* req_data;
     void* resp_data;
     int initialized;

--- a/wolfhsm/wh_utils.h
+++ b/wolfhsm/wh_utils.h
@@ -58,7 +58,7 @@ void* wh_Utils_memcpy_flush(void* dst, const void* src , size_t n);
 
 
 #if defined(DEBUG_CRYPTOCB) || defined(DEBUG_CRYPTOCB_VERBOSE)
-void _hexdump(const char* initial, uint8_t* ptr, size_t size);
+void wh_Utils_Hexdump(const char* initial, uint8_t* ptr, size_t size);
 #endif
 
 #endif /* !WOLFHSM_WH_UTILS_H_ */

--- a/wolfhsm/wh_utils.h
+++ b/wolfhsm/wh_utils.h
@@ -40,31 +40,6 @@ uint32_t wh_Utils_ntohl(uint32_t networklong);
 
 int wh_Utils_memeqzero(uint8_t* buffer, uint32_t size);
 
-/** Cache flushing and memory fencing synchronization primitives */
-/* Create a full sequential memory fence to ensure compiler memory ordering */
-#ifndef XMEMFENCE
-#define XMEMFENCE() __atomic_thread_fence(__ATOMIC_SEQ_CST)
-#endif
-
-/* Return cacheline size */
-#ifndef XCACHELINE
-#define XCACHELINE (32)
-#endif
-
-/* Flush the cache line at _p. Used after writing to ensure the memory is
- * consistent. */
-#ifndef XCACHEFLUSH
-#define XCACHEFLUSH(_p) (void)(_p)
-/* PPC32: __asm__ volatile ("dcbf 0, %0" : : "r" (_p): "memory") */
-#endif
-
-/* Invalidate the cache line at _p. Used prior to reading to ensure
- * freshness. */
-#ifndef XCACHEINVLD
-#define XCACHEINVLD(_p) (void)(_p)
-/* PPC32: __asm__ volatile ("dcbi 0, %0" : : "r" (_p): "memory") */
-#endif
-
 /** Cache helper functions */
 /* Flush the cache lines starting at p for at least n bytes */
 void* wh_Utils_CacheFlush(void* p, size_t n);


### PR DESCRIPTION
First stage of a sequence of fixes.  This one adds cache flush/mem fencing support to mem transport, stolen from the Bernina private repo, which corrects the surprisingly relaxed memory consistency on Apple silicon when running the sim.