### PR TITLE
Add RSA ser/de handling for public keys

### DIFF
--- a/src/wh_client_cryptocb.c
+++ b/src/wh_client_cryptocb.c
@@ -60,7 +60,7 @@ static int _xferSha256BlockAndUpdateDigest(whClientContext* ctx,
                                            wc_Sha256* sha256,
                                            whPacket* packet,
                                            uint32_t isLastBlock);
-#ifdef WOLFHSM_CFG_DMA                                           
+#ifdef WOLFHSM_CFG_DMA
 static int _handleSha256Dma(int devId, wc_CryptoInfo* info, void* inCtx,
                          whPacket* packet);
 #endif /* WOLFHSM_CFG_DMA */


### PR DESCRIPTION
Adds support to the RSA key serialization and deserialization functions for handling public keys (current impl assumes they are private, causing ASN errors to be thrown if used on a public key).

There is no good way to detect if a DER key is private/public, so we now will first attempt to deserialize DER as a private key, and if that fails it falls back to trying it as a public key.

For serialization, it detects the type from `RsaKey->type` field and calls the appropriate serializer.