### PR TITLE
fix GCC macro

### DIFF
--- a/wolfhsm/wh_settings.h
+++ b/wolfhsm/wh_settings.h
@@ -171,7 +171,7 @@
 /** Cache flushing and memory fencing synchronization primitives */
 /* Create a full sequential memory fence to ensure compiler memory ordering */
 #ifndef XMEMFENCE
-#if defined(__GCC__) || defined(__clang__)
+#if defined(__GNUC__) || defined(__clang__)
 #define XMEMFENCE() __atomic_thread_fence(__ATOMIC_SEQ_CST)
 /* PPC32: __asm__ volatile ("sync" : : : "memory") */
 #else


### PR DESCRIPTION
GCC defines `__GNUC__ `, not `__GCC__`. I have no idea why this isn't throwing warnings on CI (which uses GCC) - but it won't compile locally for me