### PR TITLE
Update to support relicensing to commercial license

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,16 @@
+#wolfHSM Release v1.0.0 (October 17, 2024)
+Initial release after internal and early evaluator testing. Due to NDA restrictions, access to the Infineon and ST Micro ports is limited. Please contact support@wolfssl.com for access.
+
+## New Feature Additions
+* POSIX simulator and test environment
+* Memory fencing and cache controls for memory transport
+* Support for Aurix Tricore TC3xx and ST SPC58NN
+* DMA support for SHA2 and NVM objects
+* Cancellation for CMAC
+* Support NO_MALLOC and STATIC_MEMORY
+* SHE+ interface
+
+## Enhancements and Optimizations
+* Reduction in static server memory requirements
+* Hardware offload for AURIX and ST C3 modules
+

--- a/LICENSING
+++ b/LICENSING
@@ -1,0 +1,12 @@
+
+wolfHSM and wolfCrypt is either licensed for use under the GPLv3 (or at your 
+option any later version) or a standard commercial license. For our users who 
+cannot use wolfHSM and wolfCrypt under GPLv3 (or any later version), a 
+commercial license to wolfHSM and wolfCrypt is available.
+
+Please contact wolfSSL Inc. directly at:
+
+Email: licensing@wolfssl.com
+Phone: +1 425 245-8247
+
+More information can be found on the wolfSSL website at www.wolfssl.com.

--- a/port/posix/posix_transport_shm.c
+++ b/port/posix/posix_transport_shm.c
@@ -1,3 +1,25 @@
+/*
+ * Copyright (C) 2024 wolfSSL Inc.
+ *
+ * This file is part of wolfHSM.
+ *
+ * wolfHSM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfHSM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wolfHSM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * port/posix/posix_transport_shm.c
+ */
+
 #include <fcntl.h>     /* For O_* constants */
 #include <sys/mman.h>  /* For shm_open, mmap */
 #include <sys/stat.h>  /* For mode constants */

--- a/port/posix/posix_transport_shm.h
+++ b/port/posix/posix_transport_shm.h
@@ -16,6 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with wolfHSM.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 /*
  * port/posix_transport_shm.h
  *

--- a/test/wh_test_check_struct_padding.c
+++ b/test/wh_test_check_struct_padding.c
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2024 wolfSSL Inc.
+ *
+ * This file is part of wolfHSM.
+ *
+ * wolfHSM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfHSM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wolfHSM.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef WH_TEST_CHECK_STRUCT_PADDING_C_
 #define WH_TEST_CHECK_STRUCT_PADDING_C_
 

--- a/test/wh_test_she.h
+++ b/test/wh_test_she.h
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2024 wolfSSL Inc.
+ *
+ * This file is part of wolfHSM.
+ *
+ * wolfHSM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfHSM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wolfHSM.  If not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef WH_TEST_SHE_H_
 #define WH_TEST_SHE_H_
 


### PR DESCRIPTION
1. Added missing GPLv3 license text in some source.
2. Added LICENSING note.
3. Added ChangeLog