### PR TITLE
Fix memory leak in SHE tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,6 +49,6 @@ jobs:
     - name: Build and test ASAN DEBUG
       run: cd test && make clean && make DEBUG=1 ASAN=1 WOLFSSL_DIR=../wolfssl run
 
-    # Build and test debug build with SHE
-    - name: Build and test SHE
-      run: cd test && make clean && make SHE=1 WOLFSSL_DIR=../wolfssl run
+    # Build and test with SHE and ASAN
+    - name: Build and test ASAN SHE
+      run: cd test && make clean && make SHE=1 ASAN=1 WOLFSSL_DIR=../wolfssl run

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-# wolfHSM Release v1.1.0 (January 22, 2025)
+# wolfHSM Release v1.1.0 (January 23, 2025)
 Due to NDA restrictions, access to the Infineon and ST Micro ports is limited. Please contact support@wolfssl.com for access.
 
 ## New Feature Additions
@@ -8,6 +8,7 @@ Due to NDA restrictions, access to the Infineon and ST Micro ports is limited. P
 ## Bug Fixes
 * Fixes memory error in ECC verify (PR#81)
 * Removes unused argument warnings on 32 bit targets (PR#82)
+* Fixes memory leak in SHE test (PR#88)
 
 ## Enhancements and Optimizations
 * Improved handling of Curve25519 DER encoded keys using new wolfCrypt APIs (PR#83)

--- a/test/wh_test_she.c
+++ b/test/wh_test_she.c
@@ -178,6 +178,8 @@ int whTest_SheClientConfig(whClientConfig* config)
         WH_ERROR_PRINT("Failed to wc_RNG_GenerateBlock %d\n", ret);
         goto exit;
     }
+    /* Done generating test data, free RNG */
+    wc_FreeRng(rng);
     /* cmac 0..0 | size | bootloader */
     if ((ret = wc_InitCmac(cmac, key, sizeof(key), WC_CMAC_AES, NULL)) != 0) {
         WH_ERROR_PRINT("Failed to wc_InitCmac %d\n", ret);


### PR DESCRIPTION
Fixes a memory leak in the SHE tests caused by not freeing the RNG used to generate arbitrary test data.

We weren't running SHE tests under ASAN for some reason. When I turned it on, it flagged the leak.