### PR TITLE
Curve25519 fixes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,12 +34,10 @@ jobs:
       run: cd test && make clean && make WOLFSSL_DIR=../wolfssl run
 
     # Build and test ASAN build, with wolfCrypt tests enabled.
-    # since wolfCrypt tests aren't all passing yet - this is just a status indicator
-    - name: Build and test ASAN TESTWOLFCRYPT (wolfCrypt tests OK to fail)
+    - name: Build and test ASAN TESTWOLFCRYPT
       run: cd test && make clean && make ASAN=1 TESTWOLFCRYPT=1 WOLFSSL_DIR=../wolfssl run
 
     # Build and test ASAN build, with wolfCrypt tests enabled and using the DMA devId.
-    # since wolfCrypt tests aren't all passing yet - this is just a status indicator
     - name: Build and test ASAN TESTWOLFCRYPT TESTWOLFCRYPT_DMA
       run: cd test && make clean && make ASAN=1 TESTWOLFCRYPT=1 TESTWOLFCRYPT_DMA=1 WOLFSSL_DIR=../wolfssl run
 
@@ -54,8 +52,3 @@ jobs:
     # Build and test debug build with SHE
     - name: Build and test SHE
       run: cd test && make clean && make SHE=1 WOLFSSL_DIR=../wolfssl run
-
-    ## Test structure padding
-    #- name: Check structure padding
-    #  run: cd test && make clean && make checkpadding
-

--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -1195,6 +1195,10 @@ int wh_Client_Curve25519ImportKey(whClientContext* ctx, curve25519_key* key,
         if (inout_keyId != NULL) {
             *inout_keyId = key_id;
         }
+#if defined(DEBUG_CRYPTOCB) && defined(DEBUG_CRYPTOCB_VERBOSE)
+        printf("[client] importKey: cached keyid=%u\n", key_id);
+        wh_Utils_Hexdump("[client] importKey: key=", buffer, buffer_len);
+#endif
     }
     return ret;
 }

--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -1185,8 +1185,8 @@ int wh_Client_Curve25519ImportKey(whClientContext* ctx, curve25519_key* key,
         key_id = *inout_keyId;
     }
 
-    ret = wh_Crypto_Curve25519SerializeKey(key, sizeof(buffer),buffer,
-            &buffer_len);
+    buffer_len = sizeof(buffer);
+    ret        = wh_Crypto_Curve25519SerializeKey(key, buffer, &buffer_len);
     if (ret == 0) {
         /* Cache the key and get the keyID */
         ret = wh_Client_KeyCache(ctx,
@@ -1220,8 +1220,7 @@ int wh_Client_Curve25519ExportKey(whClientContext* ctx, whKeyId keyId,
             buffer, &buffer_len);
     if (ret == 0) {
         /* Update the key structure */
-        ret = wh_Crypto_Curve25519DeserializeKey(
-                buffer_len, buffer, key);
+        ret = wh_Crypto_Curve25519DeserializeKey(buffer, buffer_len, key);
     }
 
     return ret;
@@ -1311,8 +1310,7 @@ static int _Curve25519MakeKey(whClientContext* ctx,
 
                 if (flags & WH_NVM_FLAGS_EPHEMERAL) {
                     /* Response has the exported key */
-                    ret = wh_Crypto_Curve25519DeserializeKey(
-                            der_size, key_der, key);
+                    ret = wh_Crypto_Curve25519DeserializeKey(key_der, der_size, key);
 #ifdef DEBUG_CRYPTOCB_VERBOSE
                     wh_Utils_Hexdump("[client] KeyGen export:", key_der, der_size);
 #endif

--- a/src/wh_crypto.c
+++ b/src/wh_crypto.c
@@ -208,22 +208,6 @@ int wh_Crypto_EccUpdatePrivateOnlyKeyDer(ecc_key* key, uint16_t pub_size,
 
 #ifdef HAVE_CURVE25519
 
-#ifdef HAVE_CURVE25519
-#ifdef HAVE_CURVE25519_KEY_IMPORT
-WOLFSSL_API int wc_Curve25519PrivateKeyDecode(
-    const byte* input, word32* inOutIdx, curve25519_key* key, word32 inSz);
-WOLFSSL_API int wc_Curve25519PublicKeyDecode(
-    const byte* input, word32* inOutIdx, curve25519_key* key, word32 inSz);
-#endif
-#ifdef HAVE_CURVE25519_KEY_EXPORT
-WOLFSSL_API int wc_Curve25519PrivateKeyToDer(
-    curve25519_key* key, byte* output, word32 inLen);
-WOLFSSL_API int wc_Curve25519PublicKeyToDer(
-    curve25519_key* key, byte* output, word32 inLen, int withAlg);
-#endif
-#endif /* HAVE_CURVE25519 */
-
-
 /* Store a curve25519_key to a byte sequence in DER format */
 int wh_Crypto_Curve25519SerializeKey(curve25519_key* key, uint8_t* buffer,
                                      uint16_t* derSize)

--- a/src/wh_crypto.c
+++ b/src/wh_crypto.c
@@ -257,51 +257,6 @@ int wh_Crypto_Curve25519DeserializeKey(const uint8_t* derBuffer,
 
     return wc_Curve25519KeyDecode(derBuffer, &idx, key, derSize);
 }
-
-int wh_Crypto_Curve25519SerializeKeyRaw(curve25519_key* key,
-        uint16_t max_size, uint8_t* buffer, uint16_t *out_size)
-{
-    int ret = 0;
-    word32 privSz = CURVE25519_KEYSIZE;
-    word32 pubSz = CURVE25519_KEYSIZE;
-
-    if (    (key == NULL) ||
-            (buffer == NULL)) {
-        return WH_ERROR_BADARGS;
-    }
-
-    ret = wc_curve25519_export_key_raw(key,
-            buffer + CURVE25519_KEYSIZE, &privSz,
-            buffer, &pubSz);
-    if (    (ret == 0) &&
-            (out_size != NULL)) {
-        *out_size = CURVE25519_KEYSIZE * 2;
-    }
-    return ret;
-}
-
-int wh_Crypto_Curve25519DeserializeKeyRaw(uint16_t size,
-        const uint8_t* buffer, curve25519_key* key)
-{
-    int ret = 0;
-    word32 privSz = CURVE25519_KEYSIZE;
-    word32 pubSz = CURVE25519_KEYSIZE;
-
-    if (    (size < (CURVE25519_KEYSIZE * 2)) ||
-            (buffer == NULL) ||
-            (key == NULL)) {
-        return WH_ERROR_BADARGS;
-    }
-
-    /* decode the key */
-    if (ret == 0) {
-        ret = wc_curve25519_import_private_raw(
-                buffer + CURVE25519_KEYSIZE, privSz,
-                buffer, pubSz,
-                key);
-    }
-    return ret;
-}
 #endif /* HAVE_CURVE25519 */
 
 #endif  /* !WOLFHSM_CFG_NO_CRYPTO */

--- a/src/wh_crypto.c
+++ b/src/wh_crypto.c
@@ -36,7 +36,6 @@
 #include "wolfssl/wolfcrypt/types.h"
 #include "wolfssl/wolfcrypt/error-crypt.h"
 #include "wolfssl/wolfcrypt/asn.h"
-#include "wolfssl/wolfcrypt/asn_public.h"
 #include "wolfssl/wolfcrypt/rsa.h"
 #include "wolfssl/wolfcrypt/curve25519.h"
 #include "wolfssl/wolfcrypt/ecc.h"
@@ -230,12 +229,16 @@ int wh_Crypto_Curve25519SerializeKey(curve25519_key* key, uint8_t* buffer,
                                      uint16_t* derSize)
 {
     int ret = 0;
+    /* We must include the algorithm identifier in the DER encoding, or we will
+     * not be able to deserialize it properly in the public key only case*/
+    const int WITH_ALG_ENABLE_SUBJECT_PUBLIC_KEY_INFO = 1;
 
     if ((key == NULL) || (buffer == NULL) || (derSize == NULL)) {
         return WH_ERROR_BADARGS;
     }
 
-    ret = wc_Curve25519KeyToDer(key, buffer, *derSize, 0);
+    ret = wc_Curve25519KeyToDer(key, buffer, *derSize,
+                                WITH_ALG_ENABLE_SUBJECT_PUBLIC_KEY_INFO);
 
     /* ASN.1 functions return the size of the DER encoded key on success */
     if (ret > 0) {

--- a/src/wh_crypto.c
+++ b/src/wh_crypto.c
@@ -225,7 +225,7 @@ WOLFSSL_API int wc_Curve25519PublicKeyToDer(
 #endif /* HAVE_CURVE25519 */
 
 
-/* TODO make input key const */
+/* Store a curve25519_key to a byte sequence in DER format */
 int wh_Crypto_Curve25519SerializeKey(curve25519_key* key, uint8_t* buffer,
                                      uint16_t* derSize)
 {
@@ -245,10 +245,10 @@ int wh_Crypto_Curve25519SerializeKey(curve25519_key* key, uint8_t* buffer,
     return ret;
 }
 
+/* Restore a curve25519_key from a byte sequence in DER format */
 int wh_Crypto_Curve25519DeserializeKey(const uint8_t* derBuffer,
                                        uint16_t derSize, curve25519_key* key)
 {
-    int    ret = WH_ERROR_OK;
     word32 idx = 0;
 
     if ((derBuffer == NULL) || (key == NULL)) {

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -1588,7 +1588,7 @@ static int _HandleSha256Dma(whServerContext* server, whPacket* packet,
         if (ret == WH_ERROR_OK) {
 #ifdef DEBUG_CRYPTOCB_VERBOSE
             printf("[server]   wc_Sha256Update: inAddr=%p, sz=%llu\n", inAddr,
-                   req->input.sz);
+                   (long long unsigned int)req->input.sz);
 #endif
             ret = wc_Sha256Update(sha256, inAddr, req->input.sz);
         }

--- a/src/wh_server_keystore.c
+++ b/src/wh_server_keystore.c
@@ -220,6 +220,10 @@ int hsmCacheKey(whServerContext* server, whNvmMetadata* meta, uint8_t* in)
             } else {
                 server->cache[foundIndex].commited = 1;
             }
+#if defined(DEBUG_CRYPTOCB) && defined(DEBUG_CRYPTOCB_VERBOSE)
+            printf("[server] cacheKey: caching keyid=%u\n", meta->id);
+            wh_Utils_Hexdump("[server] cacheKey: key=", in, meta->len);
+#endif
         }
     } else {
         /* try big key cache, don't put small keys into big cache if full */

--- a/test/wh_test.c
+++ b/test/wh_test.c
@@ -48,7 +48,7 @@ int whTest_Unit(void)
 
     /* Component Tests */
     WH_TEST_ASSERT(0 == whTest_Flash_RamSim());
-    /* WH_TEST_ASSERT(0 == whTest_NvmFlash()); */
+    WH_TEST_ASSERT(0 == whTest_NvmFlash());
 
     /* Comm tests */
     WH_TEST_ASSERT(0 == whTest_Comm());

--- a/test/wh_test.c
+++ b/test/wh_test.c
@@ -48,7 +48,7 @@ int whTest_Unit(void)
 
     /* Component Tests */
     WH_TEST_ASSERT(0 == whTest_Flash_RamSim());
-    WH_TEST_ASSERT(0 == whTest_NvmFlash());
+    /* WH_TEST_ASSERT(0 == whTest_NvmFlash()); */
 
     /* Comm tests */
     WH_TEST_ASSERT(0 == whTest_Comm());

--- a/wolfhsm/wh_crypto.h
+++ b/wolfhsm/wh_crypto.h
@@ -77,11 +77,17 @@ int wh_Crypto_EccUpdatePrivateOnlyKeyDer(ecc_key* key, uint16_t pub_size,
 
 #ifdef HAVE_CURVE25519
 /* Store a curve25519_key to a byte sequence */
-int wh_Crypto_Curve25519SerializeKey(curve25519_key* key,
-        uint16_t max_size, uint8_t* buffer, uint16_t *out_size);
+int wh_Crypto_Curve25519SerializeKey(curve25519_key* key, uint8_t* buffer,
+                                     uint16_t* out_size);
 /* Restore a curve25519_key from a byte sequence */
-int wh_Crypto_Curve25519DeserializeKey(uint16_t size,
-        const uint8_t* buffer, curve25519_key* key);
+int wh_Crypto_Curve25519DeserializeKey(const uint8_t* derBuffer,
+                                       uint16_t derSize, curve25519_key* key);
+/* Store a curve25519_key to a byte sequence in raw format */
+int wh_Crypto_Curve25519SerializeKeyRaw(curve25519_key* key, uint16_t max_size,
+                                        uint8_t* buffer, uint16_t* out_size);
+/* Restore a curve25519_key from a byte sequence in raw format */
+int wh_Crypto_Curve25519DeserializeKeyRaw(uint16_t size, const uint8_t* buffer,
+                                          curve25519_key* key);
 #endif /* HAVE_CURVE25519 */
 
 #endif  /* !WOLFHSM_CFG_NO_CRYPTO */

--- a/wolfhsm/wh_crypto.h
+++ b/wolfhsm/wh_crypto.h
@@ -82,12 +82,6 @@ int wh_Crypto_Curve25519SerializeKey(curve25519_key* key, uint8_t* buffer,
 /* Restore a curve25519_key from a byte sequence */
 int wh_Crypto_Curve25519DeserializeKey(const uint8_t* derBuffer,
                                        uint16_t derSize, curve25519_key* key);
-/* Store a curve25519_key to a byte sequence in raw format */
-int wh_Crypto_Curve25519SerializeKeyRaw(curve25519_key* key, uint16_t max_size,
-                                        uint8_t* buffer, uint16_t* out_size);
-/* Restore a curve25519_key from a byte sequence in raw format */
-int wh_Crypto_Curve25519DeserializeKeyRaw(uint16_t size, const uint8_t* buffer,
-                                          curve25519_key* key);
 #endif /* HAVE_CURVE25519 */
 
 #endif  /* !WOLFHSM_CFG_NO_CRYPTO */


### PR DESCRIPTION
Fixes curve25519 implementation, changing it to use new [wolfCrypt DER API ](https://github.com/wolfSSL/wolfssl/pull/8129) for ser/de instead of raw keys
