### PR TITLE
hsmFreshenKey bugfix

### DIFF
--- a/tools/whnvmtool/.gitignore
+++ b/tools/whnvmtool/.gitignore
@@ -1,4 +1,4 @@
 whnvmtool
-whNvmImage.bin
-whNvmImage.hex
 test/test_whnvmtool
+*.bin
+*.hex

--- a/tools/whnvmtool/test/test_whnvmtool.c
+++ b/tools/whnvmtool/test/test_whnvmtool.c
@@ -1,3 +1,25 @@
+/*
+ * Copyright (C) 2024 wolfSSL Inc.
+ *
+ * This file is part of wolfHSM.
+ *
+ * wolfHSM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfHSM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wolfHSM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * tools/whnvmtool/test/test_whnvmtool.c
+ *
+ */
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>

--- a/tools/whnvmtool/whnvmtool.c
+++ b/tools/whnvmtool/whnvmtool.c
@@ -1,3 +1,25 @@
+/*
+ * Copyright (C) 2024 wolfSSL Inc.
+ *
+ * This file is part of wolfHSM.
+ *
+ * wolfHSM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfHSM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wolfHSM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * tools/whnvmtool/whnvmtool.c
+ *
+ */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Fixes bug where `hsmFreshenKey()` doesn't actually do what it says it does and load from NVM into cache

Unrelated additions:
- adds license files to `whnvmtool`
- updates `whnvmtool` gitignore