### PR TITLE
DMA support for CMAC

### DIFF
--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -2009,11 +2009,11 @@ int wh_Client_CmacGetKeyId(Cmac* key, whNvmId* outId)
 
 #ifndef NO_AES
 int wh_Client_CmacAesGenerate(Cmac* cmac, byte* out, word32* outSz,
-    const byte* in, word32 inSz, whNvmId keyId, void* heap)
+    const byte* in, word32 inSz, whNvmId keyId, void* heap, int devId)
 {
     int ret;
     ret = wc_InitCmac_ex(cmac, NULL, 0, WC_CMAC_AES, NULL, heap,
-        WH_DEV_ID);
+        devId);
     /* set keyId */
     if (ret == 0)
         ret = wh_Client_CmacSetKeyId(cmac, keyId);
@@ -2025,13 +2025,13 @@ int wh_Client_CmacAesGenerate(Cmac* cmac, byte* out, word32* outSz,
 }
 
 int wh_Client_CmacAesVerify(Cmac* cmac, const byte* check, word32 checkSz,
-    const byte* in, word32 inSz, whNvmId keyId, void* heap)
+    const byte* in, word32 inSz, whNvmId keyId, void* heap, int devId)
 {
     int ret;
     word32 outSz = AES_BLOCK_SIZE;
     byte out[AES_BLOCK_SIZE];
     ret = wc_InitCmac_ex(cmac, NULL, 0, WC_CMAC_AES, NULL, heap,
-        WH_DEV_ID);
+        devId);
     /* set keyId */
     if (ret == 0)
         ret = wh_Client_CmacSetKeyId(cmac, keyId);

--- a/src/wh_client_cryptocb.c
+++ b/src/wh_client_cryptocb.c
@@ -113,7 +113,7 @@ static int _handleCmacDma(wc_CryptoInfo* info, void* inCtx, whPacket* packet)
     if (info->cmac.out != NULL) {
         /* Finalize operation */
         req->output.addr = (uintptr_t)info->cmac.out;
-        req->output.sz = (size_t)info->cmac.outSz;
+        req->output.sz = (size_t)*info->cmac.outSz;
         req->finalize = 1;
     }
 

--- a/src/wh_client_cryptocb.c
+++ b/src/wh_client_cryptocb.c
@@ -1110,7 +1110,3 @@ int wh_Client_CryptoCbDma(int devId, wc_CryptoInfo* info, void* inCtx)
 
 #endif /* !WOLFHSM_CFG_NO_CRYPTO */
 
-#ifdef WOLFSSL_CMAC
-#ifdef WOLFHSM_CFG_DMA
-#endif /* WOLFHSM_CFG_DMA */
-#endif /* WOLFSSL_CMAC */

--- a/src/wh_client_cryptocb.c
+++ b/src/wh_client_cryptocb.c
@@ -93,6 +93,10 @@ static int _handleCmacDma(wc_CryptoInfo* info, void* inCtx, whPacket* packet)
     XMEMSET(req, 0, sizeof(*req));
     req->type = info->cmac.type;
 
+    /* Store devId and devCtx to restore after request */
+    int   devId  = cmac->devId;
+    void* devCtx = cmac->devCtx;
+
     /* Set up DMA state buffer in client address space */
     req->state.addr = (uintptr_t)cmac;
     req->state.sz = sizeof(*cmac);
@@ -143,6 +147,10 @@ static int _handleCmacDma(wc_CryptoInfo* info, void* inCtx, whPacket* packet)
             *info->cmac.outSz = res->outSz;
         }
     }
+
+    /* Restore devId and devCtx after DMA operation */
+    cmac->devId  = devId;
+    cmac->devCtx = devCtx;
 
     return ret;
 }

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -2544,13 +2544,14 @@ static int _HandleCmacDma(whServerContext* server, whPacket* packet,
                         }
                         else {
                             ctxHoldsLocalKey = 1;
-                            /* Save CMAC context fields before initialization */
+
+                            /* Save CMAC state so we can resume operation after
+                             * initialization with key, as reinit will clear the
+                             * state */
                             byte   savedBuffer[AES_BLOCK_SIZE];
                             byte   savedDigest[AES_BLOCK_SIZE];
                             word32 savedBufferSz = cmac->bufferSz;
                             word32 savedTotalSz  = cmac->totalSz;
-
-                            /* Copy buffer and digest contents */
                             memcpy(savedBuffer, cmac->buffer, AES_BLOCK_SIZE);
                             memcpy(savedDigest, cmac->digest, AES_BLOCK_SIZE);
 
@@ -2558,8 +2559,7 @@ static int _HandleCmacDma(whServerContext* server, whPacket* packet,
                                                  WC_CMAC_AES, NULL, NULL,
                                                  server->crypto->devId);
 
-                            /* Restore CMAC context fields after initialization
-                             */
+                            /* Restore CMAC state */
                             memcpy(cmac->buffer, savedBuffer, AES_BLOCK_SIZE);
                             memcpy(cmac->digest, savedDigest, AES_BLOCK_SIZE);
                             cmac->bufferSz = savedBufferSz;

--- a/src/wh_server_keystore.c
+++ b/src/wh_server_keystore.c
@@ -39,6 +39,7 @@
 #include "wolfhsm/wh_error.h"
 #include "wolfhsm/wh_message.h"
 #include "wolfhsm/wh_packet.h"
+#include "wolfhsm/wh_utils.h"
 #include "wolfhsm/wh_server.h"
 
 #ifdef WOLFHSM_CFG_SHE_EXTENSION

--- a/src/wh_utils.c
+++ b/src/wh_utils.c
@@ -43,9 +43,9 @@ uint16_t wh_Utils_Swap16(uint16_t val)
 uint32_t wh_Utils_Swap32(uint32_t val)
 {
     return  ((val & 0xFF000000ul) >> 24) |
-            ((val & 0xFF0000ul) >> 8) |
-            ((val & 0xFF00ul) >> 8) |
-            ((val & 0xFFul) << 24);
+            ((val & 0x00FF0000ul) >> 8) |
+            ((val & 0x0000FF00ul) << 8) |
+            ((val & 0x000000FFul) << 24);
 }
 
 uint64_t wh_Utils_Swap64(uint64_t val)

--- a/test/wh_test_check_struct_padding.c
+++ b/test/wh_test_check_struct_padding.c
@@ -137,6 +137,8 @@ wh_Packet_pq_mldsa_sign_Dma32_req   pqMldsaSignDma32Req;
 wh_Packet_pq_mldsa_sign_Dma32_res   pqMldsaSignDma32Res;
 wh_Packet_pq_mldsa_verify_Dma32_req pqMldsaVerifyDma32Req;
 wh_Packet_pq_mldsa_verify_Dma32_res pqMldsaVerifyDma32Res;
+wh_Packet_cmac_Dma32_req            cmacDma32Req;
+wh_Packet_cmac_Dma32_res            cmacDma32Res;
 #elif defined(WOLFHSM_CFG_DMA) && WH_DMA_IS_64BIT
 wh_Packet_hash_sha256_Dma64_req     hashSha256Dma64Req;
 wh_Packet_hash_sha256_Dma64_res     hashSha256Dma64Res;
@@ -146,6 +148,8 @@ wh_Packet_pq_mldsa_sign_Dma64_req   pqMldsaSignDma64Req;
 wh_Packet_pq_mldsa_sign_Dma64_res   pqMldsaSignDma64Res;
 wh_Packet_pq_mldsa_verify_Dma64_req pqMldsaVerifyDma64Req;
 wh_Packet_pq_mldsa_verify_Dma64_res pqMldsaVerifyDma64Res;
+wh_Packet_cmac_Dma64_req            cmacDma64Req;
+wh_Packet_cmac_Dma64_res            cmacDma64Res;
 #endif
 
 #endif /* !WOLFHSM_CFG_NO_CRYPTO */

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -1168,40 +1168,46 @@ static int whTestCrypto_Cmac(whClientContext* ctx, int devId, WC_RNG* rng)
 {
     int ret;
     /* test cmac */
-    Cmac cmac[1];
+    Cmac    cmac[1];
     uint8_t knownCmacKey[] = {0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
-        0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c};
-    uint8_t knownCmacMessage[] = {0x6b, 0xc1, 0xbe, 0xe2, 0x2e, 0x40, 0x9f,
-        0x96, 0xe9, 0x3d, 0x7e, 0x11, 0x73, 0x93, 0x17, 0x2a, 0xae, 0x2d, 0x8a,
-        0x57, 0x1e, 0x03, 0xac, 0x9c, 0x9e, 0xb7, 0x6f, 0xac, 0x45, 0xaf, 0x8e,
-        0x51, 0x30, 0xc8, 0x1c, 0x46, 0xa3, 0x5c, 0xe4, 0x11, 0xe5, 0xfb, 0xc1,
-        0x19, 0x1a, 0x0a, 0x52, 0xef, 0xf6, 0x9f, 0x24, 0x45, 0xdf, 0x4f, 0x9b,
+                              0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c};
+    uint8_t knownCmacMessage[] = {
+        0x6b, 0xc1, 0xbe, 0xe2, 0x2e, 0x40, 0x9f, 0x96, 0xe9, 0x3d, 0x7e,
+        0x11, 0x73, 0x93, 0x17, 0x2a, 0xae, 0x2d, 0x8a, 0x57, 0x1e, 0x03,
+        0xac, 0x9c, 0x9e, 0xb7, 0x6f, 0xac, 0x45, 0xaf, 0x8e, 0x51, 0x30,
+        0xc8, 0x1c, 0x46, 0xa3, 0x5c, 0xe4, 0x11, 0xe5, 0xfb, 0xc1, 0x19,
+        0x1a, 0x0a, 0x52, 0xef, 0xf6, 0x9f, 0x24, 0x45, 0xdf, 0x4f, 0x9b,
         0x17, 0xad, 0x2b, 0x41, 0x7b, 0xe6, 0x6c, 0x37, 0x10};
-    uint8_t knownCmacTag[AES_BLOCK_SIZE] = {0x51, 0xf0, 0xbe, 0xbf, 0x7e, 0x3b, 0x9d, 0x92,
-        0xfc, 0x49, 0x74, 0x17, 0x79, 0x36, 0x3c, 0xfe};
+    uint8_t knownCmacTag[AES_BLOCK_SIZE] = {0x51, 0xf0, 0xbe, 0xbf, 0x7e, 0x3b,
+                                            0x9d, 0x92, 0xfc, 0x49, 0x74, 0x17,
+                                            0x79, 0x36, 0x3c, 0xfe};
 
     uint8_t labelIn[WH_NVM_LABEL_LEN] = "CMAC Key Label";
 
-    uint8_t keyEnd[sizeof(knownCmacKey)] = {0};
-    uint8_t labelEnd[WH_NVM_LABEL_LEN] = {0};
-    uint16_t outLen = 0;
-    uint8_t macOut[AES_BLOCK_SIZE] = {0};
-    word32 macLen;
-    whKeyId keyId;
+    uint8_t  keyEnd[sizeof(knownCmacKey)] = {0};
+    uint8_t  labelEnd[WH_NVM_LABEL_LEN]   = {0};
+    uint16_t outLen                       = 0;
+    uint8_t  macOut[AES_BLOCK_SIZE]       = {0};
+    word32   macLen;
+    whKeyId  keyId;
 
-    ret = wc_InitCmac_ex(cmac, knownCmacKey, sizeof(knownCmacKey), WC_CMAC_AES, NULL, NULL, devId);
+    ret = wc_InitCmac_ex(cmac, knownCmacKey, sizeof(knownCmacKey), WC_CMAC_AES,
+                         NULL, NULL, devId);
     if (ret != 0) {
         WH_ERROR_PRINT("Failed to wc_InitCmac_ex %d\n", ret);
-    } else {
+    }
+    else {
         ret = wc_CmacUpdate(cmac, knownCmacMessage, sizeof(knownCmacMessage));
         if (ret != 0) {
             WH_ERROR_PRINT("Failed to wc_CmacUpdate %d\n", ret);
-        } else {
+        }
+        else {
             macLen = sizeof(macOut);
-            ret = wc_CmacFinal(cmac, macOut, &macLen);
+            ret    = wc_CmacFinal(cmac, macOut, &macLen);
             if (ret != 0) {
                 WH_ERROR_PRINT("Failed to wc_CmacFinal %d\n", ret);
-            } else {
+            }
+            else {
                 if (memcmp(knownCmacTag, macOut, sizeof(knownCmacTag)) != 0) {
                     WH_ERROR_PRINT("CMAC FAILED KNOWN ANSWER TEST\n");
                     ret = -1;
@@ -1214,7 +1220,10 @@ static int whTestCrypto_Cmac(whClientContext* ctx, int devId, WC_RNG* rng)
 
     if (ret == 0) {
         /* test oneshot verify */
-        ret = wc_AesCmacVerify_ex(cmac, knownCmacTag, sizeof(knownCmacTag), knownCmacMessage, sizeof(knownCmacMessage), knownCmacKey, sizeof(knownCmacKey), NULL, WH_DEV_ID);
+        ret = wc_AesCmacVerify_ex(cmac, knownCmacTag, sizeof(knownCmacTag),
+                                  knownCmacMessage, sizeof(knownCmacMessage),
+                                  knownCmacKey, sizeof(knownCmacKey), NULL,
+                                  devId);
         if (ret != 0) {
             WH_ERROR_PRINT("Failed to wc_AesCmacVerify_ex %d\n", ret);
         }
@@ -1223,28 +1232,49 @@ static int whTestCrypto_Cmac(whClientContext* ctx, int devId, WC_RNG* rng)
     if (ret == 0) {
         /* test oneshot generate with pre-cached key */
         keyId = WH_KEYID_ERASED;
-        ret = wh_Client_KeyCache(ctx, 0, labelIn, sizeof(labelIn), knownCmacKey, sizeof(knownCmacKey), &keyId);
+        ret = wh_Client_KeyCache(ctx, 0, labelIn, sizeof(labelIn), knownCmacKey,
+                                 sizeof(knownCmacKey), &keyId);
         if (ret != 0) {
             WH_ERROR_PRINT("Failed to wh_Client_KeyCache %d\n", ret);
-        } else {
+        }
+        else {
             macLen = sizeof(macOut);
-            ret = wh_Client_CmacAesGenerate(cmac, macOut, &macLen, knownCmacMessage, sizeof(knownCmacMessage), keyId, NULL);
+            ret    = wh_Client_CmacAesGenerate(
+                cmac, macOut, &macLen, knownCmacMessage,
+                sizeof(knownCmacMessage), keyId, NULL, devId);
             if (ret != 0) {
                 WH_ERROR_PRINT("Failed to wh_Client_AesCmacGenerate %d\n", ret);
-            } else {
+            }
+            else {
                 if (memcmp(knownCmacTag, macOut, sizeof(knownCmacTag)) != 0) {
                     WH_ERROR_PRINT("CMAC FAILED KNOWN ANSWER TEST\n");
                     ret = -1;
-                } else {
-                    /* TODO: Eliminate this autoevict */
-                    /* verify the key was evicted after oneshot */
-                    outLen = sizeof(keyEnd);
-                    ret = wh_Client_KeyExport(ctx, keyId, labelEnd, sizeof(labelEnd), keyEnd, &outLen);
-                    if (ret != WH_ERROR_NOTFOUND) {
-                        WH_ERROR_PRINT("Failed to not find evicted key: %d\n", ret);
-                        ret = -1;
-                    } else {
-                        ret = 0;
+                }
+                else {
+                    /* DMA doesn't autoevict keys after use */
+                    /* TODO: should we instead match autoevict behavior for DMA */
+                    if (devId == WH_DEV_ID_DMA) {
+                        ret = wh_Client_KeyEvict(ctx, keyId);
+                        if (ret != 0) {
+                            WH_ERROR_PRINT("Failed to wh_Client_KeyEvict %d\n", ret);
+                            ret = -1;
+                        }
+                    }
+                    else {
+                        /* TODO: Eliminate this autoevict */
+                        /* verify the key was evicted after oneshot */
+                        outLen = sizeof(keyEnd);
+                        ret    = wh_Client_KeyExport(ctx, keyId, labelEnd,
+                                                     sizeof(labelEnd), keyEnd,
+                                                     &outLen);
+                        if (ret != WH_ERROR_NOTFOUND) {
+                            WH_ERROR_PRINT(
+                                "Failed to not find evicted key: %d\n", ret);
+                            ret = -1;
+                        }
+                        else {
+                            ret = 0;
+                        }
                     }
                 }
             }
@@ -1254,27 +1284,36 @@ static int whTestCrypto_Cmac(whClientContext* ctx, int devId, WC_RNG* rng)
     if (ret == 0) {
         /* test oneshot verify with commited key */
         keyId = WH_KEYID_ERASED;
-        ret = wh_Client_KeyCache(ctx, 0, labelIn, sizeof(labelIn), knownCmacKey, sizeof(knownCmacKey), &keyId);
+        ret = wh_Client_KeyCache(ctx, 0, labelIn, sizeof(labelIn), knownCmacKey,
+                                 sizeof(knownCmacKey), &keyId);
         if (ret != 0) {
             WH_ERROR_PRINT("Failed to wh_Client_KeyCache %d\n", ret);
-        } else {
+        }
+        else {
             ret = wh_Client_KeyCommit(ctx, keyId);
             if (ret != 0) {
                 WH_ERROR_PRINT("Failed to wh_Client_KeyCommit %d\n", ret);
-            } else {
+            }
+            else {
                 ret = wh_Client_KeyEvict(ctx, keyId);
                 if (ret != 0) {
                     WH_ERROR_PRINT("Failed to wh_Client_KeyEvict %d\n", ret);
-                } else {
+                }
+                else {
                     macLen = sizeof(macOut);
-                    ret = wh_Client_CmacAesVerify(cmac, macOut, macLen, (byte*)knownCmacMessage, sizeof(knownCmacMessage), keyId, NULL);
+                    ret    = wh_Client_CmacAesVerify(
+                        cmac, macOut, macLen, (byte*)knownCmacMessage,
+                        sizeof(knownCmacMessage), keyId, NULL, devId);
                     if (ret != 0) {
-                        WH_ERROR_PRINT("Failed to wh_Client_AesCmacVerify %d\n", ret);
-                    } else {
+                        WH_ERROR_PRINT("Failed to wh_Client_AesCmacVerify %d\n",
+                                       ret);
+                    }
+                    else {
                         /* test finished, erase key */
                         ret = wh_Client_KeyErase(ctx, keyId);
                         if (ret != 0) {
-                            WH_ERROR_PRINT("Failed to wh_Client_KeyErase %d\n", ret);
+                            WH_ERROR_PRINT("Failed to wh_Client_KeyErase %d\n",
+                                           ret);
                         }
                     }
                 }
@@ -1282,48 +1321,61 @@ static int whTestCrypto_Cmac(whClientContext* ctx, int devId, WC_RNG* rng)
         }
     }
 
-    if (ret == 0) {
-        /* test CMAC cancellation */
+    /* test CMAC cancellation for supported devIds */
+    if (ret == 0 && devId != WH_DEV_ID_DMA) {
 #define WH_TEST_CMAC_TEXTSIZE 1000
         char cmacFodder[WH_TEST_CMAC_TEXTSIZE] = {0};
 
         ret = wh_Client_EnableCancel(ctx);
         if (ret != 0) {
             WH_ERROR_PRINT("Failed to wh_Client_EnableCancel %d\n", ret);
-        } else {
-            ret = wc_InitCmac_ex(cmac, knownCmacKey, sizeof(knownCmacKey), WC_CMAC_AES, NULL, NULL, devId);
+        }
+        else {
+            ret = wc_InitCmac_ex(cmac, knownCmacKey, sizeof(knownCmacKey),
+                                 WC_CMAC_AES, NULL, NULL, devId);
             if (ret != 0) {
                 WH_ERROR_PRINT("Failed to wc_InitCmac_ex %d\n", ret);
-            } else {
+            }
+            else {
                 ret = wh_Client_CmacCancelableResponse(ctx, cmac, NULL, 0);
                 if (ret != 0) {
-                    WH_ERROR_PRINT("Failed to wh_Client_CmacCancelableResponse %d\n", ret);
-                } else {
+                    WH_ERROR_PRINT(
+                        "Failed to wh_Client_CmacCancelableResponse %d\n", ret);
+                }
+                else {
 #ifndef WOLFHSM_CFG_TEST_NO_CUSTOM_SERVERS
-                    /* TODO: use hsm pause/resume functionality on real hardware */
-                    /* delay the server so scheduling doesn't interfere with the timing */
+                    /* TODO: use hsm pause/resume functionality on real hardware
+                     */
+                    /* delay the server so scheduling doesn't interfere with the
+                     * timing */
                     serverDelay = 1;
 #endif
-                    ret = wc_CmacUpdate(cmac, (byte*)cmacFodder, sizeof(cmacFodder));
+                    ret = wc_CmacUpdate(cmac, (byte*)cmacFodder,
+                                        sizeof(cmacFodder));
                     if (ret != 0) {
                         WH_ERROR_PRINT("Failed to wc_CmacUpdate %d\n", ret);
-                    } else {
+                    }
+                    else {
                         ret = wh_Client_CancelRequest(ctx);
                         if (ret != 0) {
-                            WH_ERROR_PRINT("Failed to wh_Client_CancelRequest %d\n", ret);
-                        } else {
+                            WH_ERROR_PRINT(
+                                "Failed to wh_Client_CancelRequest %d\n", ret);
+                        }
+                        else {
 #ifndef WOLFHSM_CFG_TEST_NO_CUSTOM_SERVERS
                             serverDelay = 0;
 #endif
                             do {
                                 ret = wh_Client_CancelResponse(ctx);
                             } while (ret == WH_ERROR_NOTREADY);
-                            if(     (ret != 0) &&
+                            if ((ret != 0) &&
 #if defined(WOLFHSM_CFG_TEST_NO_CUSTOM_SERVERS)
-                                    (ret != WH_ERROR_CANCEL_LATE) &&
+                                (ret != WH_ERROR_CANCEL_LATE) &&
 #endif
-                                    (!0) ) {
-                                WH_ERROR_PRINT("Failed to wh_Client_CancelResponse %d\n", ret);
+                                (!0)) {
+                                WH_ERROR_PRINT(
+                                    "Failed to wh_Client_CancelResponse %d\n",
+                                    ret);
                             }
                         }
                     }
@@ -1331,39 +1383,67 @@ static int whTestCrypto_Cmac(whClientContext* ctx, int devId, WC_RNG* rng)
             }
 
             if (ret == 0) {
-                /* test cancelable request and response work for standard CMAC request with no cancellation */
-                ret = wc_InitCmac_ex(cmac, knownCmacKey, sizeof(knownCmacKey), WC_CMAC_AES, NULL, NULL, devId);
+                /* test cancelable request and response work for standard CMAC
+                 * request with no cancellation */
+                ret = wc_InitCmac_ex(cmac, knownCmacKey, sizeof(knownCmacKey),
+                                     WC_CMAC_AES, NULL, NULL, devId);
                 if (ret != 0) {
                     WH_ERROR_PRINT("Failed to wc_InitCmac_ex %d\n", ret);
-                } else {
+                }
+                else {
                     ret = wh_Client_CmacCancelableResponse(ctx, cmac, NULL, 0);
                     if (ret != 0) {
-                        WH_ERROR_PRINT("Failed to wh_Client_CmacCancelableResponse %d\n", ret);
-                    } else {
-                        ret = wc_CmacUpdate(cmac, (byte*)knownCmacMessage, sizeof(knownCmacMessage));
+                        WH_ERROR_PRINT(
+                            "Failed to wh_Client_CmacCancelableResponse %d\n",
+                            ret);
+                    }
+                    else {
+                        ret = wc_CmacUpdate(cmac, (byte*)knownCmacMessage,
+                                            sizeof(knownCmacMessage));
                         if (ret != 0) {
                             WH_ERROR_PRINT("Failed to wc_CmacUpdate %d\n", ret);
-                        } else {
-                            ret = wh_Client_CmacCancelableResponse(ctx, cmac, NULL, 0);
+                        }
+                        else {
+                            ret = wh_Client_CmacCancelableResponse(ctx, cmac,
+                                                                   NULL, 0);
                             if (ret != 0) {
-                                WH_ERROR_PRINT("Failed to wh_Client_CmacCancelableResponse %d\n", ret);
-                            } else {
+                                WH_ERROR_PRINT(
+                                    "Failed to "
+                                    "wh_Client_CmacCancelableResponse %d\n",
+                                    ret);
+                            }
+                            else {
                                 macLen = sizeof(knownCmacTag);
-                                ret = wc_CmacFinal(cmac, macOut, &macLen);
+                                ret    = wc_CmacFinal(cmac, macOut, &macLen);
                                 if (ret != 0) {
-                                    WH_ERROR_PRINT("Failed to wc_CmacFinal %d\n", ret);
-                                } else {
-                                    ret = wh_Client_CmacCancelableResponse(ctx, cmac, macOut, &outLen);
+                                    WH_ERROR_PRINT(
+                                        "Failed to wc_CmacFinal %d\n", ret);
+                                }
+                                else {
+                                    ret = wh_Client_CmacCancelableResponse(
+                                        ctx, cmac, macOut, &outLen);
                                     if (ret != 0) {
-                                        WH_ERROR_PRINT("Failed to wh_Client_CmacCancelableResponse %d\n", ret);
-                                    } else {
-                                        if (memcmp(knownCmacTag, macOut, sizeof(knownCmacTag)) != 0) {
-                                            WH_ERROR_PRINT("CMAC FAILED KNOWN ANSWER TEST\n");
+                                        WH_ERROR_PRINT(
+                                            "Failed to "
+                                            "wh_Client_CmacCancelableResponse "
+                                            "%d\n",
+                                            ret);
+                                    }
+                                    else {
+                                        if (memcmp(knownCmacTag, macOut,
+                                                   sizeof(knownCmacTag)) != 0) {
+                                            WH_ERROR_PRINT("CMAC FAILED KNOWN "
+                                                           "ANSWER TEST\n");
                                             ret = -1;
-                                        } else {
+                                        }
+                                        else {
                                             ret = wh_Client_DisableCancel(ctx);
                                             if (ret != 0) {
-                                                WH_ERROR_PRINT("Failed to wh_Client_DisableCancel %d\n", ret);
+                                                WH_ERROR_PRINT(
+                                                    "Failed to "
+                                                    "wh_Client_DisableCancel "
+                                                    "%d\n",
+                                                    ret);
                                             }
                                         }
                                     }
@@ -2130,8 +2210,11 @@ int whTest_CryptoClientConfig(whClientConfig* config)
 #endif /* !NO_AES */
 
 #if defined(WOLFSSL_CMAC) && !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT)
-    if (ret == 0) {
-        ret = whTestCrypto_Cmac(client, WH_DEV_ID, rng);
+    while ((ret == WH_ERROR_OK) && (i < WH_NUM_DEVIDS)) {
+        ret = whTestCrypto_Cmac(client, WH_DEV_IDS_ARRAY[i], rng);
+        if (ret == WH_ERROR_OK) {
+            i++;
+        }
     }
 #endif /* WOLFSSL_CMAC && !NO_AES && WOLFSSL_AES_DIRECT */
 

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -1456,7 +1456,7 @@ static int whTestCrypto_Cmac(whClientContext* ctx, int devId, WC_RNG* rng)
         }
     }
     if (ret == 0) {
-        printf("CMAC SUCCESS\n");
+        printf("CMAC DEVID=0x%X SUCCESS\n", devId);
     }
     return ret;
 }
@@ -2210,6 +2210,7 @@ int whTest_CryptoClientConfig(whClientConfig* config)
 #endif /* !NO_AES */
 
 #if defined(WOLFSSL_CMAC) && !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT)
+    i = 0;
     while ((ret == WH_ERROR_OK) && (i < WH_NUM_DEVIDS)) {
         ret = whTestCrypto_Cmac(client, WH_DEV_IDS_ARRAY[i], rng);
         if (ret == WH_ERROR_OK) {

--- a/wolfhsm/wh_client_crypto.h
+++ b/wolfhsm/wh_client_crypto.h
@@ -409,10 +409,11 @@ int wh_Client_AesGcm(whClientContext* ctx,
  * @param[in] inSz Size of the input buffer in bytes.
  * @param[in] keyId ID of the AES key inside the HSM.
  * @param[in] heap Heap pointer for the cmac struct.
+ * @param[in] devId ID of the wolfHSM device.
  * @return int Returns 0 on success, or a negative error code on failure.
  */
 int wh_Client_CmacAesGenerate(Cmac* cmac, byte* sig, word32* outSz,
-    const byte* hash, word32 inSz, whNvmId keyId, void* heap);
+    const byte* hash, word32 inSz, whNvmId keyId, void* heap, int devId);
 
 /**
  * @brief Verifies a CMAC-AES tag in a single call with a wolfHSM keyId.
@@ -429,18 +430,20 @@ int wh_Client_CmacAesGenerate(Cmac* cmac, byte* sig, word32* outSz,
  * @param[in] inSz Size of the input buffer in bytes.
  * @param[in] keyId ID of the AES key inside the HSM.
  * @param[in] heap Heap pointer for the cmac struct.
+ * @param[in] devId ID of the wolfHSM device.
  * @return int Returns 0 on success, 1 on tag mismatch, or a negative error
  *    code on failure.
  */
 int wh_Client_CmacAesVerify(Cmac* cmac, const byte* check, word32 checkSz,
-    const byte* hash, word32 inSz, whNvmId keyId, void* heap);
+    const byte* hash, word32 inSz, whNvmId keyId, void* heap, int devId);
 
 /**
  * @brief Handle cancelable CMAC response.
  *
  * This function handles a CMAC operation response from the server when
  * cancellation has been enabled, since wolfCrypt won't automatically block and
- * wait for the response.
+ * wait for the response. Note that DMA-based CMAC operations are NOT cancellable
+ * and if a cancel is requested, the operation will be aborted.
  *
  * @param[in] c Pointer to the client context structure.
  * @param[in] cmac Pointer to the CMAC key structure.

--- a/wolfhsm/wh_client_crypto.h
+++ b/wolfhsm/wh_client_crypto.h
@@ -442,8 +442,8 @@ int wh_Client_CmacAesVerify(Cmac* cmac, const byte* check, word32 checkSz,
  *
  * This function handles a CMAC operation response from the server when
  * cancellation has been enabled, since wolfCrypt won't automatically block and
- * wait for the response. Note that DMA-based CMAC operations are NOT cancellable
- * and if a cancel is requested, the operation will be aborted.
+ * wait for the response. Note that DMA-based CMAC operations are NOT
+ * cancellable and if a cancel is requested, the cancellation will be aborted.
  *
  * @param[in] c Pointer to the client context structure.
  * @param[in] cmac Pointer to the CMAC key structure.

--- a/wolfhsm/wh_packet.h
+++ b/wolfhsm/wh_packet.h
@@ -354,6 +354,38 @@ typedef struct  wh_Packet_cmac_res
     /* uint8_t out[]; */
 } wh_Packet_cmac_res;
 
+/* CMAC DMA packet structures */
+typedef struct wh_Packet_cmac_Dma32_req {
+    uint32_t type;             /* enum wc_CmacType */
+    uint32_t finalize;         /* 1 if final, 0 if update */
+    wh_Packet_Dma32_buffer state;  /* CMAC state buffer */
+    wh_Packet_Dma32_buffer key;    /* Key buffer */
+    wh_Packet_Dma32_buffer input;  /* Input buffer */
+    wh_Packet_Dma32_buffer output; /* Output buffer */
+    uint8_t WH_PAD[4]; /* Pad to 8-byte alignment */
+} wh_Packet_cmac_Dma32_req;
+
+typedef struct wh_Packet_cmac_Dma32_res {
+    wh_Packet_Dma32_addr_status dmaAddrStatus;
+    uint32_t outSz;
+    uint8_t WH_PAD[4]; /* Pad to 8-byte alignment */
+} wh_Packet_cmac_Dma32_res;
+
+typedef struct wh_Packet_cmac_Dma64_req {
+    uint32_t type;             /* enum wc_CmacType */
+    uint32_t finalize;         /* 1 if final, 0 if update */
+    wh_Packet_Dma64_buffer state;  /* CMAC state buffer */
+    wh_Packet_Dma64_buffer key;    /* Key buffer */
+    wh_Packet_Dma64_buffer input;  /* Input buffer */
+    wh_Packet_Dma64_buffer output; /* Output buffer */
+} wh_Packet_cmac_Dma64_req;
+
+typedef struct wh_Packet_cmac_Dma64_res {
+    wh_Packet_Dma64_addr_status dmaAddrStatus;
+    uint32_t outSz;
+    uint8_t WH_PAD[4]; /* Pad to 8-byte alignment */
+} wh_Packet_cmac_Dma64_res;
+
 typedef struct wh_Packet_hash_any_req {
     uint32_t type; /* enum wc_HashType */
     uint8_t WH_PAD[4];
@@ -403,7 +435,6 @@ typedef struct  wh_Packet_pq_mldsa_kg_res
     uint32_t len;
     /* uint8_t out[] */
 } wh_Packet_pq_mldsa_kg_res;
-
 
 typedef struct  wh_Packet_pq_mldsa_sign_req
 {
@@ -572,7 +603,6 @@ typedef struct wh_Packet_key_export_Dma64_res {
     uint8_t                     label[WH_NVM_LABEL_LEN];
     uint8_t                     WH_PAD[4]; /* Pad to 8-byte alignment */
 } wh_Packet_key_export_Dma64_res;
-
 
 /** NVM Counter packets */
 typedef struct  wh_Packet_counter_init_req
@@ -1074,6 +1104,8 @@ typedef struct whPacket
         wh_Packet_pq_mldsa_sign_Dma32_res   pqMldsaSignDma32Res;
         wh_Packet_pq_mldsa_verify_Dma32_req  pqMldsaVerifyDma32Req;
         wh_Packet_pq_mldsa_verify_Dma32_res  pqMldsaVerifyDma32Res;
+        wh_Packet_cmac_Dma32_req           cmacDma32Req;
+        wh_Packet_cmac_Dma32_res           cmacDma32Res;
 #elif defined(WOLFHSM_CFG_DMA) && WH_DMA_IS_64BIT
         wh_Packet_hash_sha256_Dma64_req     hashSha256Dma64Req;
         wh_Packet_hash_sha256_Dma64_res     hashSha256Dma64Res;
@@ -1087,6 +1119,8 @@ typedef struct whPacket
         wh_Packet_pq_mldsa_sign_Dma64_res   pqMldsaSignDma64Res;
         wh_Packet_pq_mldsa_verify_Dma64_req pqMldsaVerifyDma64Req;
         wh_Packet_pq_mldsa_verify_Dma64_res pqMldsaVerifyDma64Res;
+        wh_Packet_cmac_Dma64_req           cmacDma64Req;
+        wh_Packet_cmac_Dma64_res           cmacDma64Res;
 #endif
 
 

--- a/wolfhsm/wh_packet.h
+++ b/wolfhsm/wh_packet.h
@@ -362,7 +362,6 @@ typedef struct wh_Packet_cmac_Dma32_req {
     wh_Packet_Dma32_buffer key;    /* Key buffer */
     wh_Packet_Dma32_buffer input;  /* Input buffer */
     wh_Packet_Dma32_buffer output; /* Output buffer */
-    uint8_t WH_PAD[4]; /* Pad to 8-byte alignment */
 } wh_Packet_cmac_Dma32_req;
 
 typedef struct wh_Packet_cmac_Dma32_res {


### PR DESCRIPTION
Adds DMA support for CMAC. Can be used via ANY of wolfCrypt's CMAC APIs that accept a devId.

Passes wolfHSM and wolfCrypt tests on both POSIX sim and TC3xx.

A bit of a noisy diff, as I ran clang-format on some bigger blocks of code.

Future work:
- Overhaul existing non-DMA CMAC, specifically pushing state storage back to the client
- Remove all 32/64 bit public DMA APIs and replace with 64-bit messages only

