### PR TITLE
Remove whPacket union

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ Build/
 *.la
 **/.gdb_history
 tools/testcertgen/ca/
+tools/testcertgen/*.der
 

--- a/src/wh_client.c
+++ b/src/wh_client.c
@@ -537,6 +537,9 @@ int wh_Client_EchoRequest(whClientContext* c, uint16_t size, const void* data)
     }
 
     msg = wh_CommClient_GetDataPtr(c->comm);
+    if (msg == NULL) {
+        return WH_ERROR_BADARGS;
+    }
     memcpy(msg, data, size);
     return wh_Client_SendRequest(c,
             WH_MESSAGE_GROUP_COMM, WH_MESSAGE_COMM_ACTION_ECHO,
@@ -556,6 +559,9 @@ int wh_Client_EchoResponse(whClientContext* c, uint16_t *out_size, void* data)
     }
 
     msg = wh_CommClient_GetDataPtr(c->comm);
+    if (msg == NULL) {
+        return WH_ERROR_BADARGS;
+    }
 
     rc = wh_Client_RecvResponse(c,
          &resp_group, &resp_action,
@@ -717,7 +723,11 @@ int wh_Client_KeyCacheRequest_ex(whClientContext* c, uint32_t flags,
         return WH_ERROR_BADARGS;
     }
 
-    req    = (whMessageKeystore_CacheRequest*)wh_CommClient_GetDataPtr(c->comm);
+    req = (whMessageKeystore_CacheRequest*)wh_CommClient_GetDataPtr(c->comm);
+    if (req == NULL) {
+        return WH_ERROR_BADARGS;
+    }
+    memset(req, 0, sizeof(*req));
     packIn = (uint8_t*)(req + 1);
     req->id    = keyId;
     req->flags = flags;
@@ -764,6 +774,9 @@ int wh_Client_KeyCacheResponse(whClientContext* c, uint16_t* keyId)
     }
 
     resp = (whMessageKeystore_CacheResponse*)wh_CommClient_GetDataPtr(c->comm);
+    if (resp == NULL) {
+        return WH_ERROR_BADARGS;
+    }
 
     ret = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
@@ -809,6 +822,9 @@ int wh_Client_KeyEvictRequest(whClientContext* c, uint16_t keyId)
     }
 
     req = (whMessageKeystore_EvictRequest*)wh_CommClient_GetDataPtr(c->comm);
+    if (req == NULL) {
+        return WH_ERROR_BADARGS;
+    }
     req->id = keyId;
 
     return wh_Client_SendRequest(c, WH_MESSAGE_GROUP_KEY, WH_KEY_EVICT,
@@ -863,6 +879,9 @@ int wh_Client_KeyExportRequest(whClientContext* c, whKeyId keyId)
     }
 
     req = (whMessageKeystore_ExportRequest*)wh_CommClient_GetDataPtr(c->comm);
+    if (req == NULL) {
+        return WH_ERROR_BADARGS;
+    }
     req->id = keyId;
 
     return wh_Client_SendRequest(c, WH_MESSAGE_GROUP_KEY, WH_KEY_EXPORT,
@@ -884,6 +903,9 @@ int wh_Client_KeyExportResponse(whClientContext* c, uint8_t* label,
     }
 
     resp = (whMessageKeystore_ExportResponse*)wh_CommClient_GetDataPtr(c->comm);
+    if (resp == NULL) {
+        return WH_ERROR_BADARGS;
+    }
     packOut = (uint8_t*)(resp + 1);
 
     ret = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)resp);
@@ -936,6 +958,9 @@ int wh_Client_KeyCommitRequest(whClientContext* c, whNvmId keyId)
     }
 
     req = (whMessageKeystore_CommitRequest*)wh_CommClient_GetDataPtr(c->comm);
+    if (req == NULL) {
+        return WH_ERROR_BADARGS;
+    }
     req->id = keyId;
 
     return wh_Client_SendRequest(c, WH_MESSAGE_GROUP_KEY, WH_KEY_COMMIT,
@@ -955,6 +980,9 @@ int wh_Client_KeyCommitResponse(whClientContext* c)
     }
 
     resp = (whMessageKeystore_CommitResponse*)wh_CommClient_GetDataPtr(c->comm);
+    if (resp == NULL) {
+        return WH_ERROR_BADARGS;
+    }
 
     ret  = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
@@ -986,6 +1014,9 @@ int wh_Client_KeyEraseRequest(whClientContext* c, whNvmId keyId)
     }
 
     req = (whMessageKeystore_EraseRequest*)wh_CommClient_GetDataPtr(c->comm);
+    if (req == NULL) {
+        return WH_ERROR_BADARGS;
+    }
     req->id = keyId;
 
     return wh_Client_SendRequest(c, WH_MESSAGE_GROUP_KEY, WH_KEY_ERASE,
@@ -1005,6 +1036,9 @@ int wh_Client_KeyEraseResponse(whClientContext* c)
     }
 
     resp = (whMessageKeystore_EraseResponse*)wh_CommClient_GetDataPtr(c->comm);
+    if (resp == NULL) {
+        return WH_ERROR_BADARGS;
+    }
 
     ret  = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)resp);
     if (ret == 0) {
@@ -1037,6 +1071,9 @@ int wh_Client_CounterInitRequest(whClientContext* c, whNvmId counterId,
     }
 
     req = (whMessageCounter_InitRequest*)wh_CommClient_GetDataPtr(c->comm);
+    if (req == NULL) {
+        return WH_ERROR_BADARGS;
+    }
     req->counterId = counterId;
     req->counter = counter;
 
@@ -1057,6 +1094,9 @@ int wh_Client_CounterInitResponse(whClientContext* c, uint32_t* counter)
     }
 
     resp = (whMessageCounter_InitResponse*)wh_CommClient_GetDataPtr(c->comm);
+    if (resp == NULL) {
+        return WH_ERROR_BADARGS;
+    }
 
     ret = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
@@ -1109,6 +1149,9 @@ int wh_Client_CounterIncrementRequest(whClientContext* c, whNvmId counterId)
     }
 
     req = (whMessageCounter_IncrementRequest*)wh_CommClient_GetDataPtr(c->comm);
+    if (req == NULL) {
+        return WH_ERROR_BADARGS;
+    }
     req->counterId = counterId;
 
     return wh_Client_SendRequest(c, WH_MESSAGE_GROUP_COUNTER,
@@ -1129,6 +1172,9 @@ int wh_Client_CounterIncrementResponse(whClientContext* c, uint32_t* counter)
     }
 
     resp = (whMessageCounter_IncrementResponse*)wh_CommClient_GetDataPtr(c->comm);
+    if (resp == NULL) {
+        return WH_ERROR_BADARGS;
+    }
 
     ret = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
@@ -1164,6 +1210,9 @@ int wh_Client_CounterReadRequest(whClientContext* c, whNvmId counterId)
     }
 
     req = (whMessageCounter_ReadRequest*)wh_CommClient_GetDataPtr(c->comm);
+    if (req == NULL) {
+        return WH_ERROR_BADARGS;
+    }
     req->counterId = counterId;
 
     return wh_Client_SendRequest(c, WH_MESSAGE_GROUP_COUNTER, WH_COUNTER_READ,
@@ -1183,6 +1232,9 @@ int wh_Client_CounterReadResponse(whClientContext* c, uint32_t* counter)
     }
 
     resp = (whMessageCounter_ReadResponse*)wh_CommClient_GetDataPtr(c->comm);
+    if (resp == NULL) {
+        return WH_ERROR_BADARGS;
+    }
 
     ret = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
@@ -1218,6 +1270,9 @@ int wh_Client_CounterDestroyRequest(whClientContext* c, whNvmId counterId)
     }
 
     req = (whMessageCounter_DestroyRequest*)wh_CommClient_GetDataPtr(c->comm);
+    if (req == NULL) {
+        return WH_ERROR_BADARGS;
+    }
     req->counterId = counterId;
 
     return wh_Client_SendRequest(c, WH_MESSAGE_GROUP_COUNTER, WH_COUNTER_DESTROY,
@@ -1237,6 +1292,9 @@ int wh_Client_CounterDestroyResponse(whClientContext* c)
     }
 
     resp = (whMessageCounter_DestroyResponse*)wh_CommClient_GetDataPtr(c->comm);
+    if (resp == NULL) {
+        return WH_ERROR_BADARGS;
+    }
 
     ret = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
@@ -1273,6 +1331,10 @@ int wh_Client_KeyCacheDmaRequest(whClientContext* c, uint32_t flags,
     }
 
     req = (whMessageKeystore_CacheDmaRequest*)wh_CommClient_GetDataPtr(c->comm);
+    if (req == NULL) {
+        return WH_ERROR_BADARGS;
+    }
+    memset(req, 0, sizeof(*req));
     req->id      = keyId;
     req->flags   = flags;
     req->labelSz = labelSz;
@@ -1307,6 +1369,9 @@ int wh_Client_KeyCacheDmaResponse(whClientContext* c, uint16_t* keyId)
 
     resp =
         (whMessageKeystore_CacheDmaResponse*)wh_CommClient_GetDataPtr(c->comm);
+    if (resp == NULL) {
+        return WH_ERROR_BADARGS;
+    }
 
     ret = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)resp);
 
@@ -1356,6 +1421,9 @@ int wh_Client_KeyExportDmaRequest(whClientContext* c, uint16_t keyId,
 
     req =
         (whMessageKeystore_ExportDmaRequest*)wh_CommClient_GetDataPtr(c->comm);
+    if (req == NULL) {
+        return WH_ERROR_BADARGS;
+    }
     req->id       = keyId;
     req->key.addr = (uint64_t)((uintptr_t)keyAddr);
     req->key.sz   = keySz;
@@ -1379,6 +1447,9 @@ int wh_Client_KeyExportDmaResponse(whClientContext* c, uint8_t* label,
 
     resp =
         (whMessageKeystore_ExportDmaResponse*)wh_CommClient_GetDataPtr(c->comm);
+    if (resp == NULL) {
+        return WH_ERROR_BADARGS;
+    }
 
     rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
                                 (uint8_t*)resp);

--- a/src/wh_message_counter.c
+++ b/src/wh_message_counter.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2024 wolfSSL Inc.
+ *
+ * This file is part of wolfHSM.
+ *
+ * wolfHSM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfHSM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wolfHSM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * wolfhsm/wh_message_counter.c
+ *
+ * Message translation functions for counter operations.
+ */
+
+#include "wolfhsm/wh_message_counter.h"
+#include "wolfhsm/wh_error.h"
+#include "wolfhsm/wh_comm.h"
+#include <string.h>
+
+/* Counter Init Request translation */
+int wh_MessageCounter_TranslateInitRequest(
+    uint16_t magic, const whMessageCounter_InitRequest* src,
+    whMessageCounter_InitRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, counter);
+    WH_T16(magic, dest, src, counterId);
+    return 0;
+}
+
+/* Counter Init Response translation */
+int wh_MessageCounter_TranslateInitResponse(
+    uint16_t magic, const whMessageCounter_InitResponse* src,
+    whMessageCounter_InitResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    WH_T32(magic, dest, src, counter);
+    return 0;
+}
+
+/* Counter Increment Request translation */
+int wh_MessageCounter_TranslateIncrementRequest(
+    uint16_t magic, const whMessageCounter_IncrementRequest* src,
+    whMessageCounter_IncrementRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T16(magic, dest, src, counterId);
+    return 0;
+}
+
+/* Counter Increment Response translation */
+int wh_MessageCounter_TranslateIncrementResponse(
+    uint16_t magic, const whMessageCounter_IncrementResponse* src,
+    whMessageCounter_IncrementResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    WH_T32(magic, dest, src, counter);
+    return 0;
+}
+
+/* Counter Read Request translation */
+int wh_MessageCounter_TranslateReadRequest(
+    uint16_t magic, const whMessageCounter_ReadRequest* src,
+    whMessageCounter_ReadRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T16(magic, dest, src, counterId);
+    return 0;
+}
+
+/* Counter Read Response translation */
+int wh_MessageCounter_TranslateReadResponse(
+    uint16_t magic, const whMessageCounter_ReadResponse* src,
+    whMessageCounter_ReadResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    WH_T32(magic, dest, src, counter);
+    return 0;
+}
+
+/* Counter Destroy Request translation */
+int wh_MessageCounter_TranslateDestroyRequest(
+    uint16_t magic, const whMessageCounter_DestroyRequest* src,
+    whMessageCounter_DestroyRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T16(magic, dest, src, counterId);
+    return 0;
+}
+
+/* Counter Destroy Response translation */
+int wh_MessageCounter_TranslateDestroyResponse(
+    uint16_t magic, const whMessageCounter_DestroyResponse* src,
+    whMessageCounter_DestroyResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    return 0;
+}

--- a/src/wh_message_counter.c
+++ b/src/wh_message_counter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfHSM.
  *

--- a/src/wh_message_crypto.c
+++ b/src/wh_message_crypto.c
@@ -1,0 +1,839 @@
+/*
+ * Copyright (C) 2024 wolfSSL Inc.
+ *
+ * This file is part of wolfHSM.
+ *
+ * wolfHSM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfHSM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wolfHSM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * wolfhsm/wh_message_crypto.c
+ *
+ * Message translation functions for crypto operations.
+ */
+
+#include "wolfhsm/wh_message_crypto.h"
+#include "wolfhsm/wh_error.h"
+#include "wolfhsm/wh_comm.h"
+#include <string.h>
+
+/* Generic crypto header request translation */
+int wh_MessageCrypto_TranslateGenericRequestHeader(
+    uint16_t magic, const whMessageCrypto_GenericRequestHeader* src,
+    whMessageCrypto_GenericRequestHeader* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, algoType);
+    WH_T32(magic, dest, src, algoSubType);
+    return 0;
+}
+
+/* Generic crypto header response translation */
+int wh_MessageCrypto_TranslateGenericResponseHeader(
+    uint16_t magic, const whMessageCrypto_GenericResponseHeader* src,
+    whMessageCrypto_GenericResponseHeader* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, algoType);
+    WH_T32(magic, dest, src, rc);
+    return 0;
+}
+
+/* RNG Request translation */
+int wh_MessageCrypto_TranslateRngRequest(uint16_t magic,
+                                         const whMessageCrypto_RngRequest* src,
+                                         whMessageCrypto_RngRequest*       dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, sz);
+    return 0;
+}
+
+/* RNG Response translation */
+int wh_MessageCrypto_TranslateRngResponse(
+    uint16_t magic, const whMessageCrypto_RngResponse* src,
+    whMessageCrypto_RngResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, sz);
+    return 0;
+}
+
+
+/* AES CBC Request translation */
+int wh_MessageCrypto_TranslateAesCbcRequest(
+    uint16_t magic, const whMessageCrypto_AesCbcRequest* src,
+    whMessageCrypto_AesCbcRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, enc);
+    WH_T32(magic, dest, src, keyLen);
+    WH_T32(magic, dest, src, sz);
+    WH_T16(magic, dest, src, keyId);
+    return 0;
+}
+
+/* AES CBC Response translation */
+int wh_MessageCrypto_TranslateAesCbcResponse(
+    uint16_t magic, const whMessageCrypto_AesCbcResponse* src,
+    whMessageCrypto_AesCbcResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, sz);
+    return 0;
+}
+
+/* AES GCM Request translation */
+int wh_MessageCrypto_TranslateAesGcmRequest(
+    uint16_t magic, const whMessageCrypto_AesGcmRequest* src,
+    whMessageCrypto_AesGcmRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, enc);
+    WH_T32(magic, dest, src, keyLen);
+    WH_T32(magic, dest, src, sz);
+    WH_T32(magic, dest, src, ivSz);
+    WH_T32(magic, dest, src, authInSz);
+    WH_T32(magic, dest, src, authTagSz);
+    WH_T16(magic, dest, src, keyId);
+    return 0;
+}
+
+/* AES GCM Response translation */
+int wh_MessageCrypto_TranslateAesGcmResponse(
+    uint16_t magic, const whMessageCrypto_AesGcmResponse* src,
+    whMessageCrypto_AesGcmResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, sz);
+    WH_T32(magic, dest, src, authTagSz);
+    return 0;
+}
+/* RSA Key Generation Request translation */
+int wh_MessageCrypto_TranslateRsaKeyGenRequest(
+    uint16_t magic, const whMessageCrypto_RsaKeyGenRequest* src,
+    whMessageCrypto_RsaKeyGenRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, flags);
+    WH_T32(magic, dest, src, keyId);
+    WH_T32(magic, dest, src, size);
+    WH_T32(magic, dest, src, e);
+    /* Label is just a byte array, no translation needed */
+    memcpy(dest->label, src->label, WH_NVM_LABEL_LEN);
+    return 0;
+}
+
+/* RSA Key Generation Response translation */
+int wh_MessageCrypto_TranslateRsaKeyGenResponse(
+    uint16_t magic, const whMessageCrypto_RsaKeyGenResponse* src,
+    whMessageCrypto_RsaKeyGenResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, keyId);
+    WH_T32(magic, dest, src, len);
+    return 0;
+}
+
+/* RSA Request translation */
+int wh_MessageCrypto_TranslateRsaRequest(uint16_t magic,
+                                         const whMessageCrypto_RsaRequest* src,
+                                         whMessageCrypto_RsaRequest*       dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, opType);
+    WH_T32(magic, dest, src, options);
+    WH_T32(magic, dest, src, keyId);
+    WH_T32(magic, dest, src, inLen);
+    WH_T32(magic, dest, src, outLen);
+    return 0;
+}
+
+/* RSA Response translation */
+int wh_MessageCrypto_TranslateRsaResponse(
+    uint16_t magic, const whMessageCrypto_RsaResponse* src,
+    whMessageCrypto_RsaResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, outLen);
+    return 0;
+}
+
+/* RSA Get Size Request translation */
+int wh_MessageCrypto_TranslateRsaGetSizeRequest(
+    uint16_t magic, const whMessageCrypto_RsaGetSizeRequest* src,
+    whMessageCrypto_RsaGetSizeRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, options);
+    WH_T32(magic, dest, src, keyId);
+    return 0;
+}
+
+/* RSA Get Size Response translation */
+int wh_MessageCrypto_TranslateRsaGetSizeResponse(
+    uint16_t magic, const whMessageCrypto_RsaGetSizeResponse* src,
+    whMessageCrypto_RsaGetSizeResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, keySize);
+    return 0;
+}
+
+/* ECC Key Generation Request translation */
+int wh_MessageCrypto_TranslateEccKeyGenRequest(
+    uint16_t magic, const whMessageCrypto_EccKeyGenRequest* src,
+    whMessageCrypto_EccKeyGenRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, sz);
+    WH_T32(magic, dest, src, curveId);
+    WH_T32(magic, dest, src, keyId);
+    WH_T32(magic, dest, src, flags);
+    WH_T32(magic, dest, src, access);
+    /* Label is just a byte array, no translation needed */
+    memcpy(dest->label, src->label, sizeof(src->label));
+    return 0;
+}
+
+/* ECC Key Generation Response translation */
+int wh_MessageCrypto_TranslateEccKeyGenResponse(
+    uint16_t magic, const whMessageCrypto_EccKeyGenResponse* src,
+    whMessageCrypto_EccKeyGenResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, keyId);
+    WH_T32(magic, dest, src, len);
+    return 0;
+}
+
+/* ECDH Request translation */
+int wh_MessageCrypto_TranslateEcdhRequest(
+    uint16_t magic, const whMessageCrypto_EcdhRequest* src,
+    whMessageCrypto_EcdhRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, options);
+    WH_T32(magic, dest, src, privateKeyId);
+    WH_T32(magic, dest, src, publicKeyId);
+    return 0;
+}
+
+/* ECDH Response translation */
+int wh_MessageCrypto_TranslateEcdhResponse(
+    uint16_t magic, const whMessageCrypto_EcdhResponse* src,
+    whMessageCrypto_EcdhResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, sz);
+    return 0;
+}
+
+/* ECC Sign Request translation */
+int wh_MessageCrypto_TranslateEccSignRequest(
+    uint16_t magic, const whMessageCrypto_EccSignRequest* src,
+    whMessageCrypto_EccSignRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, options);
+    WH_T32(magic, dest, src, keyId);
+    WH_T32(magic, dest, src, sz);
+    return 0;
+}
+
+/* ECC Sign Response translation */
+int wh_MessageCrypto_TranslateEccSignResponse(
+    uint16_t magic, const whMessageCrypto_EccSignResponse* src,
+    whMessageCrypto_EccSignResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, sz);
+    return 0;
+}
+
+/* ECC Verify Request translation */
+int wh_MessageCrypto_TranslateEccVerifyRequest(
+    uint16_t magic, const whMessageCrypto_EccVerifyRequest* src,
+    whMessageCrypto_EccVerifyRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, options);
+    WH_T32(magic, dest, src, keyId);
+    WH_T32(magic, dest, src, sigSz);
+    WH_T32(magic, dest, src, hashSz);
+    return 0;
+}
+
+/* ECC Verify Response translation */
+int wh_MessageCrypto_TranslateEccVerifyResponse(
+    uint16_t magic, const whMessageCrypto_EccVerifyResponse* src,
+    whMessageCrypto_EccVerifyResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, res);
+    WH_T32(magic, dest, src, pubSz);
+    return 0;
+}
+
+/* ECC Check Request translation */
+int wh_MessageCrypto_TranslateEccCheckRequest(
+    uint16_t magic, const whMessageCrypto_EccCheckRequest* src,
+    whMessageCrypto_EccCheckRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, keyId);
+    WH_T32(magic, dest, src, curveId);
+    return 0;
+}
+
+/* ECC Check Response translation */
+int wh_MessageCrypto_TranslateEccCheckResponse(
+    uint16_t magic, const whMessageCrypto_EccCheckResponse* src,
+    whMessageCrypto_EccCheckResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, ok);
+    return 0;
+}
+
+/* Curve25519 Key Generation Request translation */
+int wh_MessageCrypto_TranslateCurve25519KeyGenRequest(
+    uint16_t magic, const whMessageCrypto_Curve25519KeyGenRequest* src,
+    whMessageCrypto_Curve25519KeyGenRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, sz);
+    WH_T32(magic, dest, src, flags);
+    WH_T32(magic, dest, src, keyId);
+    /* Label is just a byte array, no translation needed */
+    memcpy(dest->label, src->label, sizeof(src->label));
+    return 0;
+}
+
+/* Curve25519 Key Generation Response translation */
+int wh_MessageCrypto_TranslateCurve25519KeyGenResponse(
+    uint16_t magic, const whMessageCrypto_Curve25519KeyGenResponse* src,
+    whMessageCrypto_Curve25519KeyGenResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, keyId);
+    WH_T32(magic, dest, src, len);
+    return 0;
+}
+
+/* Curve25519 Request translation */
+int wh_MessageCrypto_TranslateCurve25519Request(
+    uint16_t magic, const whMessageCrypto_Curve25519Request* src,
+    whMessageCrypto_Curve25519Request* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, options);
+    WH_T32(magic, dest, src, privateKeyId);
+    WH_T32(magic, dest, src, publicKeyId);
+    WH_T32(magic, dest, src, endian);
+    return 0;
+}
+
+/* Curve25519 Response translation */
+int wh_MessageCrypto_TranslateCurve25519Response(
+    uint16_t magic, const whMessageCrypto_Curve25519Response* src,
+    whMessageCrypto_Curve25519Response* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, sz);
+    /* Padding is just a byte array, no translation needed */
+    memcpy(dest->WH_PAD, src->WH_PAD, sizeof(src->WH_PAD));
+    return 0;
+}
+
+/* SHA256 Request translation */
+int wh_MessageCrypto_TranslateSha256Request(
+    uint16_t magic, const whMessageCrypto_Sha256Request* src,
+    whMessageCrypto_Sha256Request* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, resumeState.hiLen);
+    WH_T32(magic, dest, src, resumeState.loLen);
+    /* Hash value is just a byte array, no translation needed */
+    memcpy(dest->resumeState.hash, src->resumeState.hash,
+           sizeof(src->resumeState.hash));
+    WH_T32(magic, dest, src, isLastBlock);
+    WH_T32(magic, dest, src, lastBlockLen);
+    /* Input block is just a byte array, no translation needed */
+    memcpy(dest->inBlock, src->inBlock, sizeof(src->inBlock));
+    return 0;
+}
+
+/* SHA256 Response translation */
+int wh_MessageCrypto_TranslateSha256Response(
+    uint16_t magic, const whMessageCrypto_Sha256Response* src,
+    whMessageCrypto_Sha256Response* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, hiLen);
+    WH_T32(magic, dest, src, loLen);
+    /* Hash value is just a byte array, no translation needed */
+    memcpy(dest->hash, src->hash, sizeof(src->hash));
+    return 0;
+}
+
+/* CMAC Request translation */
+int wh_MessageCrypto_TranslateCmacRequest(
+    uint16_t magic, const whMessageCrypto_CmacRequest* src,
+    whMessageCrypto_CmacRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, type);
+    WH_T32(magic, dest, src, outSz);
+    WH_T32(magic, dest, src, inSz);
+    WH_T32(magic, dest, src, keySz);
+    WH_T16(magic, dest, src, keyId);
+    return 0;
+}
+
+/* CMAC Response translation */
+int wh_MessageCrypto_TranslateCmacResponse(
+    uint16_t magic, const whMessageCrypto_CmacResponse* src,
+    whMessageCrypto_CmacResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, outSz);
+    WH_T16(magic, dest, src, keyId);
+    return 0;
+}
+
+/* ML-DSA Key Generation Request translation */
+int wh_MessageCrypto_TranslateMlDsaKeyGenRequest(
+    uint16_t magic, const whMessageCrypto_MlDsaKeyGenRequest* src,
+    whMessageCrypto_MlDsaKeyGenRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, sz);
+    WH_T32(magic, dest, src, level);
+    WH_T32(magic, dest, src, keyId);
+    WH_T32(magic, dest, src, flags);
+    WH_T32(magic, dest, src, access);
+    /* Label is just a byte array, no translation needed */
+    memcpy(dest->label, src->label, sizeof(src->label));
+    return 0;
+}
+
+/* ML-DSA Key Generation Response translation */
+int wh_MessageCrypto_TranslateMlDsaKeyGenResponse(
+    uint16_t magic, const whMessageCrypto_MlDsaKeyGenResponse* src,
+    whMessageCrypto_MlDsaKeyGenResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, keyId);
+    WH_T32(magic, dest, src, len);
+    return 0;
+}
+
+/* ML-DSA Sign Request translation */
+int wh_MessageCrypto_TranslateMlDsaSignRequest(
+    uint16_t magic, const whMessageCrypto_MlDsaSignRequest* src,
+    whMessageCrypto_MlDsaSignRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, options);
+    WH_T32(magic, dest, src, level);
+    WH_T32(magic, dest, src, keyId);
+    WH_T32(magic, dest, src, sz);
+    return 0;
+}
+
+/* ML-DSA Sign Response translation */
+int wh_MessageCrypto_TranslateMlDsaSignResponse(
+    uint16_t magic, const whMessageCrypto_MlDsaSignResponse* src,
+    whMessageCrypto_MlDsaSignResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, sz);
+    return 0;
+}
+
+/* ML-DSA Verify Request translation */
+int wh_MessageCrypto_TranslateMlDsaVerifyRequest(
+    uint16_t magic, const whMessageCrypto_MlDsaVerifyRequest* src,
+    whMessageCrypto_MlDsaVerifyRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, options);
+    WH_T32(magic, dest, src, level);
+    WH_T32(magic, dest, src, keyId);
+    WH_T32(magic, dest, src, sigSz);
+    WH_T32(magic, dest, src, hashSz);
+    return 0;
+}
+
+/* ML-DSA Verify Response translation */
+int wh_MessageCrypto_TranslateMlDsaVerifyResponse(
+    uint16_t magic, const whMessageCrypto_MlDsaVerifyResponse* src,
+    whMessageCrypto_MlDsaVerifyResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, res);
+    return 0;
+}
+
+/*
+ * DMA Messages
+ */
+
+/* DMA Buffer translation */
+int wh_MessageCrypto_TranslateDmaBuffer(uint16_t                         magic,
+                                        const whMessageCrypto_DmaBuffer* src,
+                                        whMessageCrypto_DmaBuffer*       dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T64(magic, dest, src, addr);
+    WH_T64(magic, dest, src, sz);
+    return 0;
+}
+
+/* DMA Address status translation */
+int wh_MessageCrypto_TranslateDmaAddrStatus(
+    uint16_t magic, const whMessageCrypto_DmaAddrStatus* src,
+    whMessageCrypto_DmaAddrStatus* dest)
+{
+    return wh_MessageCrypto_TranslateDmaBuffer(magic, &src->badAddr,
+                                               &dest->badAddr);
+}
+
+/* SHA256 DMA Request translation */
+int wh_MessageCrypto_TranslateSha256DmaRequest(
+    uint16_t magic, const whMessageCrypto_Sha256DmaRequest* src,
+    whMessageCrypto_Sha256DmaRequest* dest)
+{
+    int ret;
+
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+
+    WH_T64(magic, dest, src, finalize);
+
+    ret = wh_MessageCrypto_TranslateDmaBuffer(magic, &src->input, &dest->input);
+    if (ret != 0) {
+        return ret;
+    }
+
+    ret = wh_MessageCrypto_TranslateDmaBuffer(magic, &src->state, &dest->state);
+    if (ret != 0) {
+        return ret;
+    }
+
+    ret =
+        wh_MessageCrypto_TranslateDmaBuffer(magic, &src->output, &dest->output);
+    if (ret != 0) {
+        return ret;
+    }
+
+    return 0;
+}
+
+/* SHA256 DMA Response translation */
+int wh_MessageCrypto_TranslateSha256DmaResponse(
+    uint16_t magic, const whMessageCrypto_Sha256DmaResponse* src,
+    whMessageCrypto_Sha256DmaResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    return wh_MessageCrypto_TranslateDmaAddrStatus(magic, &src->dmaAddrStatus,
+                                                   &dest->dmaAddrStatus);
+}
+
+/* CMAC DMA Request translation */
+int wh_MessageCrypto_TranslateCmacDmaRequest(
+    uint16_t magic, const whMessageCrypto_CmacDmaRequest* src,
+    whMessageCrypto_CmacDmaRequest* dest)
+{
+    int ret;
+
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+
+    WH_T32(magic, dest, src, type);
+    WH_T32(magic, dest, src, finalize);
+
+    ret = wh_MessageCrypto_TranslateDmaBuffer(magic, &src->state, &dest->state);
+    if (ret != 0) {
+        return ret;
+    }
+
+    ret = wh_MessageCrypto_TranslateDmaBuffer(magic, &src->key, &dest->key);
+    if (ret != 0) {
+        return ret;
+    }
+
+    ret = wh_MessageCrypto_TranslateDmaBuffer(magic, &src->input, &dest->input);
+    if (ret != 0) {
+        return ret;
+    }
+
+    ret =
+        wh_MessageCrypto_TranslateDmaBuffer(magic, &src->output, &dest->output);
+    if (ret != 0) {
+        return ret;
+    }
+
+    return 0;
+}
+
+/* CMAC DMA Response translation */
+int wh_MessageCrypto_TranslateCmacDmaResponse(
+    uint16_t magic, const whMessageCrypto_CmacDmaResponse* src,
+    whMessageCrypto_CmacDmaResponse* dest)
+{
+    int ret;
+
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+
+    ret = wh_MessageCrypto_TranslateDmaAddrStatus(magic, &src->dmaAddrStatus,
+                                                  &dest->dmaAddrStatus);
+    if (ret != 0) {
+        return ret;
+    }
+
+    WH_T32(magic, dest, src, outSz);
+    return 0;
+}
+
+/* ML-DSA DMA Key Generation Request translation */
+int wh_MessageCrypto_TranslateMlDsaKeyGenDmaRequest(
+    uint16_t magic, const whMessageCrypto_MlDsaKeyGenDmaRequest* src,
+    whMessageCrypto_MlDsaKeyGenDmaRequest* dest)
+{
+    int ret;
+
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+
+    ret = wh_MessageCrypto_TranslateDmaBuffer(magic, &src->key, &dest->key);
+    if (ret != 0) {
+        return ret;
+    }
+
+    WH_T32(magic, dest, src, level);
+    WH_T32(magic, dest, src, flags);
+    WH_T32(magic, dest, src, keyId);
+    WH_T32(magic, dest, src, access);
+    WH_T32(magic, dest, src, labelSize);
+    /* Label is just a byte array, no translation needed */
+    memcpy(dest->label, src->label, sizeof(src->label));
+
+    return 0;
+}
+
+/* ML-DSA DMA Response translation */
+int wh_MessageCrypto_TranslateMlDsaKeyGenDmaResponse(
+    uint16_t magic, const whMessageCrypto_MlDsaKeyGenDmaResponse* src,
+    whMessageCrypto_MlDsaKeyGenDmaResponse* dest)
+{
+    int ret;
+
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+
+    ret = wh_MessageCrypto_TranslateDmaAddrStatus(magic, &src->dmaAddrStatus,
+                                                  &dest->dmaAddrStatus);
+    if (ret != 0) {
+        return ret;
+    }
+
+    WH_T32(magic, dest, src, keyId);
+    WH_T32(magic, dest, src, keySize);
+    return 0;
+}
+
+/* ML-DSA DMA Sign Request translation */
+int wh_MessageCrypto_TranslateMlDsaSignDmaRequest(
+    uint16_t magic, const whMessageCrypto_MlDsaSignDmaRequest* src,
+    whMessageCrypto_MlDsaSignDmaRequest* dest)
+{
+    int ret;
+
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+
+    ret = wh_MessageCrypto_TranslateDmaBuffer(magic, &src->msg, &dest->msg);
+    if (ret != 0) {
+        return ret;
+    }
+
+    ret = wh_MessageCrypto_TranslateDmaBuffer(magic, &src->sig, &dest->sig);
+    if (ret != 0) {
+        return ret;
+    }
+
+    WH_T32(magic, dest, src, options);
+    WH_T32(magic, dest, src, level);
+    WH_T32(magic, dest, src, keyId);
+
+    return 0;
+}
+
+/* ML-DSA DMA Sign Response translation */
+int wh_MessageCrypto_TranslateMlDsaSignDmaResponse(
+    uint16_t magic, const whMessageCrypto_MlDsaSignDmaResponse* src,
+    whMessageCrypto_MlDsaSignDmaResponse* dest)
+{
+    int ret;
+
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+
+    ret = wh_MessageCrypto_TranslateDmaAddrStatus(magic, &src->dmaAddrStatus,
+                                                  &dest->dmaAddrStatus);
+    if (ret != 0) {
+        return ret;
+    }
+
+    WH_T32(magic, dest, src, sigLen);
+    return 0;
+}
+
+/* ML-DSA DMA Verify Request translation */
+int wh_MessageCrypto_TranslateMlDsaVerifyDmaRequest(
+    uint16_t magic, const whMessageCrypto_MlDsaVerifyDmaRequest* src,
+    whMessageCrypto_MlDsaVerifyDmaRequest* dest)
+{
+    int ret;
+
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+
+    ret = wh_MessageCrypto_TranslateDmaBuffer(magic, &src->sig, &dest->sig);
+    if (ret != 0) {
+        return ret;
+    }
+
+    ret = wh_MessageCrypto_TranslateDmaBuffer(magic, &src->msg, &dest->msg);
+    if (ret != 0) {
+        return ret;
+    }
+
+    WH_T32(magic, dest, src, options);
+    WH_T32(magic, dest, src, level);
+    WH_T32(magic, dest, src, keyId);
+
+    return 0;
+}
+
+/* ML-DSA DMA Verify Response translation */
+int wh_MessageCrypto_TranslateMlDsaVerifyDmaResponse(
+    uint16_t magic, const whMessageCrypto_MlDsaVerifyDmaResponse* src,
+    whMessageCrypto_MlDsaVerifyDmaResponse* dest)
+{
+    int ret;
+
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+
+    ret = wh_MessageCrypto_TranslateDmaAddrStatus(magic, &src->dmaAddrStatus,
+                                                  &dest->dmaAddrStatus);
+    if (ret != 0) {
+        return ret;
+    }
+
+    WH_T32(magic, dest, src, verifyResult);
+    return 0;
+}

--- a/src/wh_message_crypto.c
+++ b/src/wh_message_crypto.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfHSM.
  *

--- a/src/wh_message_crypto.c
+++ b/src/wh_message_crypto.c
@@ -148,7 +148,9 @@ int wh_MessageCrypto_TranslateRsaKeyGenRequest(
     WH_T32(magic, dest, src, size);
     WH_T32(magic, dest, src, e);
     /* Label is just a byte array, no translation needed */
-    memcpy(dest->label, src->label, WH_NVM_LABEL_LEN);
+    if (src != dest) {
+        memcpy(dest->label, src->label, WH_NVM_LABEL_LEN);
+    }
     return 0;
 }
 
@@ -232,7 +234,9 @@ int wh_MessageCrypto_TranslateEccKeyGenRequest(
     WH_T32(magic, dest, src, flags);
     WH_T32(magic, dest, src, access);
     /* Label is just a byte array, no translation needed */
-    memcpy(dest->label, src->label, sizeof(src->label));
+    if (src != dest) {
+        memcpy(dest->label, src->label, sizeof(src->label));
+    }
     return 0;
 }
 
@@ -366,7 +370,9 @@ int wh_MessageCrypto_TranslateCurve25519KeyGenRequest(
     WH_T32(magic, dest, src, flags);
     WH_T32(magic, dest, src, keyId);
     /* Label is just a byte array, no translation needed */
-    memcpy(dest->label, src->label, sizeof(src->label));
+    if (src != dest) {
+        memcpy(dest->label, src->label, sizeof(src->label));
+    }
     return 0;
 }
 
@@ -407,8 +413,6 @@ int wh_MessageCrypto_TranslateCurve25519Response(
         return WH_ERROR_BADARGS;
     }
     WH_T32(magic, dest, src, sz);
-    /* Padding is just a byte array, no translation needed */
-    memcpy(dest->WH_PAD, src->WH_PAD, sizeof(src->WH_PAD));
     return 0;
 }
 
@@ -423,12 +427,16 @@ int wh_MessageCrypto_TranslateSha256Request(
     WH_T32(magic, dest, src, resumeState.hiLen);
     WH_T32(magic, dest, src, resumeState.loLen);
     /* Hash value is just a byte array, no translation needed */
-    memcpy(dest->resumeState.hash, src->resumeState.hash,
-           sizeof(src->resumeState.hash));
+    if (src != dest) {
+        memcpy(dest->resumeState.hash, src->resumeState.hash,
+               sizeof(src->resumeState.hash));
+    }
     WH_T32(magic, dest, src, isLastBlock);
     WH_T32(magic, dest, src, lastBlockLen);
     /* Input block is just a byte array, no translation needed */
-    memcpy(dest->inBlock, src->inBlock, sizeof(src->inBlock));
+    if (src != dest) {
+        memcpy(dest->inBlock, src->inBlock, sizeof(src->inBlock));
+    }
     return 0;
 }
 
@@ -443,7 +451,9 @@ int wh_MessageCrypto_TranslateSha256Response(
     WH_T32(magic, dest, src, hiLen);
     WH_T32(magic, dest, src, loLen);
     /* Hash value is just a byte array, no translation needed */
-    memcpy(dest->hash, src->hash, sizeof(src->hash));
+    if (src != dest) {
+        memcpy(dest->hash, src->hash, sizeof(src->hash));
+    }
     return 0;
 }
 
@@ -490,7 +500,9 @@ int wh_MessageCrypto_TranslateMlDsaKeyGenRequest(
     WH_T32(magic, dest, src, flags);
     WH_T32(magic, dest, src, access);
     /* Label is just a byte array, no translation needed */
-    memcpy(dest->label, src->label, sizeof(src->label));
+    if (src != dest) {
+        memcpy(dest->label, src->label, sizeof(src->label));
+    }
     return 0;
 }
 
@@ -713,7 +725,9 @@ int wh_MessageCrypto_TranslateMlDsaKeyGenDmaRequest(
     WH_T32(magic, dest, src, access);
     WH_T32(magic, dest, src, labelSize);
     /* Label is just a byte array, no translation needed */
-    memcpy(dest->label, src->label, sizeof(src->label));
+    if (src != dest) {
+        memcpy(dest->label, src->label, sizeof(src->label));
+    }
 
     return 0;
 }

--- a/src/wh_message_keystore.c
+++ b/src/wh_message_keystore.c
@@ -65,7 +65,7 @@ int wh_MessageKeystore_TranslateEvictRequest(
     if ((src == NULL) || (dest == NULL)) {
         return WH_ERROR_BADARGS;
     }
-    WH_T32(magic, dest, src, id);
+    WH_T16(magic, dest, src, id);
     return 0;
 }
 
@@ -90,7 +90,7 @@ int wh_MessageKeystore_TranslateCommitRequest(
     if ((src == NULL) || (dest == NULL)) {
         return WH_ERROR_BADARGS;
     }
-    WH_T32(magic, dest, src, id);
+    WH_T16(magic, dest, src, id);
     return 0;
 }
 
@@ -115,7 +115,7 @@ int wh_MessageKeystore_TranslateExportRequest(
     if ((src == NULL) || (dest == NULL)) {
         return WH_ERROR_BADARGS;
     }
-    WH_T32(magic, dest, src, id);
+    WH_T16(magic, dest, src, id);
     return 0;
 }
 
@@ -142,7 +142,7 @@ int wh_MessageKeystore_TranslateEraseRequest(
     if ((src == NULL) || (dest == NULL)) {
         return WH_ERROR_BADARGS;
     }
-    WH_T32(magic, dest, src, id);
+    WH_T16(magic, dest, src, id);
     return 0;
 }
 
@@ -207,7 +207,7 @@ int wh_MessageKeystore_TranslateExportDmaRequest(
     }
     WH_T64(magic, dest, src, key.addr);
     WH_T64(magic, dest, src, key.sz);
-    WH_T32(magic, dest, src, id);
+    WH_T16(magic, dest, src, id);
     return 0;
 }
 

--- a/src/wh_message_keystore.c
+++ b/src/wh_message_keystore.c
@@ -40,7 +40,9 @@ int wh_MessageKeystore_TranslateCacheRequest(
     WH_T32(magic, dest, src, labelSz);
     WH_T16(magic, dest, src, id);
     /* Label is just a byte array, no translation needed */
-    memcpy(dest->label, src->label, WH_NVM_LABEL_LEN);
+    if (src != dest) {
+        memcpy(dest->label, src->label, WH_NVM_LABEL_LEN);
+    }
     return 0;
 }
 
@@ -130,7 +132,9 @@ int wh_MessageKeystore_TranslateExportResponse(
     WH_T32(magic, dest, src, rc);
     WH_T32(magic, dest, src, len);
     /* Label is just a byte array, no translation needed */
-    memcpy(dest->label, src->label, WH_NVM_LABEL_LEN);
+    if (src != dest) {
+        memcpy(dest->label, src->label, WH_NVM_LABEL_LEN);
+    }
     return 0;
 }
 
@@ -178,7 +182,9 @@ int wh_MessageKeystore_TranslateCacheDmaRequest(
     WH_T32(magic, dest, src, labelSz);
     WH_T16(magic, dest, src, id);
     /* Label is just a byte array, no translation needed */
-    memcpy(dest->label, src->label, WH_NVM_LABEL_LEN);
+    if (src != dest) {
+        memcpy(dest->label, src->label, WH_NVM_LABEL_LEN);
+    }
     return 0;
 }
 
@@ -224,7 +230,9 @@ int wh_MessageKeystore_TranslateExportDmaResponse(
     WH_T64(magic, dest, src, dmaAddrStatus.badAddr.sz);
     WH_T32(magic, dest, src, len);
     /* Label is just a byte array, no translation needed */
-    memcpy(dest->label, src->label, WH_NVM_LABEL_LEN);
+    if (src != dest) {
+        memcpy(dest->label, src->label, WH_NVM_LABEL_LEN);
+    }
     return 0;
 }
 

--- a/src/wh_message_keystore.c
+++ b/src/wh_message_keystore.c
@@ -1,0 +1,231 @@
+/*
+ * Copyright (C) 2024 wolfSSL Inc.
+ *
+ * This file is part of wolfHSM.
+ *
+ * wolfHSM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfHSM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wolfHSM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * wolfhsm/wh_message_keystore.c
+ *
+ * Message translation functions for keystore operations.
+ */
+
+#include "wolfhsm/wh_message_keystore.h"
+#include "wolfhsm/wh_error.h"
+#include "wolfhsm/wh_comm.h"
+#include <string.h>
+
+/* Key Cache Request translation */
+int wh_MessageKeystore_TranslateCacheRequest(
+    uint16_t magic, const whMessageKeystore_CacheRequest* src,
+    whMessageKeystore_CacheRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, flags);
+    WH_T32(magic, dest, src, sz);
+    WH_T32(magic, dest, src, labelSz);
+    WH_T16(magic, dest, src, id);
+    /* Label is just a byte array, no translation needed */
+    memcpy(dest->label, src->label, WH_NVM_LABEL_LEN);
+    return 0;
+}
+
+/* Key Cache Response translation */
+int wh_MessageKeystore_TranslateCacheResponse(
+    uint16_t magic, const whMessageKeystore_CacheResponse* src,
+    whMessageKeystore_CacheResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    WH_T16(magic, dest, src, id);
+    return 0;
+}
+
+/* Key Evict Request translation */
+int wh_MessageKeystore_TranslateEvictRequest(
+    uint16_t magic, const whMessageKeystore_EvictRequest* src,
+    whMessageKeystore_EvictRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, id);
+    return 0;
+}
+
+/* Key Evict Response translation */
+int wh_MessageKeystore_TranslateEvictResponse(
+    uint16_t magic, const whMessageKeystore_EvictResponse* src,
+    whMessageKeystore_EvictResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    WH_T32(magic, dest, src, ok);
+    return 0;
+}
+
+/* Key Commit Request translation */
+int wh_MessageKeystore_TranslateCommitRequest(
+    uint16_t magic, const whMessageKeystore_CommitRequest* src,
+    whMessageKeystore_CommitRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, id);
+    return 0;
+}
+
+/* Key Commit Response translation */
+int wh_MessageKeystore_TranslateCommitResponse(
+    uint16_t magic, const whMessageKeystore_CommitResponse* src,
+    whMessageKeystore_CommitResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    WH_T32(magic, dest, src, ok);
+    return 0;
+}
+
+/* Key Export Request translation */
+int wh_MessageKeystore_TranslateExportRequest(
+    uint16_t magic, const whMessageKeystore_ExportRequest* src,
+    whMessageKeystore_ExportRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, id);
+    return 0;
+}
+
+/* Key Export Response translation */
+int wh_MessageKeystore_TranslateExportResponse(
+    uint16_t magic, const whMessageKeystore_ExportResponse* src,
+    whMessageKeystore_ExportResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    WH_T32(magic, dest, src, len);
+    /* Label is just a byte array, no translation needed */
+    memcpy(dest->label, src->label, WH_NVM_LABEL_LEN);
+    return 0;
+}
+
+/* Key Erase Request translation */
+int wh_MessageKeystore_TranslateEraseRequest(
+    uint16_t magic, const whMessageKeystore_EraseRequest* src,
+    whMessageKeystore_EraseRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, id);
+    return 0;
+}
+
+/* Key Erase Response translation */
+int wh_MessageKeystore_TranslateEraseResponse(
+    uint16_t magic, const whMessageKeystore_EraseResponse* src,
+    whMessageKeystore_EraseResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    WH_T32(magic, dest, src, ok);
+    return 0;
+}
+
+#ifdef WOLFHSM_CFG_DMA
+/*
+ * DMA-based keystore operations
+ */
+
+/* Key Cache DMA Request translation */
+int wh_MessageKeystore_TranslateCacheDmaRequest(
+    uint16_t magic, const whMessageKeystore_CacheDmaRequest* src,
+    whMessageKeystore_CacheDmaRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T64(magic, dest, src, key.addr);
+    WH_T64(magic, dest, src, key.sz);
+    WH_T32(magic, dest, src, flags);
+    WH_T32(magic, dest, src, labelSz);
+    WH_T16(magic, dest, src, id);
+    /* Label is just a byte array, no translation needed */
+    memcpy(dest->label, src->label, WH_NVM_LABEL_LEN);
+    return 0;
+}
+
+/* Key Cache DMA Response translation */
+int wh_MessageKeystore_TranslateCacheDmaResponse(
+    uint16_t magic, const whMessageKeystore_CacheDmaResponse* src,
+    whMessageKeystore_CacheDmaResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    WH_T64(magic, dest, src, dmaAddrStatus.badAddr.addr);
+    WH_T64(magic, dest, src, dmaAddrStatus.badAddr.sz);
+    WH_T16(magic, dest, src, id);
+    return 0;
+}
+
+/* Key Export DMA Request translation */
+int wh_MessageKeystore_TranslateExportDmaRequest(
+    uint16_t magic, const whMessageKeystore_ExportDmaRequest* src,
+    whMessageKeystore_ExportDmaRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T64(magic, dest, src, key.addr);
+    WH_T64(magic, dest, src, key.sz);
+    WH_T32(magic, dest, src, id);
+    return 0;
+}
+
+/* Key Export DMA Response translation */
+int wh_MessageKeystore_TranslateExportDmaResponse(
+    uint16_t magic, const whMessageKeystore_ExportDmaResponse* src,
+    whMessageKeystore_ExportDmaResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    WH_T64(magic, dest, src, dmaAddrStatus.badAddr.addr);
+    WH_T64(magic, dest, src, dmaAddrStatus.badAddr.sz);
+    WH_T32(magic, dest, src, len);
+    /* Label is just a byte array, no translation needed */
+    memcpy(dest->label, src->label, WH_NVM_LABEL_LEN);
+    return 0;
+}
+
+#endif /* WOLFHSM_CFG_DMA */

--- a/src/wh_message_keystore.c
+++ b/src/wh_message_keystore.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfHSM.
  *

--- a/src/wh_message_nvm.c
+++ b/src/wh_message_nvm.c
@@ -135,7 +135,9 @@ int wh_MessageNvm_TranslateGetMetadataResponse(uint16_t magic,
     WH_T16(magic, dest, src, access);
     WH_T16(magic, dest, src, flags);
     WH_T16(magic, dest, src, len);
-    memcpy(dest->label, src->label, sizeof(dest->label));
+    if (src != dest) {  
+        memcpy(dest->label, src->label, sizeof(dest->label));
+    }
     return 0;
 }
 
@@ -150,7 +152,9 @@ int wh_MessageNvm_TranslateAddObjectRequest(uint16_t magic,
     WH_T16(magic, dest, src, access);
     WH_T16(magic, dest, src, flags);
     WH_T16(magic, dest, src, len);
-    memcpy(dest->label, src->label, sizeof(dest->label));
+    if (src != dest) {
+        memcpy(dest->label, src->label, sizeof(dest->label));
+    }
     return 0;
 }
 

--- a/src/wh_message_she.c
+++ b/src/wh_message_she.c
@@ -41,7 +41,9 @@ int wh_MessageShe_TranslateSetUidRequest(uint16_t magic,
     if ((src == NULL) || (dest == NULL)) {
         return WH_ERROR_BADARGS;
     }
-    memcpy(dest->uid, src->uid, WH_SHE_UID_SZ);
+    if (src != dest) {
+        memcpy(dest->uid, src->uid, WH_SHE_UID_SZ);
+    }
     return 0;
 }
 
@@ -139,9 +141,11 @@ int wh_MessageShe_TranslateLoadKeyRequest(
     if ((src == NULL) || (dest == NULL)) {
         return WH_ERROR_BADARGS;
     }
-    memcpy(dest->messageOne, src->messageOne, WH_SHE_M1_SZ);
-    memcpy(dest->messageTwo, src->messageTwo, WH_SHE_M2_SZ);
-    memcpy(dest->messageThree, src->messageThree, WH_SHE_M3_SZ);
+    if (src != dest) {
+        memcpy(dest->messageOne, src->messageOne, WH_SHE_M1_SZ);
+        memcpy(dest->messageTwo, src->messageTwo, WH_SHE_M2_SZ);
+        memcpy(dest->messageThree, src->messageThree, WH_SHE_M3_SZ);
+    }
     return 0;
 }
 
@@ -153,8 +157,10 @@ int wh_MessageShe_TranslateLoadKeyResponse(
         return WH_ERROR_BADARGS;
     }
     WH_T32(magic, dest, src, rc);
-    memcpy(dest->messageFour, src->messageFour, WH_SHE_M4_SZ);
-    memcpy(dest->messageFive, src->messageFive, WH_SHE_M5_SZ);
+    if (src != dest) {
+        memcpy(dest->messageFour, src->messageFour, WH_SHE_M4_SZ);
+        memcpy(dest->messageFive, src->messageFive, WH_SHE_M5_SZ);
+    }
     return 0;
 }
 
@@ -166,7 +172,9 @@ int wh_MessageShe_TranslateLoadPlainKeyRequest(
     if ((src == NULL) || (dest == NULL)) {
         return WH_ERROR_BADARGS;
     }
-    memcpy(dest->key, src->key, WH_SHE_KEY_SZ);
+    if (src != dest) {
+        memcpy(dest->key, src->key, WH_SHE_KEY_SZ);
+    }
     return 0;
 }
 
@@ -190,11 +198,13 @@ int wh_MessageShe_TranslateExportRamKeyResponse(
         return WH_ERROR_BADARGS;
     }
     WH_T32(magic, dest, src, rc);
-    memcpy(dest->messageOne, src->messageOne, WH_SHE_M1_SZ);
-    memcpy(dest->messageTwo, src->messageTwo, WH_SHE_M2_SZ);
-    memcpy(dest->messageThree, src->messageThree, WH_SHE_M3_SZ);
-    memcpy(dest->messageFour, src->messageFour, WH_SHE_M4_SZ);
-    memcpy(dest->messageFive, src->messageFive, WH_SHE_M5_SZ);
+    if (src != dest) {
+        memcpy(dest->messageOne, src->messageOne, WH_SHE_M1_SZ);
+        memcpy(dest->messageTwo, src->messageTwo, WH_SHE_M2_SZ);
+        memcpy(dest->messageThree, src->messageThree, WH_SHE_M3_SZ);
+        memcpy(dest->messageFour, src->messageFour, WH_SHE_M4_SZ);
+        memcpy(dest->messageFive, src->messageFive, WH_SHE_M5_SZ);
+    }
     return 0;
 }
 
@@ -220,7 +230,9 @@ int wh_MessageShe_TranslateRndResponse(uint16_t                        magic,
         return WH_ERROR_BADARGS;
     }
     WH_T32(magic, dest, src, rc);
-    memcpy(dest->rnd, src->rnd, WH_SHE_KEY_SZ);
+    if (src != dest) {
+        memcpy(dest->rnd, src->rnd, WH_SHE_KEY_SZ);
+    }
     return 0;
 }
 
@@ -232,7 +244,9 @@ int wh_MessageShe_TranslateExtendSeedRequest(
     if ((src == NULL) || (dest == NULL)) {
         return WH_ERROR_BADARGS;
     }
-    memcpy(dest->entropy, src->entropy, WH_SHE_KEY_SZ);
+    if (src != dest) {
+        memcpy(dest->entropy, src->entropy, WH_SHE_KEY_SZ);
+    }
     return 0;
 }
 
@@ -283,7 +297,9 @@ int wh_MessageShe_TranslateEncCbcRequest(uint16_t magic,
     }
     WH_T32(magic, dest, src, sz);
     dest->keyId = src->keyId;
-    memcpy(dest->iv, src->iv, WH_SHE_KEY_SZ);
+    if (src != dest) {
+        memcpy(dest->iv, src->iv, WH_SHE_KEY_SZ);
+    }
     return 0;
 }
 
@@ -334,7 +350,9 @@ int wh_MessageShe_TranslateDecCbcRequest(uint16_t magic,
     }
     WH_T32(magic, dest, src, sz);
     dest->keyId = src->keyId;
-    memcpy(dest->iv, src->iv, WH_SHE_KEY_SZ);
+    if (src != dest) {
+        memcpy(dest->iv, src->iv, WH_SHE_KEY_SZ);
+    }
     return 0;
 }
 
@@ -371,7 +389,9 @@ int wh_MessageShe_TranslateGenMacResponse(
         return WH_ERROR_BADARGS;
     }
     WH_T32(magic, dest, src, rc);
-    memcpy(dest->mac, src->mac, WH_SHE_KEY_SZ);
+    if (src != dest) {
+        memcpy(dest->mac, src->mac, WH_SHE_KEY_SZ);
+    }
     return 0;
 }
 

--- a/src/wh_message_she.c
+++ b/src/wh_message_she.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 wolfSSL Inc.
+ * Copyright (C) 2025 wolfSSL Inc.
  *
  * This file is part of wolfHSM.
  *

--- a/src/wh_message_she.c
+++ b/src/wh_message_she.c
@@ -1,0 +1,404 @@
+/*
+ * Copyright (C) 2024 wolfSSL Inc.
+ *
+ * This file is part of wolfHSM.
+ *
+ * wolfHSM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfHSM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wolfHSM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * wolfhsm/wh_message_she.c
+ *
+ * Message translation functions for SHE operations.
+ */
+
+#include "wolfhsm/wh_settings.h"
+
+#ifdef WOLFHSM_CFG_SHE_EXTENSION
+
+#include <stdint.h>
+#include <string.h>
+
+#include "wolfhsm/wh_error.h"
+#include "wolfhsm/wh_comm.h"
+#include "wolfhsm/wh_message_she.h"
+
+/* Set UID translation function */
+int wh_MessageShe_TranslateSetUidRequest(uint16_t magic,
+                                         const whMessageShe_SetUidRequest* src,
+                                         whMessageShe_SetUidRequest*       dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    memcpy(dest->uid, src->uid, WH_SHE_UID_SZ);
+    return 0;
+}
+
+/* Set UID response translation function */
+int wh_MessageShe_TranslateSetUidResponse(uint16_t magic,
+                                         const whMessageShe_SetUidResponse* src,
+                                         whMessageShe_SetUidResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    return 0;
+}
+
+/* Secure Boot Init translation functions */
+int wh_MessageShe_TranslateSecureBootInitRequest(
+    uint16_t magic, const whMessageShe_SecureBootInitRequest* src,
+    whMessageShe_SecureBootInitRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, sz);
+    return 0;
+}
+
+int wh_MessageShe_TranslateSecureBootInitResponse(
+    uint16_t magic, const whMessageShe_SecureBootInitResponse* src,
+    whMessageShe_SecureBootInitResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    WH_T32(magic, dest, src, status);
+    return 0;
+}
+
+/* Secure Boot Update translation functions */
+int wh_MessageShe_TranslateSecureBootUpdateRequest(
+    uint16_t magic, const whMessageShe_SecureBootUpdateRequest* src,
+    whMessageShe_SecureBootUpdateRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, sz);
+    return 0;
+}
+
+int wh_MessageShe_TranslateSecureBootUpdateResponse(
+    uint16_t magic, const whMessageShe_SecureBootUpdateResponse* src,
+    whMessageShe_SecureBootUpdateResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    WH_T32(magic, dest, src, status);
+    return 0;
+}
+
+/* Secure Boot Finish translation function */
+int wh_MessageShe_TranslateSecureBootFinishResponse(
+    uint16_t magic, const whMessageShe_SecureBootFinishResponse* src,
+    whMessageShe_SecureBootFinishResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    WH_T32(magic, dest, src, status);
+    return 0;
+}
+
+/* Get Status translation function */
+int wh_MessageShe_TranslateGetStatusResponse(
+    uint16_t magic, const whMessageShe_GetStatusResponse* src,
+    whMessageShe_GetStatusResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    dest->sreg = src->sreg;
+    return 0;
+}
+
+/* Load Key translation functions */
+int wh_MessageShe_TranslateLoadKeyRequest(
+    uint16_t magic, const whMessageShe_LoadKeyRequest* src,
+    whMessageShe_LoadKeyRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    memcpy(dest->messageOne, src->messageOne, WH_SHE_M1_SZ);
+    memcpy(dest->messageTwo, src->messageTwo, WH_SHE_M2_SZ);
+    memcpy(dest->messageThree, src->messageThree, WH_SHE_M3_SZ);
+    return 0;
+}
+
+int wh_MessageShe_TranslateLoadKeyResponse(
+    uint16_t magic, const whMessageShe_LoadKeyResponse* src,
+    whMessageShe_LoadKeyResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    memcpy(dest->messageFour, src->messageFour, WH_SHE_M4_SZ);
+    memcpy(dest->messageFive, src->messageFive, WH_SHE_M5_SZ);
+    return 0;
+}
+
+/* Load Plain Key translation function */
+int wh_MessageShe_TranslateLoadPlainKeyRequest(
+    uint16_t magic, const whMessageShe_LoadPlainKeyRequest* src,
+    whMessageShe_LoadPlainKeyRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    memcpy(dest->key, src->key, WH_SHE_KEY_SZ);
+    return 0;
+}
+
+int wh_MessageShe_TranslateLoadPlainKeyResponse(
+    uint16_t magic, const whMessageShe_LoadPlainKeyResponse* src,
+    whMessageShe_LoadPlainKeyResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    return 0;
+}
+
+/* Export RAM Key translation function */
+int wh_MessageShe_TranslateExportRamKeyResponse(
+    uint16_t magic, const whMessageShe_ExportRamKeyResponse* src,
+    whMessageShe_ExportRamKeyResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    memcpy(dest->messageOne, src->messageOne, WH_SHE_M1_SZ);
+    memcpy(dest->messageTwo, src->messageTwo, WH_SHE_M2_SZ);
+    memcpy(dest->messageThree, src->messageThree, WH_SHE_M3_SZ);
+    memcpy(dest->messageFour, src->messageFour, WH_SHE_M4_SZ);
+    memcpy(dest->messageFive, src->messageFive, WH_SHE_M5_SZ);
+    return 0;
+}
+
+/* Init RNG translation function */
+int wh_MessageShe_TranslateInitRngResponse(
+    uint16_t magic, const whMessageShe_InitRngResponse* src,
+    whMessageShe_InitRngResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    WH_T32(magic, dest, src, status);
+    return 0;
+}
+
+/* RND translation function */
+int wh_MessageShe_TranslateRndResponse(uint16_t                        magic,
+                                       const whMessageShe_RndResponse* src,
+                                       whMessageShe_RndResponse*       dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    memcpy(dest->rnd, src->rnd, WH_SHE_KEY_SZ);
+    return 0;
+}
+
+/* Extend Seed translation functions */
+int wh_MessageShe_TranslateExtendSeedRequest(
+    uint16_t magic, const whMessageShe_ExtendSeedRequest* src,
+    whMessageShe_ExtendSeedRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    memcpy(dest->entropy, src->entropy, WH_SHE_KEY_SZ);
+    return 0;
+}
+
+int wh_MessageShe_TranslateExtendSeedResponse(
+    uint16_t magic, const whMessageShe_ExtendSeedResponse* src,
+    whMessageShe_ExtendSeedResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    WH_T32(magic, dest, src, status);
+    return 0;
+}
+
+/* Encrypt ECB translation functions */
+int wh_MessageShe_TranslateEncEcbRequest(uint16_t magic,
+                                         const whMessageShe_EncEcbRequest* src,
+                                         whMessageShe_EncEcbRequest*       dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, sz);
+    dest->keyId = src->keyId;
+    return 0;
+}
+
+int wh_MessageShe_TranslateEncEcbResponse(
+    uint16_t magic, const whMessageShe_EncEcbResponse* src,
+    whMessageShe_EncEcbResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    WH_T32(magic, dest, src, sz);
+    return 0;
+}
+
+/* Encrypt CBC translation functions */
+int wh_MessageShe_TranslateEncCbcRequest(uint16_t magic,
+                                         const whMessageShe_EncCbcRequest* src,
+                                         whMessageShe_EncCbcRequest*       dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, sz);
+    dest->keyId = src->keyId;
+    memcpy(dest->iv, src->iv, WH_SHE_KEY_SZ);
+    return 0;
+}
+
+int wh_MessageShe_TranslateEncCbcResponse(
+    uint16_t magic, const whMessageShe_EncCbcResponse* src,
+    whMessageShe_EncCbcResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    WH_T32(magic, dest, src, sz);
+    return 0;
+}
+
+/* Decrypt ECB translation functions */
+int wh_MessageShe_TranslateDecEcbRequest(uint16_t magic,
+                                         const whMessageShe_DecEcbRequest* src,
+                                         whMessageShe_DecEcbRequest*       dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, sz);
+    dest->keyId = src->keyId;
+    return 0;
+}
+
+int wh_MessageShe_TranslateDecEcbResponse(
+    uint16_t magic, const whMessageShe_DecEcbResponse* src,
+    whMessageShe_DecEcbResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    WH_T32(magic, dest, src, sz);
+    return 0;
+}
+
+/* Decrypt CBC translation functions */
+int wh_MessageShe_TranslateDecCbcRequest(uint16_t magic,
+                                         const whMessageShe_DecCbcRequest* src,
+                                         whMessageShe_DecCbcRequest*       dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, sz);
+    dest->keyId = src->keyId;
+    memcpy(dest->iv, src->iv, WH_SHE_KEY_SZ);
+    return 0;
+}
+
+int wh_MessageShe_TranslateDecCbcResponse(
+    uint16_t magic, const whMessageShe_DecCbcResponse* src,
+    whMessageShe_DecCbcResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    WH_T32(magic, dest, src, sz);
+    return 0;
+}
+
+/* Generate MAC translation functions */
+int wh_MessageShe_TranslateGenMacRequest(uint16_t magic,
+                                         const whMessageShe_GenMacRequest* src,
+                                         whMessageShe_GenMacRequest*       dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, keyId);
+    WH_T32(magic, dest, src, sz);
+    return 0;
+}
+
+int wh_MessageShe_TranslateGenMacResponse(
+    uint16_t magic, const whMessageShe_GenMacResponse* src,
+    whMessageShe_GenMacResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    memcpy(dest->mac, src->mac, WH_SHE_KEY_SZ);
+    return 0;
+}
+
+/* Verify MAC translation functions */
+int wh_MessageShe_TranslateVerifyMacRequest(
+    uint16_t magic, const whMessageShe_VerifyMacRequest* src,
+    whMessageShe_VerifyMacRequest* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, keyId);
+    WH_T32(magic, dest, src, messageLen);
+    WH_T32(magic, dest, src, macLen);
+    return 0;
+}
+
+int wh_MessageShe_TranslateVerifyMacResponse(
+    uint16_t magic, const whMessageShe_VerifyMacResponse* src,
+    whMessageShe_VerifyMacResponse* dest)
+{
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
+    WH_T32(magic, dest, src, rc);
+    dest->status = src->status;
+    return 0;
+}
+
+#endif /* WOLFHSM_CFG_SHE_EXTENSION */

--- a/src/wh_server.c
+++ b/src/wh_server.c
@@ -40,7 +40,6 @@
 #include "wolfhsm/wh_message.h"
 #include "wolfhsm/wh_message_comm.h"
 #include "wolfhsm/wh_message_nvm.h"
-#include "wolfhsm/wh_packet.h"
 
 /* Server API's */
 #include "wolfhsm/wh_server.h"
@@ -309,24 +308,25 @@ int wh_Server_HandleRequestMessage(whServerContext* server)
         break;
 
         case WH_MESSAGE_GROUP_COUNTER:
-            rc = wh_Server_HandleCounter(server, action, data, &size);
-        break;
+            rc = wh_Server_HandleCounter(server, magic, action, size, data,
+                                         &size, data);
+            break;
 
 #ifndef WOLFHSM_CFG_NO_CRYPTO
         case WH_MESSAGE_GROUP_KEY:
-            rc = wh_Server_HandleKeyRequest(server, magic, action, seq,
-                    data, &size);
-        break;
+            rc = wh_Server_HandleKeyRequest(server, magic, action, size, data,
+                                            &size, data);
+            break;
 
         case WH_MESSAGE_GROUP_CRYPTO:
-            rc = wh_Server_HandleCryptoRequest(server, action, data,
-                &size, seq);
-        break;
+            rc = wh_Server_HandleCryptoRequest(server, magic, action, seq, size,
+                                               data, &size, data);
+            break;
 
 #ifdef WOLFHSM_CFG_DMA
         case WH_MESSAGE_GROUP_CRYPTO_DMA:
-            rc = wh_Server_HandleCryptoDmaRequest(server, action, data,
-                &size, seq);
+            rc = wh_Server_HandleCryptoDmaRequest(server, magic, action, seq,
+                                                  size, data, &size, data);
             break;
 #endif /* WOLFHSM_CFG_DMA */
 

--- a/src/wh_server.c
+++ b/src/wh_server.c
@@ -339,9 +339,9 @@ int wh_Server_HandleRequestMessage(whServerContext* server)
 
 #ifdef WOLFHSM_CFG_SHE_EXTENSION
         case WH_MESSAGE_GROUP_SHE:
-            rc = wh_Server_HandleSheRequest(server, action, data,
-                &size);
-        break;
+            rc = wh_Server_HandleSheRequest(server, magic, action, size, data,
+                                            &size, data);
+            break;
 #endif
 
         case WH_MESSAGE_GROUP_CUSTOM:

--- a/src/wh_server_counter.c
+++ b/src/wh_server_counter.c
@@ -30,86 +30,156 @@
 #include "wolfhsm/wh_common.h"
 #include "wolfhsm/wh_error.h"
 #include "wolfhsm/wh_message.h"
-#include "wolfhsm/wh_packet.h"
+#include "wolfhsm/wh_message_counter.h"
 #include "wolfhsm/wh_server.h"
 
 #include "wolfhsm/wh_server_counter.h"
 
-int wh_Server_HandleCounter(whServerContext* server, uint16_t action,
-    uint8_t* data, uint16_t* size)
+int wh_Server_HandleCounter(whServerContext* server, uint16_t magic,
+                            uint16_t action, uint16_t req_size,
+                            const void* req_packet, uint16_t* out_resp_size,
+                            void* resp_packet)
 {
-    whKeyId counterId = 0;
-    int ret = 0;
-    whPacket* packet = (whPacket*)data;
-    whNvmMetadata meta[1] = {{0}};
-    uint32_t* counter = (uint32_t*)(&meta->label);
+    whKeyId       counterId = 0;
+    int           ret       = 0;
+    whNvmMetadata meta[1]   = {{0}};
+    uint32_t*     counter   = (uint32_t*)(&meta->label);
 
-    if (server == NULL || server->nvm == NULL || data == NULL || size == NULL)
+    if (server == NULL || server->nvm == NULL || req_packet == NULL ||
+        out_resp_size == NULL) {
         return WH_ERROR_BADARGS;
-
-    switch (action)
-    {
-    case WH_COUNTER_INIT:
-        /* write 0 to nvm with the supplied id and user_id */
-        meta->id = WH_MAKE_KEYID(WH_KEYTYPE_COUNTER,
-            server->comm->client_id, packet->counterInitReq.counterId);
-        /* use the label buffer to hold the counter value */
-        *counter = packet->counterInitReq.counter;
-        ret = wh_Nvm_AddObjectWithReclaim(server->nvm, meta, 0, NULL);
-        if (ret == 0) {
-            packet->counterInitRes.counter = *counter;
-            *size = WH_PACKET_STUB_SIZE + sizeof(packet->counterInitRes);
-        }
-        break;
-    case WH_COUNTER_INCREMENT:
-        /* read the counter, stored in the metadata label */
-        ret = wh_Nvm_GetMetadata(server->nvm, WH_MAKE_KEYID(
-            WH_KEYTYPE_COUNTER, server->comm->client_id,
-            packet->counterIncrementReq.counterId), meta);
-        /* increment and write the counter back */
-        if (ret == 0) {
-            *counter = *counter + 1;
-            /* set counter to uint32_t max if it rolled over */
-            if (*counter == 0) {
-                *counter = UINT32_MAX;
-            }
-            /* only update if we didn't saturate */
-            else {
-                ret = wh_Nvm_AddObjectWithReclaim(server->nvm, meta, 0, NULL);
-            }
-        }
-        /* return counter to the caller */
-        if (ret == 0) {
-            packet->counterIncrementRes.counter = *counter;
-            *size = WH_PACKET_STUB_SIZE +
-                sizeof(packet->counterIncrementRes);
-        }
-        break;
-    case WH_COUNTER_READ:
-        /* read the counter, stored in the metadata label */
-        ret = wh_Nvm_GetMetadata(server->nvm, WH_MAKE_KEYID(
-            WH_KEYTYPE_COUNTER, server->comm->client_id,
-            packet->counterReadReq.counterId), meta);
-        /* return counter to the caller */
-        if (ret == 0) {
-
-            packet->counterReadRes.counter = *counter;
-            *size = WH_PACKET_STUB_SIZE + sizeof(packet->counterReadRes);
-        }
-        break;
-    case WH_COUNTER_DESTROY:
-        counterId = WH_MAKE_KEYID(WH_KEYTYPE_COUNTER,
-            server->comm->client_id, packet->counterDestroyReq.counterId);
-        ret = wh_Nvm_DestroyObjects(server->nvm, 1, &counterId);
-        if (ret == 0)
-            *size = WH_PACKET_STUB_SIZE;
-        break;
-    default:
-        ret = WH_ERROR_BADARGS;
-        break;
     }
-    packet->rc = ret;
-    if (ret != 0)
-        *size = WH_PACKET_STUB_SIZE + sizeof(packet->rc);
-    return 0;
+
+    switch (action) {
+        case WH_COUNTER_INIT: {
+            whMessageCounter_InitRequest  req;
+            whMessageCounter_InitResponse resp;
+
+            /* translate request */
+            (void)wh_MessageCounter_TranslateInitRequest(
+                magic, (whMessageCounter_InitRequest*)req_packet, &req);
+
+            /* write 0 to nvm with the supplied id and user_id */
+            meta->id = WH_MAKE_KEYID(WH_KEYTYPE_COUNTER,
+                                     server->comm->client_id, req.counterId);
+            /* use the label buffer to hold the counter value */
+            *counter = req.counter;
+            ret      = wh_Nvm_AddObjectWithReclaim(server->nvm, meta, 0, NULL);
+            if (ret == WH_ERROR_OK) {
+                resp.counter = *counter;
+            }
+            resp.rc = ret;
+            /* TODO: are there any fatal server errors? */
+            ret = WH_ERROR_OK;
+
+            (void)wh_MessageCounter_TranslateInitResponse(
+                magic, &resp, (whMessageCounter_InitResponse*)resp_packet);
+
+            *out_resp_size = sizeof(resp);
+        } break;
+
+        case WH_COUNTER_INCREMENT: {
+            whMessageCounter_IncrementRequest  req;
+            whMessageCounter_IncrementResponse resp;
+
+            /* translate request */
+            (void)wh_MessageCounter_TranslateIncrementRequest(
+                magic, (whMessageCounter_IncrementRequest*)req_packet, &req);
+
+            /* read the counter, stored in the metadata label */
+            ret     = wh_Nvm_GetMetadata(server->nvm,
+                                         WH_MAKE_KEYID(WH_KEYTYPE_COUNTER,
+                                                       server->comm->client_id,
+                                                       req.counterId),
+                                         meta);
+            resp.rc = ret;
+
+            /* increment and write the counter back */
+            if (ret == WH_ERROR_OK) {
+                *counter = *counter + 1;
+                /* set counter to uint32_t max if it rolled over */
+                if (*counter == 0) {
+                    *counter = UINT32_MAX;
+                }
+                /* only update if we didn't saturate */
+                else {
+                    ret =
+                        wh_Nvm_AddObjectWithReclaim(server->nvm, meta, 0, NULL);
+                    resp.rc = ret;
+                }
+            }
+
+            /* return counter to the caller */
+            if (ret == WH_ERROR_OK) {
+                resp.counter = *counter;
+            }
+
+            (void)wh_MessageCounter_TranslateIncrementResponse(
+                magic, &resp, (whMessageCounter_IncrementResponse*)resp_packet);
+
+            *out_resp_size = sizeof(resp);
+
+            /* TODO: are there any fatal server errors? */
+            ret = WH_ERROR_OK;
+        } break;
+
+        case WH_COUNTER_READ: {
+            whMessageCounter_ReadRequest  req;
+            whMessageCounter_ReadResponse resp;
+
+            /* translate request */
+            (void)wh_MessageCounter_TranslateReadRequest(
+                magic, (whMessageCounter_ReadRequest*)req_packet, &req);
+
+            /* read the counter, stored in the metadata label */
+            ret     = wh_Nvm_GetMetadata(server->nvm,
+                                         WH_MAKE_KEYID(WH_KEYTYPE_COUNTER,
+                                                       server->comm->client_id,
+                                                       req.counterId),
+                                         meta);
+            resp.rc = ret;
+
+            /* return counter to the caller */
+            if (ret == WH_ERROR_OK) {
+                resp.counter = *counter;
+            }
+
+            (void)wh_MessageCounter_TranslateReadResponse(
+                magic, &resp, (whMessageCounter_ReadResponse*)resp_packet);
+
+            *out_resp_size = sizeof(resp);
+
+            /* TODO: are there any fatal server errors? */
+            ret = WH_ERROR_OK;
+        } break;
+
+        case WH_COUNTER_DESTROY: {
+            whMessageCounter_DestroyRequest  req;
+            whMessageCounter_DestroyResponse resp;
+
+            /* translate request */
+            (void)wh_MessageCounter_TranslateDestroyRequest(
+                magic, (whMessageCounter_DestroyRequest*)req_packet, &req);
+
+            counterId = WH_MAKE_KEYID(WH_KEYTYPE_COUNTER,
+                                      server->comm->client_id, req.counterId);
+
+            ret     = wh_Nvm_DestroyObjects(server->nvm, 1, &counterId);
+            resp.rc = ret;
+
+            (void)wh_MessageCounter_TranslateDestroyResponse(
+                magic, &resp, (whMessageCounter_DestroyResponse*)resp_packet);
+
+            *out_resp_size = sizeof(resp);
+
+            /* TODO: are there any fatal server errors? */
+            ret = WH_ERROR_OK;
+        } break;
+
+        default:
+            ret = WH_ERROR_BADARGS;
+            break;
+    }
+
+    return ret;
 }

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -1548,7 +1548,8 @@ static int _HandleCmac(whServerContext* ctx, uint16_t magic, uint16_t seq,
                         printf("[server] cmac readkey got key len:%u\n", len);
 #endif
                         moveToBigCache = 1;
-                        XMEMCPY(tmpKey, (uint8_t*)ctx->crypto->algoCtx.cmac, len);
+                        memcpy(tmpKey, (uint8_t*)ctx->crypto->algoCtx.cmac,
+                               len);
                         ret = wc_InitCmac_ex(ctx->crypto->algoCtx.cmac, tmpKey, len,
                             WC_CMAC_AES, NULL, NULL, ctx->crypto->devId);
                     }

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -44,7 +44,6 @@
 #include "wolfssl/wolfcrypt/dilithium.h"
 
 #include "wolfhsm/wh_error.h"
-#include "wolfhsm/wh_packet.h"
 #include "wolfhsm/wh_crypto.h"
 #include "wolfhsm/wh_utils.h"
 #include "wolfhsm/wh_server_keystore.h"
@@ -52,43 +51,62 @@
 
 #include "wolfhsm/wh_server.h"
 
+#include "wolfhsm/wh_message_crypto.h"
+
 /** Forward declarations */
 #ifndef NO_RSA
 #ifdef WOLFSSL_KEY_GEN
 /* Process a Generate RsaKey request packet and produce a response packet */
-static int _HandleRsaKeyGen(whServerContext* ctx, whPacket* packet,
-        uint16_t *out_size);
+static int _HandleRsaKeyGen(whServerContext* ctx, uint16_t magic,
+                            const void* cryptoDataIn, uint16_t inSize,
+                            void* cryptoDataOut, uint16_t* outSize);
 #endif /* WOLFSSL_KEY_GEN */
 
+/* Process a Rng request packet and produce a response packet */
+static int _HandleRng(whServerContext* ctx, uint16_t magic,
+                      const void* cryptoDataIn, uint16_t inSize,
+                      void* cryptoDataOut, uint16_t* outSize);
+
 /* Process a Rsa Function request packet and produce a response packet */
-static int _HandleRsaFunction(whServerContext* ctx, whPacket* packet,
-        uint16_t *out_size);
+static int _HandleRsaFunction(whServerContext* ctx, uint16_t magic,
+                              const void* cryptoDataIn, uint16_t inSize,
+                              void* cryptoDataOut, uint16_t* outSize);
+
 /* Process a Rsa Get Size request packet and produce a response packet */
-static int _HandleRsaGetSize(whServerContext* ctx, whPacket* packet,
-        uint16_t *out_size);
+static int _HandleRsaGetSize(whServerContext* ctx, uint16_t magic,
+                             const void* cryptoDataIn, uint16_t inSize,
+                             void* cryptoDataOut, uint16_t* outSize);
 #endif /* !NO_RSA */
 
 #ifndef NO_AES
 
 #ifdef HAVE_AESGCM
-static int _HandleAesGcm(whServerContext* ctx, whPacket* packet,
-        uint16_t* out_size);
+static int _HandleAesCbc(whServerContext* ctx, uint16_t magic,
+                         const void* cryptoDataIn, uint16_t inSize,
+                         void* cryptoDataOut, uint16_t* outSize);
+static int _HandleAesGcm(whServerContext* ctx, uint16_t magic,
+                         const void* cryptoDataIn, uint16_t inSize,
+                         void* cryptoDataOut, uint16_t* outSize);
 #endif
 
 #endif /* !NO_AES */
 
 #ifdef HAVE_ECC
-static int _HandleEccKeyGen(whServerContext* ctx, whPacket* packet,
-        uint16_t *out_size);
+static int _HandleEccKeyGen(whServerContext* ctx, uint16_t magic,
+                            const void* cryptoDataIn, uint16_t inSize,
+                            void* cryptoDataOut, uint16_t* outSize);
 
-static int _HandleEccSharedSecret(whServerContext* ctx, whPacket* packet,
-        uint16_t *out_size);
+static int _HandleEccSharedSecret(whServerContext* ctx, uint16_t magic,
+                                  const void* cryptoDataIn, uint16_t inSize,
+                                  void* cryptoDataOut, uint16_t* outSize);
 
-static int _HandleEccSign(whServerContext* ctx, whPacket* packet,
-        uint16_t *out_size);
+static int _HandleEccSign(whServerContext* ctx, uint16_t magic,
+                          const void* cryptoDataIn, uint16_t inSize,
+                          void* cryptoDataOut, uint16_t* outSize);
 
-static int _HandleEccVerify(whServerContext* ctx, whPacket* packet,
-        uint16_t *out_size);
+static int _HandleEccVerify(whServerContext* ctx, uint16_t magic,
+                            const void* cryptoDataIn, uint16_t inSize,
+                            void* cryptoDataOut, uint16_t* outSize);
 #if 0
 static int _HandleEccCheckPrivKey(whServerContext* server, whPacket* packet,
     uint16_t* size)
@@ -98,29 +116,36 @@ static int _HandleEccCheckPrivKey(whServerContext* server, whPacket* packet,
 
 #ifdef HAVE_CURVE25519
 /* Process a Generate curve25519_key request packet and produce a response */
-static int _HandleCurve25519KeyGen(whServerContext* ctx, whPacket* packet,
-        uint16_t *out_size);
+static int _HandleCurve25519KeyGen(whServerContext* ctx, uint16_t magic,
+                                   const void* cryptoDataIn, uint16_t inSize,
+                                   void* cryptoDataOut, uint16_t* outSize);
 
 /* Process a curve25519_key Function request packet and produce a response */
-static int _HandleCurve25519SharedSecret(whServerContext* ctx, whPacket* packet,
-        uint16_t *out_size);
+static int _HandleCurve25519SharedSecret(whServerContext* ctx, uint16_t magic,
+                                         const void* cryptoDataIn,
+                                         uint16_t inSize, void* cryptoDataOut,
+                                         uint16_t* outSize);
 #endif /* HAVE_CURVE25519 */
 
 #ifdef HAVE_DILITHIUM
 /* Process a Dilithium KeyGen request packet and produce a response packet */
-static int _HandleMlDsaKeyGen(whServerContext* ctx, whPacket* packet,
-        uint16_t *out_size);
+static int _HandleMlDsaKeyGen(whServerContext* ctx, uint16_t magic,
+                              const void* cryptoDataIn, uint16_t inSize,
+                              void* cryptoDataOut, uint16_t* outSize);
 /* Process a Dilithium Sign request packet and produce a response packet */
-static int _HandleMlDsaSign(whServerContext* ctx, whPacket* packet,
-        uint16_t *out_size);
+static int _HandleMlDsaSign(whServerContext* ctx, uint16_t magic,
+                            const void* cryptoDataIn, uint16_t inSize,
+                            void* cryptoDataOut, uint16_t* outSize);
 /* Process a Dilithium Verify request packet and produce a response packet */
-static int _HandleMlDsaVerify(whServerContext* ctx, whPacket* packet,
-        uint16_t *out_size);
+static int _HandleMlDsaVerify(whServerContext* ctx, uint16_t magic,
+                              const void* cryptoDataIn, uint16_t inSize,
+                              void* cryptoDataOut, uint16_t* outSize);
 /* Process a Dilithium Check PrivKey request packet and produce a response
  * packet */
-static int _HandleMlDsaCheckPrivKey(whServerContext* ctx, whPacket* packet,
-        uint16_t *out_size);
-#endif /* HAVE_DILITHIUM */ 
+static int _HandleMlDsaCheckPrivKey(whServerContext* ctx, uint16_t magic,
+                                    const void* cryptoDataIn, uint16_t inSize,
+                                    void* cryptoDataOut, uint16_t* outSize);
+#endif /* HAVE_DILITHIUM */
 
 /** Public server crypto functions */
 
@@ -193,26 +218,39 @@ int wh_Server_CacheExportRsaKey(whServerContext* ctx, whKeyId keyId,
 }
 
 #ifdef WOLFSSL_KEY_GEN
-static int _HandleRsaKeyGen(whServerContext* ctx,
-        whPacket* packet, uint16_t *out_size)
+static int _HandleRsaKeyGen(whServerContext* ctx, uint16_t magic,
+                         const void* cryptoDataIn, uint16_t inSize,
+                         void* cryptoDataOut, uint16_t* outSize)
 {
-    int ret = 0;
+    int    ret    = 0;
     RsaKey rsa[1] = {0};
-    int key_size        = packet->pkRsakgReq.size;
-    long e              = packet->pkRsakgReq.e;
+    whMessageCrypto_RsaKeyGenRequest req;
+    whMessageCrypto_RsaKeyGenResponse res;
+
+    /* Translate request */
+    ret = wh_MessageCrypto_TranslateRsaKeyGenRequest(
+        magic, (const whMessageCrypto_RsaKeyGenRequest*)cryptoDataIn, &req);
+    if (ret != 0) {
+        return ret;
+    }
+
+    /* Extract parameters from translated request */
+    int  key_size = req.size;
+    long e        = req.e;
 
     /* Force incoming key_id to have current user/type */
-    whKeyId key_id      = WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
-                            ctx->comm->client_id,
-                            packet->pkRsakgReq.keyId);
-    whNvmFlags flags    = packet->pkRsakgReq.flags;
-    uint8_t* label      = packet->pkRsakgReq.label;
-    uint32_t label_size = WH_NVM_LABEL_LEN;
+    whKeyId key_id =
+        WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id, req.keyId);
+    whNvmFlags flags      = req.flags;
+    uint8_t*   label      = req.label;
+    uint32_t   label_size = WH_NVM_LABEL_LEN;
 
-    uint8_t* out        = (uint8_t*)(&packet->pkRsakgRes + 1);
-    word32 max_size     = (word32)(WOLFHSM_CFG_COMM_DATA_LEN -
-                            (out - (uint8_t*)packet));
-    uint16_t der_size        = 0;
+    /* Get pointer to where key data would be stored (after response struct) */
+    uint8_t* out =
+        (uint8_t*)cryptoDataOut + sizeof(whMessageCrypto_RsaKeyGenResponse);
+    uint16_t max_size = (uint16_t)(WOLFHSM_CFG_COMM_DATA_LEN -
+                                   ((uint8_t*)out - (uint8_t*)cryptoDataOut));
+    uint16_t der_size = 0;
 
     /* init the rsa key */
     ret = wc_InitRsaKey_ex(rsa, NULL, ctx->crypto->devId);
@@ -220,68 +258,82 @@ static int _HandleRsaKeyGen(whServerContext* ctx,
         /* make the rsa key with the given params */
         ret = wc_MakeRsaKey(rsa, key_size, e, ctx->crypto->rng);
 #ifdef DEBUG_CRYPTOCB_VERBOSE
-        printf("[server] MakeRsaKey: size:%d, e:%ld, ret:%d\n",
-                key_size, e, ret);
+        printf("[server] MakeRsaKey: size:%d, e:%ld, ret:%d\n", key_size, e,
+               ret);
 #endif
 
-        if ( ret == 0) {
+        if (ret == 0) {
             /* Check incoming flags */
             if (flags & WH_NVM_FLAGS_EPHEMERAL) {
                 /* Must serialize the key into the response packet */
-                ret = wh_Crypto_RsaSerializeKeyDer(rsa, max_size, out, &der_size);
+                ret =
+                    wh_Crypto_RsaSerializeKeyDer(rsa, max_size, out, &der_size);
                 if (ret == 0) {
-                    packet->pkRsakgRes.keyId = 0;
-                    packet->pkRsakgRes.len = der_size;
+                    res.keyId = 0;
+                    res.len   = der_size;
                 }
-            } else {
+            }
+            else {
                 /* Must import the key into the cache and return keyid */
                 if (WH_KEYID_ISERASED(key_id)) {
                     /* Generate a new id */
                     ret = hsmGetUniqueId(ctx, &key_id);
 #ifdef DEBUG_CRYPTOCB_VERBOSE
-                    printf("[server] RsaKeyGen UniqueId: keyId:%u, ret:%d\n", key_id, ret);
+                    printf("[server] RsaKeyGen UniqueId: keyId:%u, ret:%d\n",
+                           key_id, ret);
 #endif
                 }
 
-                ret = wh_Server_CacheImportRsaKey(ctx, rsa,
-                        key_id, flags, label_size, label);
+                ret = wh_Server_CacheImportRsaKey(ctx, rsa, key_id, flags,
+                                                  label_size, label);
 #ifdef DEBUG_CRYPTOCB_VERBOSE
-                printf("[server] RsaKeyGen CacheKeyRsa: keyId:%u, ret:%d\n", key_id, ret);
+                printf("[server] RsaKeyGen CacheKeyRsa: keyId:%u, ret:%d\n",
+                       key_id, ret);
 #endif
-                packet->pkRsakgRes.keyId = (key_id & WH_KEYID_MASK);
-                packet->pkRsakgRes.len = 0;
+                res.keyId = WH_KEYID_ID(key_id);
+                res.len   = 0;
             }
         }
         wc_FreeRsaKey(rsa);
     }
 
     if (ret == 0) {
-        /* set the assigned id */
-        *out_size = WH_PACKET_STUB_SIZE +
-                sizeof(packet->pkRsakgRes) +
-                packet->pkRsakgRes.len;
+        wh_MessageCrypto_TranslateRsaKeyGenResponse(
+            magic, &res, (whMessageCrypto_RsaKeyGenResponse*)cryptoDataOut);
+
+        *outSize = sizeof(whMessageCrypto_RsaKeyGenResponse) + res.len;
     }
+
     return ret;
 }
 #endif /* WOLFSSL_KEY_GEN */
 
-static int _HandleRsaFunction(whServerContext* ctx, whPacket* packet,
-    uint16_t *out_size)
+static int _HandleRsaFunction( whServerContext* ctx, uint16_t magic,
+                      const void* cryptoDataIn, uint16_t inSize,
+                      void* cryptoDataOut, uint16_t* outSize)
 {
-    int ret;
-    RsaKey rsa[1];
-    int op_type         = (int)(packet->pkRsaReq.opType);
-    uint32_t options    = packet->pkRsaReq.options;
-    int evict           = !!(options & WH_PACKET_PK_RSA_OPTIONS_EVICT);
+    int                        ret;
+    RsaKey                     rsa[1];
+    whMessageCrypto_RsaRequest req;
 
-    whKeyId key_id      = WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
-                            ctx->comm->client_id,
-                            packet->pkRsaReq.keyId);
-    word32 in_len       = (word32)(packet->pkRsaReq.inLen);
-    word32 out_len      = (word32)(packet->pkRsaReq.outLen);
+    /* Translate request */
+    ret = wh_MessageCrypto_TranslateRsaRequest(
+        magic, (const whMessageCrypto_RsaRequest*)cryptoDataIn, &req);
+    if (ret != 0) {
+        return ret;
+    }
+
+    /* Extract parameters from translated request */
+    int      op_type = (int)(req.opType);
+    uint32_t options = req.options;
+    int      evict   = !!(options & WH_MESSAGE_CRYPTO_RSA_OPTIONS_EVICT);
+    whKeyId  key_id =
+        WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id, req.keyId);
+    word32 in_len  = (word32)(req.inLen);
+    word32 out_len = (word32)(req.outLen);
     /* in and out are after the fixed size fields */
-    byte* in            = (uint8_t*)(&packet->pkRsaReq + 1);
-    byte* out           = (uint8_t*)(&packet->pkRsaRes + 1);
+    byte* in  = (uint8_t*)(cryptoDataIn + sizeof(whMessageCrypto_RsaRequest));
+    byte* out = (uint8_t*)(cryptoDataOut + sizeof(whMessageCrypto_RsaResponse));
 
 #ifdef DEBUG_CRYPTOCB_VERBOSE
     printf("[server] HandleRsaFunction opType:%d inLen:%u keyId:%u outLen:%u\n",
@@ -329,23 +381,38 @@ static int _HandleRsaFunction(whServerContext* ctx, whPacket* packet,
         (void)hsmEvictKey(ctx, key_id);
     }
     if (ret == 0) {
+        whMessageCrypto_RsaResponse res;
         /*set outLen and outgoing message size */
-        packet->pkRsaRes.outLen = out_len;
-        *out_size = WH_PACKET_STUB_SIZE + sizeof(packet->pkRsaRes) + out_len;
+        res.outLen = out_len;
+        wh_MessageCrypto_TranslateRsaResponse(
+            magic, &res, (whMessageCrypto_RsaResponse*)cryptoDataOut);
+
+        *outSize = sizeof(whMessageCrypto_RsaResponse) + out_len;
     }
     return ret;
 }
 
-static int _HandleRsaGetSize(whServerContext* ctx, whPacket* packet,
-    uint16_t *out_size)
+static int _HandleRsaGetSize(whServerContext* ctx, uint16_t magic,
+                             const void* cryptoDataIn, uint16_t inSize,
+                             void* cryptoDataOut, uint16_t* outSize)
 {
-    int ret;
-    RsaKey rsa[1];
-    whKeyId key_id      = WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
-                            ctx->comm->client_id,
-                            packet->pkRsaGetSizeReq.keyId);
-    uint32_t options    = packet->pkRsaGetSizeReq.options;
-    int evict           = !!(options & WH_PACKET_PK_RSA_GET_SIZE_OPTIONS_EVICT);
+    int                                ret;
+    RsaKey                             rsa[1];
+    whMessageCrypto_RsaGetSizeRequest  req;
+    whMessageCrypto_RsaGetSizeResponse res;
+
+    /* Translate request */
+    ret = wh_MessageCrypto_TranslateRsaGetSizeRequest(
+        magic, (const whMessageCrypto_RsaGetSizeRequest*)cryptoDataIn, &req);
+    if (ret != 0) {
+        return ret;
+    }
+
+    /* Extract parameters from translated request */
+    whKeyId key_id =
+        WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id, req.keyId);
+    uint32_t options = req.options;
+    int      evict = !!(options & WH_MESSAGE_CRYPTO_RSA_GET_SIZE_OPTIONS_EVICT);
 
     int key_size = 0;
 
@@ -366,18 +433,21 @@ static int _HandleRsaGetSize(whServerContext* ctx, whPacket* packet,
     if (evict != 0) {
 #ifdef DEBUG_CRYPTOCB_VERBOSE
         printf("[server] %s evicting temp key:%x options:%u evict:%u\n",
-                __func__, key_id, options, evict);
+               __func__, key_id, options, evict);
 #endif
         (void)hsmEvictKey(ctx, key_id);
     }
     if (ret == 0) {
-        /*set keySize */
-        packet->pkRsaGetSizeRes.keySize = key_size;
-        *out_size = WH_PACKET_STUB_SIZE + sizeof(packet->pkRsaGetSizeRes);
+        res.keySize = key_size;
+
+        wh_MessageCrypto_TranslateRsaGetSizeResponse(
+            magic, &res, (whMessageCrypto_RsaGetSizeResponse*)cryptoDataOut);
+
+        *outSize = sizeof(whMessageCrypto_RsaGetSizeResponse);
     }
 #ifdef DEBUG_CRYPTOCB_VERBOSE
-        printf("[server] %s keyId:%d, key_size:%d, ret:%d\n",
-                __func__, key_id, key_size, ret);
+    printf("[server] %s keyId:%d, key_size:%d, ret:%d\n", __func__, key_id,
+           key_size, ret);
 #endif
     return ret;
 }
@@ -587,96 +657,128 @@ int wh_Server_MlDsaKeyCacheExport(whServerContext* ctx, whKeyId keyId,
 /** Request/Response Handling functions */
 
 #ifdef HAVE_ECC
-static int _HandleEccKeyGen(whServerContext* ctx, whPacket* packet,
-    uint16_t* out_size)
+static int _HandleEccKeyGen(whServerContext* ctx, uint16_t magic,
+                            const void* cryptoDataIn, uint16_t inSize,
+                            void* cryptoDataOut, uint16_t* outSize)
 {
-    int ret = WH_ERROR_OK;
-    ecc_key key[1];
-    wh_Packet_pk_eckg_req* req = &packet->pkEckgReq;
-    wh_Packet_pk_eckg_res* res = &packet->pkEckgRes;
+    int                               ret = WH_ERROR_OK;
+    ecc_key                           key[1];
+    whMessageCrypto_EccKeyGenRequest  req;
+    whMessageCrypto_EccKeyGenResponse res;
 
-    /* Request message */
-    int key_size        = req->sz;
-    int curve_id        = req->curveId;
-    whKeyId key_id      = WH_MAKE_KEYID(    WH_KEYTYPE_CRYPTO,
-                                            ctx->comm->client_id,
-                                            req->keyId);
-    whNvmFlags flags    = req->flags;
-    uint8_t* label      = req->label;
-    uint16_t label_size = WH_NVM_LABEL_LEN;
+    /* Translate request */
+    ret = wh_MessageCrypto_TranslateEccKeyGenRequest(
+        magic, (const whMessageCrypto_EccKeyGenRequest*)cryptoDataIn, &req);
+    if (ret != 0) {
+        return ret;
+    }
+
+    /* Extract parameters from translated request */
+    int     key_size = req.sz;
+    int     curve_id = req.curveId;
+    whKeyId key_id =
+        WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id, req.keyId);
+    whNvmFlags flags      = req.flags;
+    uint8_t*   label      = req.label;
+    uint16_t   label_size = WH_NVM_LABEL_LEN;
 
     /* Response message */
-    uint8_t* res_out    = (uint8_t*)(res + 1);
-    uint16_t max_size     = (uint16_t)(WOLFHSM_CFG_COMM_DATA_LEN -
-                            (res_out - (uint8_t*)packet));
-    uint16_t res_size   = 0;
+    uint8_t* res_out =
+        (uint8_t*)cryptoDataOut + sizeof(whMessageCrypto_EccKeyGenResponse);
+    uint16_t max_size = (uint16_t)(WOLFHSM_CFG_COMM_DATA_LEN -
+                                   (res_out - (uint8_t*)cryptoDataOut));
+    uint16_t res_size = 0;
 
     /* init ecc key */
     ret = wc_ecc_init_ex(key, NULL, ctx->crypto->devId);
     if (ret == 0) {
         /* generate the key */
         ret = wc_ecc_make_key_ex(ctx->crypto->rng, key_size, key, curve_id);
-        if ( ret == 0) {
+        if (ret == 0) {
             /* Check incoming flags */
             if (flags & WH_NVM_FLAGS_EPHEMERAL) {
                 /* Must serialize the key into the response message. */
                 key_id = WH_KEYID_ERASED;
-                ret = wh_Crypto_EccSerializeKeyDer(key, max_size, res_out, &res_size);
-            } else {
-                /* Must import the key into the cache and return keyid */
+                ret    = wh_Crypto_EccSerializeKeyDer(key, max_size, res_out,
+                                                      &res_size);
+                /* TODO: RSA has the following, should we do the same? */
+                /*
+                if (ret == 0) {
+                    res.keyId = 0;
+                    res.len = res_size;
+                }
+                */
+            }
+            else {
+                /* Must import the key into the cache and return keyid
+                 */
                 res_size = 0;
                 if (WH_KEYID_ISERASED(key_id)) {
                     /* Generate a new id */
                     ret = hsmGetUniqueId(ctx, &key_id);
 #ifdef DEBUG_CRYPTOCB
-                    printf("[server] %s UniqueId: keyId:%u, ret:%d\n",
-                            __func__, key_id, ret);
+                    printf("[server] %s UniqueId: keyId:%u, ret:%d\n", __func__,
+                           key_id, ret);
 #endif
                 }
-                ret = wh_Server_EccKeyCacheImport(ctx, key,
-                        key_id, flags, label_size, label);
+                ret = wh_Server_EccKeyCacheImport(ctx, key, key_id, flags,
+                                                  label_size, label);
 #ifdef DEBUG_CRYPTOCB
-                printf("[server] %s CacheImport: keyId:%u, ret:%d\n",
-                        __func__, key_id, ret);
+                printf("[server] %s CacheImport: keyId:%u, ret:%d\n", __func__,
+                       key_id, ret);
 #endif
+                /* TODO: RSA has the following, should we do the same? */
+                /*
+                res.keyId = WH_KEYID_ID(key_id);
+                res.len = 0;
+                */
             }
         }
         wc_ecc_free(key);
     }
 
     if (ret == WH_ERROR_OK) {
-        res->keyId  = WH_KEYID_ID(key_id);
-        res->len    = res_size;
-        *out_size   = WH_PACKET_STUB_SIZE + sizeof(*res) + res_size;
+        res.keyId = WH_KEYID_ID(key_id);
+        res.len   = res_size;
+
+        wh_MessageCrypto_TranslateEccKeyGenResponse(
+            magic, &res, (whMessageCrypto_EccKeyGenResponse*)cryptoDataOut);
+
+        *outSize = sizeof(whMessageCrypto_EccKeyGenResponse) + res_size;
     }
     return ret;
 }
 
-static int _HandleEccSharedSecret(whServerContext* ctx, whPacket* packet,
-        uint16_t *out_size)
+static int _HandleEccSharedSecret(whServerContext* ctx, uint16_t magic,
+                                  const void* cryptoDataIn, uint16_t inSize,
+                                  void* cryptoDataOut, uint16_t* outSize)
 {
-    int ret = WH_ERROR_OK;
-    ecc_key pub_key[1];
-    ecc_key prv_key[1];
+    int                         ret = WH_ERROR_OK;
+    ecc_key                     pub_key[1];
+    ecc_key                     prv_key[1];
+    whMessageCrypto_EcdhRequest req;
 
-    wh_Packet_pk_ecdh_req* req = &packet->pkEcdhReq;
-    wh_Packet_pk_ecdh_res* res = &packet->pkEcdhRes;
+    /* Translate request */
+    ret = wh_MessageCrypto_TranslateEcdhRequest(
+        magic, (const whMessageCrypto_EcdhRequest*)cryptoDataIn, &req);
+    if (ret != 0) {
+        return ret;
+    }
 
-    /* Request message */
-    uint32_t options    = req->options;
-    int evict_pub       = !!(options & WH_PACKET_PK_ECDH_OPTIONS_EVICTPUB);
-    int evict_prv       = !!(options & WH_PACKET_PK_ECDH_OPTIONS_EVICTPRV);
-    whKeyId pub_key_id  = WH_MAKE_KEYID(    WH_KEYTYPE_CRYPTO,
-                                            ctx->comm->client_id,
-                                            req->publicKeyId);
-    whKeyId prv_key_id  = WH_MAKE_KEYID(    WH_KEYTYPE_CRYPTO,
-                                            ctx->comm->client_id,
-                                            req->privateKeyId);
+    /* Extract parameters from translated request */
+    uint32_t options   = req.options;
+    int      evict_pub = !!(options & WH_MESSAGE_CRYPTO_ECDH_OPTIONS_EVICTPUB);
+    int      evict_prv = !!(options & WH_MESSAGE_CRYPTO_ECDH_OPTIONS_EVICTPRV);
+    whKeyId  pub_key_id =
+        WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id, req.publicKeyId);
+    whKeyId prv_key_id = WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id,
+                                       req.privateKeyId);
 
     /* Response message */
-    byte* res_out       = (uint8_t*)(res + 1);
-    word32 max_len      = (word32)(WOLFHSM_CFG_COMM_DATA_LEN -
-                            (res_out - (uint8_t*)packet));
+    byte* res_out =
+        (byte*)cryptoDataOut + sizeof(whMessageCrypto_EcdhResponse);
+    word32 max_len = (word32)(WOLFHSM_CFG_COMM_DATA_LEN -
+                              (res_out - (uint8_t*)cryptoDataOut));
     word32 res_len;
 
     /* init ecc keys */
@@ -710,34 +812,47 @@ static int _HandleEccSharedSecret(whServerContext* ctx, whPacket* packet,
         (void)hsmEvictKey(ctx, prv_key_id);
     }
     if (ret == 0) {
-        res->sz = res_len;
-        *out_size = WH_PACKET_STUB_SIZE + sizeof(*res) + res_len;
+        whMessageCrypto_EcdhResponse res;
+        res.sz = res_len;
+
+        wh_MessageCrypto_TranslateEcdhResponse(
+            magic, &res, (whMessageCrypto_EcdhResponse*)cryptoDataOut);
+
+        *outSize = sizeof(whMessageCrypto_EcdhResponse) + res_len;
     }
     return ret;
 }
 
-static int _HandleEccSign(whServerContext* ctx, whPacket* packet,
-    uint16_t *out_size)
+static int _HandleEccSign(whServerContext* ctx, uint16_t magic,
+                          const void* cryptoDataIn, uint16_t inSize,
+                          void* cryptoDataOut, uint16_t* outSize)
 {
-    int ret;
-    ecc_key key[1];
-    wh_Packet_pk_ecc_sign_req* req = &packet->pkEccSignReq;
-    wh_Packet_pk_ecc_sign_res* res = &packet->pkEccSignRes;
+    int                            ret;
+    ecc_key                        key[1];
+    whMessageCrypto_EccSignRequest req;
 
-    /* Request message */
-    byte* in        = (uint8_t*)(req + 1);
-    whKeyId key_id  = WH_MAKE_KEYID(    WH_KEYTYPE_CRYPTO,
-                                        ctx->comm->client_id,
-                                        req->keyId);
-    word32 in_len   = req->sz;
-    uint32_t options = req->options;
-    int evict       = !!(options & WH_PACKET_PK_ECCSIGN_OPTIONS_EVICT);
+    /* Translate request */
+    ret = wh_MessageCrypto_TranslateEccSignRequest(
+        magic, (const whMessageCrypto_EccSignRequest*)cryptoDataIn, &req);
+    if (ret != 0) {
+        return ret;
+    }
+
+    /* Extract parameters from translated request */
+    uint8_t* in =
+        (uint8_t*)cryptoDataIn + sizeof(whMessageCrypto_EccSignRequest);
+    whKeyId key_id =
+        WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id, req.keyId);
+    word32   in_len  = req.sz;
+    uint32_t options = req.options;
+    int      evict   = !!(options & WH_MESSAGE_CRYPTO_ECCSIGN_OPTIONS_EVICT);
 
     /* Response message */
-    byte* res_out   = (uint8_t*)(res + 1);
-    word32 max_len  = (word32)(WOLFHSM_CFG_COMM_DATA_LEN -
-                        (res_out - (uint8_t*)packet));
-    word32 res_len;
+    byte* res_out =
+        (byte*)cryptoDataOut + sizeof(whMessageCrypto_EccSignResponse);
+    word32 max_len = (word32)(WOLFHSM_CFG_COMM_DATA_LEN -
+                              (res_out - (uint8_t*)cryptoDataOut));
+    word32 res_len = max_len;
 
     /* init private key */
     ret = wc_ecc_init_ex(key, NULL, ctx->crypto->devId);
@@ -745,10 +860,18 @@ static int _HandleEccSign(whServerContext* ctx, whPacket* packet,
         /* load the private key */
         ret = wh_Server_EccKeyCacheExport(ctx, key_id, key);
         if (ret == WH_ERROR_OK) {
+#ifdef DEBUG_CRYPTOCB_VERBOSE
+            printf(
+                "[server] EccSign: key_id=%x, in_len=%u, res_len=%u, ret=%d\n",
+                key_id, (unsigned)in_len, (unsigned)res_len, ret);
+            wh_Utils_Hexdump("[server] EccSign in:", in, in_len);
+#endif
             /* sign the input */
-            res_len = max_len;
             ret = wc_ecc_sign_hash(in, in_len, res_out, &res_len,
-                    ctx->crypto->rng, key);
+                                   ctx->crypto->rng, key);
+#ifdef DEBUG_CRYPTOCB_VERBOSE
+            wh_Utils_Hexdump("[server] EccSign res:", res_out, res_len);
+#endif
         }
         wc_ecc_free(key);
     }
@@ -756,37 +879,53 @@ static int _HandleEccSign(whServerContext* ctx, whPacket* packet,
         (void)hsmEvictKey(ctx, key_id);
     }
     if (ret == 0) {
-        res->sz = res_len;
-        *out_size = WH_PACKET_STUB_SIZE + sizeof(*res) + res_len;
+        whMessageCrypto_EccSignResponse res;
+        res.sz = res_len;
+
+        wh_MessageCrypto_TranslateEccSignResponse(
+            magic, &res, (whMessageCrypto_EccSignResponse*)cryptoDataOut);
+
+        *outSize = sizeof(whMessageCrypto_EccSignResponse) + res_len;
     }
     return ret;
 }
-static int _HandleEccVerify(whServerContext* ctx, whPacket* packet,
-        uint16_t *out_size)
-{
-    int ret;
-    ecc_key key[1];
-    wh_Packet_pk_ecc_verify_req* req = &packet->pkEccVerifyReq;
-    wh_Packet_pk_ecc_verify_res* res = &packet->pkEccVerifyRes;
 
-    /* Request Message */
-    uint32_t options    = req->options;
-    whKeyId key_id      = WH_MAKE_KEYID(    WH_KEYTYPE_CRYPTO,
-                                            ctx->comm->client_id,
-                                            req->keyId);
-    uint32_t hash_len   = req->hashSz;
-    uint32_t sig_len    = req->sigSz;
-    byte* req_sig       = (uint8_t*)(req + 1);
-    byte* req_hash      = req_sig + sig_len;
-    int evict           = !!(options & WH_PACKET_PK_ECCVERIFY_OPTIONS_EVICT);
-    int export_pub_key  = !!(options & WH_PACKET_PK_ECCVERIFY_OPTIONS_EXPORTPUB);
+static int _HandleEccVerify(whServerContext* ctx, uint16_t magic,
+                            const void* cryptoDataIn, uint16_t inSize,
+                            void* cryptoDataOut, uint16_t* outSize)
+{
+    int                               ret;
+    ecc_key                           key[1];
+    whMessageCrypto_EccVerifyRequest  req;
+    whMessageCrypto_EccVerifyResponse res;
+
+    /* Translate request */
+    ret = wh_MessageCrypto_TranslateEccVerifyRequest(
+        magic, (const whMessageCrypto_EccVerifyRequest*)cryptoDataIn, &req);
+    if (ret != 0) {
+        return ret;
+    }
+
+    /* Extract parameters from translated request */
+    uint32_t options = req.options;
+    whKeyId  key_id =
+        WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id, req.keyId);
+    uint32_t hash_len = req.hashSz;
+    uint32_t sig_len  = req.sigSz;
+    uint8_t* req_sig =
+        (uint8_t*)(cryptoDataIn) + sizeof(whMessageCrypto_EccVerifyRequest);
+    uint8_t* req_hash = req_sig + sig_len;
+    int      evict    = !!(options & WH_MESSAGE_CRYPTO_ECCVERIFY_OPTIONS_EVICT);
+    int      export_pub_key =
+        !!(options & WH_MESSAGE_CRYPTO_ECCVERIFY_OPTIONS_EXPORTPUB);
 
     /* Response message */
-    byte* res_pub       = (uint8_t*)(res + 1);
-    word32 max_size     = (word32)(WOLFHSM_CFG_COMM_DATA_LEN -
-                                (res_pub - (uint8_t*)packet));
-    uint32_t pub_size   = 0;
-    int result;
+    byte* res_pub =
+        (uint8_t*)(cryptoDataOut + sizeof(whMessageCrypto_EccVerifyResponse));
+    word32   max_size = (word32)(WOLFHSM_CFG_COMM_DATA_LEN -
+                               (res_pub - (uint8_t*)cryptoDataOut));
+    uint32_t pub_size = 0;
+    int      result;
 
     /* init public key */
     ret = wc_ecc_init_ex(key, NULL, ctx->crypto->devId);
@@ -796,18 +935,26 @@ static int _HandleEccVerify(whServerContext* ctx, whPacket* packet,
         if (ret == WH_ERROR_OK) {
             /* verify the signature */
             ret = wc_ecc_verify_hash(req_sig, sig_len, req_hash, hash_len,
-                &result, key);
-            if (    (ret == 0) &&
-                    (export_pub_key != 0) ) {
+                                     &result, key);
+#ifdef DEBUG_CRYPTOCB_VERBOSE
+            printf("[server] EccVerify: key_id=%x, sig_len=%u, hash_len=%u, "
+                   "result=%d, ret=%d\n",
+                   key_id, (unsigned)sig_len, (unsigned)hash_len, result, ret);
+
+            wh_Utils_Hexdump("[server] EccVerify hash:", req_hash, hash_len);
+            wh_Utils_Hexdump("[server] EccVerify sig:", req_sig, sig_len);
+#endif
+
+            if ((ret == 0) && (export_pub_key != 0)) {
                 /* Export the public key to the result message*/
-                ret = wc_EccPublicKeyToDer(key, (byte*)res_pub,
-                        max_size, 1);
+                ret = wc_EccPublicKeyToDer(key, (byte*)res_pub, max_size, 1);
                 if (ret < 0) {
                     /* Problem dumping the public key.  Set to 0 length */
                     pub_size = 0;
-                } else {
+                }
+                else {
                     pub_size = ret;
-                    ret = 0;
+                    ret      = 0;
                 }
             }
         }
@@ -818,9 +965,13 @@ static int _HandleEccVerify(whServerContext* ctx, whPacket* packet,
         (void)hsmEvictKey(ctx, key_id);
     }
     if (ret == 0) {
-        res->pubSz  = pub_size;
-        res->res    = result;
-        *out_size   = WH_PACKET_STUB_SIZE + sizeof(*res) + pub_size;
+        res.pubSz = pub_size;
+        res.res   = result;
+
+        wh_MessageCrypto_TranslateEccVerifyResponse(
+            magic, &res, (whMessageCrypto_EccVerifyResponse*)cryptoDataOut);
+
+        *outSize = sizeof(whMessageCrypto_EccVerifyResponse) + pub_size;
     }
     return ret;
 }
@@ -863,58 +1014,106 @@ static int _HandleEccCheckPrivKey(whServerContext* server, whPacket* packet,
 #endif
 #endif /* HAVE_ECC */
 
-#ifdef HAVE_CURVE25519
-static int _HandleCurve25519KeyGen(whServerContext* server, whPacket* packet,
-    uint16_t* out_size)
-{
-    int ret = WH_ERROR_OK;
-    curve25519_key key[1];
-    wh_Packet_pk_curve25519kg_req* req = &packet->pkCurve25519kgReq;
-    wh_Packet_pk_curve25519kg_res* res = &packet->pkCurve25519kgRes;
 
-    /* Request Message */
-    int key_size        = req->sz;
-    whKeyId key_id      = WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
-                            server->comm->client_id,
-                            req->keyId);
-    whNvmFlags flags    = req->flags;
-    uint8_t* label      = req->label;
-    uint16_t label_size = WH_NVM_LABEL_LEN;
+#ifndef WC_NO_RNG
+static int _HandleRng(whServerContext* ctx, uint16_t magic,
+                      const void* cryptoDataIn, uint16_t inSize,
+                      void* cryptoDataOut, uint16_t* outSize)
+{
+    int                         ret = WH_ERROR_OK;
+    whMessageCrypto_RngRequest  req;
+    whMessageCrypto_RngResponse res;
+
+    /* Translate request */
+    ret = wh_MessageCrypto_TranslateRngRequest(
+        magic, (const whMessageCrypto_RngRequest*)cryptoDataIn, &req);
+    if (ret != 0) {
+        return ret;
+    }
+
+    /* Generate the random data */
+    ret = wc_RNG_GenerateBlock(ctx->crypto->rng, (byte*)cryptoDataOut, req.sz);
+    if (ret != 0) {
+        return ret;
+    }
+
+    /* Translate response */
+    res.sz = req.sz;
+    ret    = wh_MessageCrypto_TranslateRngResponse(
+        magic, &res, (whMessageCrypto_RngResponse*)cryptoDataOut);
+    if (ret != 0) {
+        return ret;
+    }
+
+    /* set the output size */
+    *outSize = sizeof(whMessageCrypto_RngResponse) + req.sz;
+
+    return ret;
+}
+#endif /* WC_NO_RNG */
+
+#ifdef HAVE_CURVE25519
+static int _HandleCurve25519KeyGen(whServerContext* ctx, uint16_t magic,
+                                   const void* cryptoDataIn, uint16_t inSize,
+                                   void* cryptoDataOut, uint16_t* outSize)
+{
+    int                                      ret = WH_ERROR_OK;
+    curve25519_key                           key[1];
+    whMessageCrypto_Curve25519KeyGenRequest  req;
+    whMessageCrypto_Curve25519KeyGenResponse res;
+
+    /* Translate request */
+    ret = wh_MessageCrypto_TranslateCurve25519KeyGenRequest(
+        magic, (const whMessageCrypto_Curve25519KeyGenRequest*)cryptoDataIn,
+        &req);
+    if (ret != 0) {
+        return ret;
+    }
+
+    /* Extract parameters from translated request */
+    int     key_size = req.sz;
+    whKeyId key_id =
+        WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id, req.keyId);
+    whNvmFlags flags      = req.flags;
+    uint8_t*   label      = req.label;
+    uint16_t   label_size = WH_NVM_LABEL_LEN;
 
     /* Response Message */
-    uint8_t* out        = (uint8_t*)(res + 1);
+    uint8_t* out = (uint8_t*)cryptoDataOut +
+                   sizeof(whMessageCrypto_Curve25519KeyGenResponse);
     /* Initialize the key size to the max size of the buffer */
-    uint16_t ser_size   = (word32)(WOLFHSM_CFG_COMM_DATA_LEN -
-                            (out - (uint8_t*)packet));
+    uint16_t ser_size =
+        (word32)(WOLFHSM_CFG_COMM_DATA_LEN - (out - (uint8_t*)cryptoDataOut));
 
     /* init key */
-    ret = wc_curve25519_init_ex(key, NULL, server->crypto->devId);
+    ret = wc_curve25519_init_ex(key, NULL, ctx->crypto->devId);
     if (ret == 0) {
         /* make the key */
-        ret = wc_curve25519_make_key(server->crypto->rng, key_size, key);
-        if ( ret == 0) {
+        ret = wc_curve25519_make_key(ctx->crypto->rng, key_size, key);
+        if (ret == 0) {
             /* Check incoming flags */
             if (flags & WH_NVM_FLAGS_EPHEMERAL) {
                 /* Must serialize the key into the response packet */
                 key_id = WH_KEYID_ERASED;
-                ret = wh_Crypto_Curve25519SerializeKey(key, out, &ser_size);
-            } else {
+                ret    = wh_Crypto_Curve25519SerializeKey(key, out, &ser_size);
+            }
+            else {
                 ser_size = 0;
                 /* Must import the key into the cache and return keyid */
                 if (WH_KEYID_ISERASED(key_id)) {
                     /* Generate a new id */
-                    ret = hsmGetUniqueId(server, &key_id);
+                    ret = hsmGetUniqueId(ctx, &key_id);
 #ifdef DEBUG_CRYPTOCB
-                    printf("[server] %s UniqueId: keyId:%u, ret:%d\n",
-                            __func__, key_id, ret);
+                    printf("[server] %s UniqueId: keyId:%u, ret:%d\n", __func__,
+                           key_id, ret);
 #endif
                 }
 
-                ret = wh_Server_CacheImportCurve25519Key(server, key,
-                        key_id, flags, label_size, label);
+                ret = wh_Server_CacheImportCurve25519Key(
+                    ctx, key, key_id, flags, label_size, label);
 #ifdef DEBUG_CRYPTOCB
-                    printf("[server] %s CacheImport: keyId:%u, ret:%d\n",
-                            __func__, key_id, ret);
+                printf("[server] %s CacheImport: keyId:%u, ret:%d\n", __func__,
+                       key_id, ret);
 #endif
             }
         }
@@ -922,38 +1121,55 @@ static int _HandleCurve25519KeyGen(whServerContext* server, whPacket* packet,
     }
 
     if (ret == 0) {
-        res->keyId  = WH_KEYID_ID(key_id);
-        res->len    = ser_size;
-        *out_size   = WH_PACKET_STUB_SIZE + sizeof(*res) + ser_size;
+        res.keyId = WH_KEYID_ID(key_id);
+        res.len   = ser_size;
+
+        /* Translate response */
+        wh_MessageCrypto_TranslateCurve25519KeyGenResponse(
+            magic, &res,
+            (whMessageCrypto_Curve25519KeyGenResponse*)cryptoDataOut);
+
+        *outSize = sizeof(whMessageCrypto_Curve25519KeyGenResponse) + ser_size;
     }
     return ret;
 }
 
-static int _HandleCurve25519SharedSecret(whServerContext* ctx, whPacket* packet, uint16_t* out_size)
+static int _HandleCurve25519SharedSecret(whServerContext* ctx, uint16_t magic,
+                                         const void* cryptoDataIn,
+                                         uint16_t inSize, void* cryptoDataOut,
+                                         uint16_t* outSize)
 {
     int ret;
     curve25519_key priv[1] = {0};
     curve25519_key pub[1] = {0};
 
-    wh_Packet_pk_curve25519_req* req = &packet->pkCurve25519Req;
-    wh_Packet_pk_curve25519_res* res = &packet->pkCurve25519Res;
+    whMessageCrypto_Curve25519Request  req;
+    whMessageCrypto_Curve25519Response res;
 
-    /* Request message */
-    uint32_t options    = req->options;
-    int evict_pub       = !!(options & WH_PACKET_PK_CURVE25519_OPTIONS_EVICTPUB);
-    int evict_prv       = !!(options & WH_PACKET_PK_CURVE25519_OPTIONS_EVICTPRV);
+    /* Translate request */
+    ret = wh_MessageCrypto_TranslateCurve25519Request(
+        magic, (const whMessageCrypto_Curve25519Request*)cryptoDataIn, &req);
+    if (ret != 0) {
+        return ret;
+    }
+
+    /* Extract parameters from translated request */
+    uint32_t options    = req.options;
+    int evict_pub = !!(options & WH_MESSAGE_CRYPTO_CURVE25519_OPTIONS_EVICTPUB);
+    int evict_prv = !!(options & WH_MESSAGE_CRYPTO_CURVE25519_OPTIONS_EVICTPRV);
     whKeyId pub_key_id  = WH_MAKE_KEYID(    WH_KEYTYPE_CRYPTO,
                                             ctx->comm->client_id,
-                                            req->publicKeyId);
+                                            req.publicKeyId);
     whKeyId prv_key_id  = WH_MAKE_KEYID(    WH_KEYTYPE_CRYPTO,
                                             ctx->comm->client_id,
-                                            req->privateKeyId);
-    int endian          = req->endian;
+                                            req.privateKeyId);
+    int endian          = req.endian;
 
     /* Response message */
-    byte* res_out       = (uint8_t*)(res + 1);
-    word32 max_len      = (word32)(WOLFHSM_CFG_COMM_DATA_LEN -
-                            (res_out - (uint8_t*)packet));
+    uint8_t* res_out       = (uint8_t*)cryptoDataOut +
+                             sizeof(whMessageCrypto_Curve25519Response);
+    uint16_t max_len      = (uint16_t)(WOLFHSM_CFG_COMM_DATA_LEN -
+                            (res_out - (uint8_t*)cryptoDataOut));
     word32 res_len      = max_len;
 
     /* init private key */
@@ -983,8 +1199,13 @@ static int _HandleCurve25519SharedSecret(whServerContext* ctx, whPacket* packet,
         (void)hsmEvictKey(ctx, prv_key_id);
     }
     if (ret == 0) {
-        res->sz = res_len;
-        *out_size = WH_PACKET_STUB_SIZE + sizeof(*res) + res_len;
+        res.sz = res_len;
+
+        wh_MessageCrypto_TranslateCurve25519Response(
+            magic, &res,
+            (whMessageCrypto_Curve25519Response*)cryptoDataOut);
+
+        *outSize = sizeof(whMessageCrypto_Curve25519Response) + res_len;
     }
     return ret;
 }
@@ -992,38 +1213,177 @@ static int _HandleCurve25519SharedSecret(whServerContext* ctx, whPacket* packet,
 
 #ifndef NO_AES
 #ifdef HAVE_AES_CBC
-static int _HandleAesCbc(whServerContext* ctx, whPacket* packet,
-        uint16_t* size)
+static int _HandleAesCbc(whServerContext* ctx, uint16_t magic, const void* cryptoDataIn,
+                         uint16_t inSize, void* cryptoDataOut,
+                         uint16_t* outSize)
 {
-    int ret = 0;
-    Aes aes[1] = {0};
-    uint8_t read_key[AES_MAX_KEY_SIZE];
-    uint32_t read_key_len = sizeof(read_key);
+    int                            ret    = 0;
+    Aes                            aes[1] = {0};
+    whMessageCrypto_AesCbcRequest  req;
+    whMessageCrypto_AesCbcResponse res;
+    uint8_t                        read_key[AES_MAX_KEY_SIZE];
+    uint32_t                       read_key_len = sizeof(read_key);
 
-    wh_Packet_cipher_aescbc_req* req = &packet->cipherAesCbcReq;
-    wh_Packet_cipher_aescbc_res* res = &packet->cipherAesCbcRes;
+    /* Translate request */
+    ret = wh_MessageCrypto_TranslateAesCbcRequest(
+        magic, (const whMessageCrypto_AesCbcRequest*)cryptoDataIn, &req);
+    if (ret != 0) {
+        return ret;
+    }
 
-    uint32_t enc = req->enc;
-    uint32_t key_len = req->keyLen;
-    uint32_t len = req->sz;
-    whKeyId key_id = WH_MAKE_KEYID(
-                        WH_KEYTYPE_CRYPTO,
-                        ctx->comm->client_id,
-                        req->keyId);
+    uint32_t enc     = req.enc;
+    uint32_t key_len = req.keyLen;
+    uint32_t len     = req.sz;
+    whKeyId  key_id =
+        WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id, req.keyId);
 
     /* in, key, iv, and out are after fixed size fields */
-    uint8_t* in = (uint8_t*)(req + 1);
+    uint8_t* in =
+        (uint8_t*)(cryptoDataIn + sizeof(whMessageCrypto_AesCbcRequest));
     uint8_t* key = in + len;
-    uint8_t* iv = key + key_len;
+    uint8_t* iv  = key + key_len;
 
-    uint8_t* out = (uint8_t*)(res + 1);
+    uint8_t* out =
+        (uint8_t*)(cryptoDataOut + sizeof(whMessageCrypto_AesCbcResponse));
 
+    /* Debug printouts */
+#ifdef DEBUG_CRYPTOCB_VERBOSE
+    wh_Utils_Hexdump("[AesCbc] Input data", in, len);
+    wh_Utils_Hexdump("[AesCbc] IV", iv, AES_BLOCK_SIZE);
+#endif
     /* Read the key if it is not erased */
     if (!WH_KEYID_ISERASED(key_id)) {
         ret = hsmReadKey(ctx, key_id, NULL, read_key, &read_key_len);
         if (ret == 0) {
             /* override the incoming values */
-            key = read_key;
+            key     = read_key;
+            key_len = read_key_len;
+#ifdef DEBUG_CRYPTOCB_VERBOSE
+            wh_Utils_Hexdump("[AesCbc] Key from HSM", key, key_len);
+#endif
+        }
+    }
+    else {
+#ifdef DEBUG_CRYPTOCB_VERBOSE
+        wh_Utils_Hexdump("[AesCbc] Key ", key, key_len);
+#endif
+    }
+    if (ret == 0) {
+        /* init key with possible hardware */
+        ret = wc_AesInit(aes, NULL, ctx->crypto->devId);
+    }
+    if (ret == 0) {
+        /* load the key */
+        ret = wc_AesSetKey(aes, (byte*)key, (word32)key_len, (byte*)iv,
+                           enc != 0 ? AES_ENCRYPTION : AES_DECRYPTION);
+        if (ret == 0) {
+            /* do the crypto operation */
+            if (enc != 0) {
+                ret = wc_AesCbcEncrypt(aes, (byte*)out, (byte*)in, (word32)len);
+                if (ret == 0) {
+#ifdef DEBUG_CRYPTOCB_VERBOSE
+                    wh_Utils_Hexdump("[AesCbc] Encrypted output", out, len);
+#endif
+                }
+            }
+            else {
+                ret = wc_AesCbcDecrypt(aes, (byte*)out, (byte*)in, (word32)len);
+                if (ret == 0) {
+#ifdef DEBUG_CRYPTOCB_VERBOSE
+                    wh_Utils_Hexdump("[AesCbc] Decrypted output", out, len);
+#endif
+                }
+            }
+        }
+        wc_AesFree(aes);
+    }
+    /* encode the return sz */
+    if (ret == 0) {
+        /* set sz */
+        res.sz   = len;
+        *outSize = sizeof(whMessageCrypto_AesCbcResponse) + len;
+
+        /* Translate response back */
+        ret = wh_MessageCrypto_TranslateAesCbcResponse(
+            magic, &res, (whMessageCrypto_AesCbcResponse*)cryptoDataOut);
+    }
+    return ret;
+}
+#endif /* HAVE_AES_CBC */
+
+#ifdef HAVE_AESGCM
+static int _HandleAesGcm(whServerContext* ctx, uint16_t magic,
+                         const void* cryptoDataIn, uint16_t inSize,
+                         void* cryptoDataOut, uint16_t* outSize)
+{
+    int      ret    = 0;
+    Aes      aes[1] = {0};
+    uint8_t  read_key[AES_MAX_KEY_SIZE];
+    uint32_t read_key_len = sizeof(read_key);
+
+    /* Translate request */
+    whMessageCrypto_AesGcmRequest req;
+    ret = wh_MessageCrypto_TranslateAesGcmRequest(
+        magic, (const whMessageCrypto_AesGcmRequest*)cryptoDataIn, &req);
+    if (ret != 0) {
+        return ret;
+    }
+
+    /* Translate response */
+    whMessageCrypto_AesGcmResponse res;
+    res.sz        = req.sz;
+    res.authTagSz = (req.enc == 0) ? 0 : req.authTagSz;
+
+    uint32_t enc        = req.enc;
+    uint32_t key_len    = req.keyLen;
+    uint32_t len        = req.sz;
+    uint32_t iv_len     = req.ivSz;
+    uint32_t authin_len = req.authInSz;
+    uint32_t tag_len    = req.authTagSz;
+    whKeyId  key_id =
+        WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id, req.keyId);
+
+    /* in, key, iv, authin, tag, and out are after fixed size fields */
+    uint8_t* in = (uint8_t*)(cryptoDataIn) + sizeof(whMessageCrypto_AesGcmRequest);
+    uint8_t* key = in + len;
+    uint8_t* iv = key + key_len;
+    uint8_t* authin = iv + iv_len;
+    uint8_t* tag = authin + authin_len;
+
+    /* TODO: This should not include the generic request header, though doesn't
+     * matter since it is just a debug printf*/
+    uint32_t req_len = sizeof(whMessageCrypto_AesGcmRequest) + len + key_len +
+                       iv_len + authin_len + ((enc == 0) ? tag_len : 0);
+    (void)req_len;
+
+    /* Set up response pointers */
+    uint8_t* out = (uint8_t*)(cryptoDataOut) + sizeof(whMessageCrypto_AesGcmResponse);
+    uint8_t* out_tag = out + len;
+
+    uint32_t res_len = sizeof(whMessageCrypto_AesGcmResponse) + len +
+                       ((enc == 0) ? 0 : tag_len);
+
+#ifdef DEBUG_CRYPTOCB_VERBOSE
+    printf("[server] AESGCM: enc:%d keylen:%d ivsz:%d insz:%d authinsz:%d "
+           "authtagsz:%d reqsz:%u ressz:%u\n",
+           enc, key_len, iv_len, len, authin_len, tag_len, req_len, res_len);
+    printf("[server] AESGCM: req:%p in:%p key:%p iv:%p authin:%p tag:%p res:%p "
+           "out:%p out_tag:%p\n",
+           &req, in, key, iv, authin, tag, &res, out, out_tag);
+    wh_Utils_Hexdump("[server] AESGCM req packet: \n", (uint8_t*)cryptoDataIn,
+                     req_len);
+#endif
+
+    /* Read the key if it is not erased */
+    if (!WH_KEYID_ISERASED(key_id)) {
+        ret = hsmReadKey(ctx, key_id, NULL, read_key, &read_key_len);
+#ifdef DEBUG_CRYPTOCB_VERBOSE
+        printf("[server] AesGcm ReadKey key_id:%u, key_len:%d ret:%d\n", key_id,
+               read_key_len, ret);
+#endif
+        if (ret == 0) {
+            /* override the incoming values */
+            key     = read_key;
             key_len = read_key_len;
         }
     }
@@ -1033,159 +1393,70 @@ static int _HandleAesCbc(whServerContext* ctx, whPacket* packet,
     }
     if (ret == 0) {
         /* load the key */
-        ret = wc_AesSetKey(aes, (byte*)key, (word32)key_len, (byte*)iv,
-            enc != 0 ? AES_ENCRYPTION : AES_DECRYPTION);
+        ret = wc_AesGcmSetKey(aes, (byte*)key, (word32)key_len);
+#ifdef DEBUG_CRYPTOCB_VERBOSE
+        printf("[server] AesGcmSetKey key_id:%u key_len:%u ret:%d\n", key_id,
+               key_len, ret);
+        wh_Utils_Hexdump("[server] key: ", key, key_len);
+#endif
         if (ret == 0) {
             /* do the crypto operation */
+#ifdef DEBUG_CRYPTOCB_VERBOSE
+            printf(
+                "[server] enc:%d len:%d, ivSz:%d authTagSz:%d, authInSz:%d\n",
+                enc, len, iv_len, tag_len, authin_len);
+            wh_Utils_Hexdump("[server] in: ", in, len);
+            wh_Utils_Hexdump("[server] iv: ", iv, iv_len);
+            wh_Utils_Hexdump("[server] authin: ", authin, authin_len);
+#endif
             if (enc != 0) {
-                ret = wc_AesCbcEncrypt(aes, (byte*)out, (byte*)in, (word32)len);
-            } else {
-                ret = wc_AesCbcDecrypt(aes, (byte*)out, (byte*)in, (word32)len);
+                /* For encryption, write tag to the response output tag area */
+                ret = wc_AesGcmEncrypt(aes, (byte*)out, (byte*)in, (word32)len,
+                                       (byte*)iv, (word32)iv_len, (byte*)out_tag,
+                                       (word32)tag_len, (byte*)authin,
+                                       (word32)authin_len);
+#ifdef DEBUG_CRYPTOCB_VERBOSE
+                printf("[server] enc ret:%d\n", ret);
+                wh_Utils_Hexdump("[server] out: \n", out, len);
+                wh_Utils_Hexdump("[server] enc tag: ", out_tag, tag_len);
+#endif
             }
+            else {
+                /* set authTag as a packet input */
+#ifdef DEBUG_CRYPTOCB_VERBOSE
+                wh_Utils_Hexdump("[server] dec tag: ", tag, tag_len);
+#endif
+                ret = wc_AesGcmDecrypt(aes, (byte*)out, (byte*)in, (word32)len,
+                                       (byte*)iv, (word32)iv_len, (byte*)tag,
+                                       (word32)tag_len, (byte*)authin,
+                                       (word32)authin_len);
+#ifdef DEBUG_CRYPTOCB_VERBOSE
+                printf("[server] dec ret:%d\n", ret);
+                wh_Utils_Hexdump("[server] out: \n", out, len);
+#endif
+            }
+#ifdef DEBUG_CRYPTOCB_VERBOSE
+            wh_Utils_Hexdump("[server] post iv: ", iv, iv_len);
+            wh_Utils_Hexdump("[server] post authin: ", authin, authin_len);
+#endif
         }
         wc_AesFree(aes);
     }
     /* encode the return sz */
     if (ret == 0) {
         /* set sz */
-        res->sz = len;
-        *size = WH_PACKET_STUB_SIZE + sizeof(*res) + len;
-    }
-    return ret;
-}
-#endif /* HAVE_AES_CBC */
-
-#ifdef HAVE_AESGCM
-static int _HandleAesGcm(whServerContext* ctx, whPacket* packet,
-        uint16_t* out_size)
-{
-    int ret = 0;
-    Aes aes[1] = {0};
-
-    wh_Packet_cipher_aesgcm_req* req = &packet->cipherAesGcmReq;
-    wh_Packet_cipher_aesgcm_res* res = &packet->cipherAesGcmRes;
-
-    uint32_t enc        = req->enc;
-    uint32_t key_len    = req->keyLen;
-    uint32_t len        = req->sz;
-    uint32_t iv_len     = req->ivSz;
-    uint32_t authin_len = req->authInSz;
-    uint32_t tag_len    = req->authTagSz;
-    whKeyId key_id      = WH_MAKE_KEYID(
-                            WH_KEYTYPE_CRYPTO,
-                            ctx->comm->client_id,
-                            req->keyId);
-
-    /* Request packet */
-    uint8_t* in         = (uint8_t*)(req + 1);
-    uint8_t* key        = in + len;
-    uint8_t* iv         = key + key_len;
-    uint8_t* authin     = iv + iv_len;
-    uint8_t* dec_tag    = authin + authin_len;
-
-    uint32_t req_len    = WH_PACKET_STUB_SIZE + sizeof(*req) + len +
-                            key_len + iv_len + authin_len +
-                            ((enc == 0) ? tag_len : 0);
-    (void)req_len;
-
-    /* Response packet */
-    uint8_t* out        = (uint8_t*)(res + 1);
-    uint8_t* enc_tag    = out + len;
-
-    uint32_t res_len    = WH_PACKET_STUB_SIZE+ sizeof(*res) + len +
-                            ((enc == 0) ? 0: tag_len);
-
-    uint8_t tmpKey[AES_MAX_KEY_SIZE + AES_IV_SIZE];
-
+        res.sz        = len;
+        res.authTagSz = (enc == 0) ? 0 : tag_len;
+        *outSize      = res_len;
 #ifdef DEBUG_CRYPTOCB_VERBOSE
-            printf("[server] AESGCM: enc:%d keylen:%d ivsz:%d insz:%d authinsz:%d authtagsz:%d reqsz:%u ressz:%u\n",
-                        enc, key_len, iv_len, len, authin_len, tag_len,
-                        req_len, res_len);
-            printf("[server] AESGCM: req:%p in:%p key:%p iv:%p authin:%p dec_tag:%p res:%p out:%p enc_tag:%p\n",
-                    req, in, key, iv, authin, dec_tag, res, out, enc_tag);
-            wh_Utils_Hexdump("[server] AESGCM req packet: \n", (uint8_t*)packet, req_len);
+        printf("[server] res out_size:%d\n", *outSize);
+        wh_Utils_Hexdump("[server] AESGCM res packet: \n",
+                         (uint8_t*)cryptoDataOut, res_len);
 #endif
-    /* use keyId and load from keystore if keyId is not erased */
-    if (!WH_KEYID_ISERASED(key_id)) {
-        key_len = sizeof(tmpKey);
-        ret = hsmReadKey(ctx, key_id, NULL, tmpKey, &key_len);
-#ifdef DEBUG_CRYPTOCB_VERBOSE
-        printf("[server] AesGcm ReadKey key_id:%u, key_len:%d ret:%d\n",
-                key_id, key_len, ret);
-#endif
-        if (ret == 0) {
-            /* set key to use tmpKey data */
-            key = tmpKey;
-        }
-    }
-    if (ret == 0) {
-        /* init key with possible hardware */
-        ret = wc_AesInit(aes, NULL, ctx->crypto->devId);
-    }
-    if (ret == 0) {
-        /* load the key */
-        ret = wc_AesGcmSetKey(aes, key, key_len);
-#ifdef DEBUG_CRYPTOCB_VERBOSE
-        printf("[server] AesGcmSetKey key_id:%u key_len:%u ret:%d\n",
-                key_id, key_len, ret);
-        wh_Utils_Hexdump("[server] key: ", key, key_len);
-#endif
-        if (ret == 0) {
-            /* do the crypto operation */
-#ifdef DEBUG_CRYPTOCB_VERBOSE
-            printf("[server] enc:%d len:%d, ivSz:%d authTagSz:%d, authInSz:%d\n",
-                    enc, len,iv_len, tag_len, authin_len);
-            wh_Utils_Hexdump("[server] in: ", in, len);
-            wh_Utils_Hexdump("[server] iv: ", iv, iv_len);
-            wh_Utils_Hexdump("[server] authin: ", authin,  authin_len);
-#endif
-            if (enc != 0) {
-                ret = wc_AesGcmEncrypt(aes, out,
-                    in, len,
-                    iv, iv_len,
-                    enc_tag, tag_len,
-                    authin, authin_len);
-#ifdef DEBUG_CRYPTOCB_VERBOSE
-                printf("[server] enc ret:%d\n",ret);
-                wh_Utils_Hexdump("[server] out: \n", out, len);
-                wh_Utils_Hexdump("[server] enc tag: ", enc_tag,  tag_len);
-#endif
-            } else {
-                /* set authTag as a packet input */
-#ifdef DEBUG_CRYPTOCB_VERBOSE
-                wh_Utils_Hexdump("[server] dec tag: ", dec_tag,  tag_len);
-#endif
-                ret = wc_AesGcmDecrypt(aes, out,
-                    in, len,
-                    iv, iv_len,
-                    dec_tag, tag_len,
-                    authin, authin_len);
-#ifdef DEBUG_CRYPTOCB_VERBOSE
-                printf("[server] dec ret:%d\n",ret);
-                wh_Utils_Hexdump("[server] out: \n", out, len);
 
-                #endif
-            }
-#ifdef DEBUG_CRYPTOCB_VERBOSE
-            wh_Utils_Hexdump("[server] post iv: ", iv, iv_len);
-            wh_Utils_Hexdump("[server] post authin: ", authin,  authin_len);
-#endif
-        }
-        wc_AesFree(aes);
-    }
-    /* encode the return sz */
-    if (ret == 0) {
-        res->sz = len;
-        res->authTagSz = (enc == 0) ? 0 : tag_len;
-        *out_size = res_len;
-#ifdef DEBUG_CRYPTOCB_VERBOSE
-        printf("[server] res out_size:%d\n", *out_size);
-        wh_Utils_Hexdump("[server] AESGCM res packet: \n", (uint8_t*)packet, res_len);
-
-#endif
-        /*
-        memcpy(packet, res_packet, res_len);
-        */
+        /* Translate response back */
+        ret = wh_MessageCrypto_TranslateAesGcmResponse(
+            magic, &res, (whMessageCrypto_AesGcmResponse*)cryptoDataOut);
     }
     return ret;
 }
@@ -1193,56 +1464,64 @@ static int _HandleAesGcm(whServerContext* ctx, whPacket* packet,
 #endif /* !NO_AES */
 
 #ifdef WOLFSSL_CMAC
-static int _HandleCmac(whServerContext* server, whPacket* packet,
-    uint16_t* size, uint16_t seq)
+static int _HandleCmac(whServerContext* ctx, uint16_t magic, uint16_t seq,
+                       const void* cryptoDataIn, uint16_t inSize,
+                       void* cryptoDataOut, uint16_t* outSize)
 {
     int ret;
+    whMessageCrypto_CmacRequest req;
+    whMessageCrypto_CmacResponse res;
 
-    switch(packet->cmacReq.type) {
+    /* Translate request */
+    ret = wh_MessageCrypto_TranslateCmacRequest(magic, cryptoDataIn, &req);
+    if (ret != 0) {
+        return ret;
+    }
+
+    int i;
+    word32 len;
+    uint16_t cancelSeq;
+    whKeyId keyId = WH_KEYID_ERASED;
+
+    /* Setup fixed size fields */
+    uint8_t* in =
+        (uint8_t*)(cryptoDataIn) + sizeof(whMessageCrypto_CmacRequest);
+    uint8_t* key = in + req.inSz;
+    uint8_t* out =
+        (uint8_t*)(cryptoDataOut) + sizeof(whMessageCrypto_CmacResponse);
+
+    switch(req.type) {
 #if !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT)
     case WC_CMAC_AES:
     {
-        int i;
-        whKeyId keyId = WH_KEYID_ERASED;
-        word32 len;
-        uint16_t cancelSeq;
-        /* in, out and key are after the fixed size fields */
-        byte* in = (uint8_t*)(&packet->cmacReq + 1);
-        byte* key = in + packet->cmacReq.inSz;
-        byte* out = (uint8_t*)(&packet->cmacRes + 1);
         whNvmMetadata meta[1] = {{0}};
         uint8_t moveToBigCache = 0;
         word32 blockSz = AES_BLOCK_SIZE;
         uint8_t tmpKey[AES_MAX_KEY_SIZE + AES_IV_SIZE];
 
         /* attempt oneshot if all fields are present */
-        if (packet->cmacReq.inSz != 0 && packet->cmacReq.keySz != 0 &&
-            packet->cmacReq.outSz != 0) {
-            len = packet->cmacReq.outSz;
+        if (req.inSz != 0 && req.keySz != 0 && req.outSz != 0) {
+            len = req.outSz;
 #ifdef DEBUG_CRYPTOCB_VERBOSE
             printf("[server] cmac generate oneshot\n");
 #endif
-                ret = wc_AesCmacGenerate_ex(server->crypto->algoCtx.cmac, out, &len, in,
-                    packet->cmacReq.inSz, key, packet->cmacReq.keySz, NULL,
-                    server->crypto->devId);
-                packet->cmacRes.outSz = len;
+            ret = wc_AesCmacGenerate_ex(ctx->crypto->algoCtx.cmac, out, &len, in,
+                                        req.inSz, key, req.keySz, NULL,
+                                        ctx->crypto->devId);
+            res.outSz = len;
         } else {
 #ifdef DEBUG_CRYPTOCB_VERBOSE
             printf("[server] cmac begin keySz:%d inSz:%d outSz:%d keyId:%x\n",
-                    packet->cmacReq.keySz,
-                    packet->cmacReq.inSz,
-                    packet->cmacReq.outSz,
-                    packet->cmacReq.keyId);
+                    req.keySz, req.inSz, req.outSz, req.keyId);
 #endif
             /* do each operation based on which fields are set */
-            if (packet->cmacReq.keySz != 0) {
+            if (req.keySz != 0) {
                 /* initialize cmac with key and type */
-                ret = wc_InitCmac_ex(server->crypto->algoCtx.cmac, key,
-                    packet->cmacReq.keySz, packet->cmacReq.type, NULL, NULL,
-                    server->crypto->devId);
+                ret = wc_InitCmac_ex(ctx->crypto->algoCtx.cmac, key, req.keySz,
+                                     req.type, NULL, NULL, ctx->crypto->devId);
 #ifdef DEBUG_CRYPTOCB_VERBOSE
                 printf("[server] cmac init with key:%p keylen:%d, type:%d ret:%d\n",
-                        key, packet->cmacReq.keySz, packet->cmacReq.type, ret);
+                        key, req.keySz, req.type, ret);
 #endif
             } else {
                 /* Key is not present, meaning client wants to use AES key from
@@ -1251,13 +1530,12 @@ static int _HandleCmac(whServerContext* server, whPacket* packet,
                  * (which also holds the key). To do this we hijack the requested key's
                  * cache slot until CmacFinal() is called, at which point we evict the
                  * struct from the cache. TODO: client should hold CMAC state */
-                len = sizeof(server->crypto->algoCtx.cmac);
-                keyId = WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, server->comm->client_id, packet->cmacReq.keyId);
-                ret = hsmReadKey(server,
-                    keyId,
-                    NULL,
-                    (uint8_t*)server->crypto->algoCtx.cmac,
-                    (uint32_t*)&len);
+                len   = sizeof(ctx->crypto->algoCtx.cmac);
+                keyId = WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id,
+                                      req.keyId);
+                ret   = hsmReadKey(ctx, keyId, NULL,
+                                   (uint8_t*)ctx->crypto->algoCtx.cmac,
+                                   (uint32_t*)&len);
                 if (ret == WH_ERROR_OK) {
                     /* if the key size is a multiple of aes, init the key and
                      * overwrite the existing key on exit */
@@ -1267,39 +1545,39 @@ static int _HandleCmac(whServerContext* server, whPacket* packet,
                         printf("[server] cmac readkey got key len:%u\n", len);
 #endif
                         moveToBigCache = 1;
-                        XMEMCPY(tmpKey, (uint8_t*)server->crypto->algoCtx.cmac, len);
-                        ret = wc_InitCmac_ex(server->crypto->algoCtx.cmac, tmpKey, len,
-                            WC_CMAC_AES, NULL, NULL, server->crypto->devId);
+                        XMEMCPY(tmpKey, (uint8_t*)ctx->crypto->algoCtx.cmac, len);
+                        ret = wc_InitCmac_ex(ctx->crypto->algoCtx.cmac, tmpKey, len,
+                            WC_CMAC_AES, NULL, NULL, ctx->crypto->devId);
                     }
-                    else if (len != sizeof(server->crypto->algoCtx.cmac)) {
+                    else if (len != sizeof(ctx->crypto->algoCtx.cmac)) {
 #ifdef DEBUG_CRYPTOCB_VERBOSE
                         printf("[server] cmac bad readkey len:%u. sizeof(cmac):%lu\n",
-                                len, sizeof(server->crypto->algoCtx.cmac));
+                                len, sizeof(ctx->crypto->algoCtx.cmac));
 #endif
                         ret = BAD_FUNC_ARG;
                     }
-                } else {
+                }
+                else {
                     /* Initialize the cmac with a NULL key */
                     /* initialize cmac with key and type */
-                    ret = wc_InitCmac_ex(server->crypto->algoCtx.cmac, NULL,
-                        packet->cmacReq.keySz, packet->cmacReq.type, NULL, NULL,
-                        server->crypto->devId);
+                    ret = wc_InitCmac_ex(ctx->crypto->algoCtx.cmac, NULL,
+                        req.keySz, req.type, NULL, NULL, ctx->crypto->devId);
 #ifdef DEBUG_CRYPTOCB_VERBOSE
                     printf("[server] cmac init with NULL type:%d ret:%d\n",
-                            packet->cmacReq.type, ret);
+                            req.type, ret);
 #endif
                 }
             }
             /* Handle CMAC update, checking for cancellation */
-            if (ret == 0 && packet->cmacReq.inSz != 0) {
-                for (i = 0; ret == 0 && i < packet->cmacReq.inSz; i += AES_BLOCK_SIZE) {
-                    if (i + AES_BLOCK_SIZE > packet->cmacReq.inSz) {
-                        blockSz = packet->cmacReq.inSz - i;
+            if (ret == 0 && req.inSz != 0) {
+                for (i = 0; ret == 0 && i < req.inSz; i += AES_BLOCK_SIZE) {
+                    if (i + AES_BLOCK_SIZE > req.inSz) {
+                        blockSz = req.inSz - i;
                     }
-                    ret = wc_CmacUpdate(server->crypto->algoCtx.cmac, in + i,
+                    ret = wc_CmacUpdate(ctx->crypto->algoCtx.cmac, in + i,
                         blockSz);
                     if (ret == 0) {
-                        ret = wh_Server_GetCanceledSequence(server, &cancelSeq);
+                        ret = wh_Server_GetCanceledSequence(ctx, &cancelSeq);
                         if (ret == 0 && cancelSeq == seq) {
                             ret = WH_ERROR_CANCEL;
                         }
@@ -1311,24 +1589,24 @@ static int _HandleCmac(whServerContext* server, whPacket* packet,
             }
             /* do final and evict the struct if outSz is set, otherwise cache the
              * struct for a future call */
-            if ((ret == 0 && packet->cmacReq.outSz != 0) || ret == WH_ERROR_CANCEL) {
+            if ((ret == 0 && req.outSz != 0) || ret == WH_ERROR_CANCEL) {
                 if (ret != WH_ERROR_CANCEL) {
-                    keyId = packet->cmacReq.keyId;
-                    len = packet->cmacReq.outSz;
+                    keyId = req.keyId;
+                    len = req.outSz;
 #ifdef DEBUG_CRYPTOCB_VERBOSE
                     printf("[server] cmac final keyId:%x len:%d\n",keyId, len);
 #endif
-                    ret = wc_CmacFinal(server->crypto->algoCtx.cmac, out, &len);
-                    packet->cmacRes.outSz = len;
-                    packet->cmacRes.keyId = WH_KEYID_ERASED;
+                    ret = wc_CmacFinal(ctx->crypto->algoCtx.cmac, out, &len);
+                    res.outSz = len;
+                    res.keyId = WH_KEYID_ERASED;
                 }
                 /* evict the key, canceling means abandoning the current state */
                 if (ret == 0 || ret == WH_ERROR_CANCEL) {
                     if (!WH_KEYID_ISERASED(keyId)) {
                         /* Don't override return value except on failure */
                         int tmpRet = hsmEvictKey(
-                            server, WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
-                                                       server->comm->client_id, keyId));
+                            ctx, WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
+                                               ctx->comm->client_id, keyId));
                         if (tmpRet != 0) {
                             ret = tmpRet;
                         }
@@ -1338,29 +1616,29 @@ static int _HandleCmac(whServerContext* server, whPacket* packet,
             /* Cache the CMAC struct for a future update call */
             else if (ret == 0) {
                 /* cache/re-cache updated struct */
-                if (packet->cmacReq.keySz != 0) {
+                if (req.keySz != 0) {
                     keyId = WH_MAKE_KEYID(  WH_KEYTYPE_CRYPTO,
-                                            server->comm->client_id,
+                                            ctx->comm->client_id,
                                             WH_KEYID_ERASED);
-                    ret = hsmGetUniqueId(server, &keyId);
+                    ret = hsmGetUniqueId(ctx, &keyId);
                 }
                 else {
                     keyId = WH_MAKE_KEYID(  WH_KEYTYPE_CRYPTO,
-                                            server->comm->client_id,
-                                            packet->cmacReq.keyId);
+                                            ctx->comm->client_id,
+                                            req.keyId);
                 }
                 /* evict the aes sized key in the normal cache */
                 if (moveToBigCache == 1) {
-                    ret = hsmEvictKey(server, keyId);
+                    ret = hsmEvictKey(ctx, keyId);
                 }
                 meta->id = keyId;
-                meta->len = sizeof(server->crypto->algoCtx.cmac);
-                ret = hsmCacheKey(server, meta, (uint8_t*)server->crypto->algoCtx.cmac);
-                packet->cmacRes.keyId = WH_KEYID_ID(keyId);
-                packet->cmacRes.outSz = 0;
+                meta->len = sizeof(ctx->crypto->algoCtx.cmac);
+                ret = hsmCacheKey(ctx, meta, (uint8_t*)ctx->crypto->algoCtx.cmac);
+                res.keyId = WH_KEYID_ID(keyId);
+                res.outSz = 0;
 #ifdef DEBUG_CRYPTOCB_VERBOSE
                 printf("[server] cmac saved state in keyid:%x %x len:%u ret:%d type:%d\n",
-                        keyId, WH_KEYID_ID(keyId), meta->len, ret, server->crypto->algoCtx.cmac->type);
+                        keyId, WH_KEYID_ID(keyId), meta->len, ret, ctx->crypto->algoCtx.cmac->type);
 #endif
             }
         }
@@ -1371,8 +1649,10 @@ static int _HandleCmac(whServerContext* server, whPacket* packet,
         ret = CRYPTOCB_UNAVAILABLE;
     }
     if (ret == 0) {
-        *size = WH_PACKET_STUB_SIZE + sizeof(packet->cmacRes) +
-            packet->cmacRes.outSz;
+        ret = wh_MessageCrypto_TranslateCmacResponse(magic, &res, cryptoDataOut);
+        if (ret == 0) {
+            *outSize = sizeof(res) + res.outSz;
+        }
     }
 #ifdef DEBUG_CRYPTOCB_VERBOSE
     printf("[server] cmac end ret:%d\n", ret);
@@ -1382,50 +1662,66 @@ static int _HandleCmac(whServerContext* server, whPacket* packet,
 #endif
 
 #ifndef NO_SHA256
-static int _HandleSha256(whServerContext* server, whPacket* packet,
-                           uint16_t* size)
+static int _HandleSha256(whServerContext* ctx, uint16_t magic,
+                         const void* cryptoDataIn, uint16_t inSize,
+                         void* cryptoDataOut, uint16_t* outSize)
 {
-    int                        ret    = 0;
-    wc_Sha256*                 sha256 = server->crypto->algoCtx.sha256;
-    wh_Packet_hash_sha256_req* req    = &packet->hashSha256Req;
-    wh_Packet_hash_sha256_res* res    = &packet->hashSha256Res;
+    int                            ret    = 0;
+    wc_Sha256*                     sha256 = ctx->crypto->algoCtx.sha256;
+    whMessageCrypto_Sha256Request  req;
+    whMessageCrypto_Sha256Response res;
 
     /* THe server SHA256 struct doesn't persist state (it is a union), meaning
      * the devId may get blown away between calls. We must restore the server
      * devId each time */
-    sha256->devId = server->crypto->devId;
+    sha256->devId = ctx->crypto->devId;
+
+    /* Translate the request */
+    ret = wh_MessageCrypto_TranslateSha256Request(magic, cryptoDataIn, &req);
+    if (ret != 0) {
+        return ret;
+    }
 
     /* Init the SHA256 context if this is the first time, otherwise restore the
      * hash state from the client */
-    if (req->resumeState.hiLen == 0 && req->resumeState.loLen == 0) {
-        ret = wc_InitSha256_ex(sha256, NULL, server->crypto->devId);
+    if (req.resumeState.hiLen == 0 && req.resumeState.loLen == 0) {
+        ret = wc_InitSha256_ex(sha256, NULL, ctx->crypto->devId);
     }
     else {
-         /* HAVE_DILITHIUM */
-        XMEMCPY(sha256->digest, req->resumeState.hash, WC_SHA256_DIGEST_SIZE);
-        sha256->loLen = req->resumeState.loLen;
-        sha256->hiLen = req->resumeState.hiLen;
+        /* HAVE_DILITHIUM */
+        memcpy(sha256->digest, req.resumeState.hash, WC_SHA256_DIGEST_SIZE);
+        sha256->loLen = req.resumeState.loLen;
+        sha256->hiLen = req.resumeState.hiLen;
     }
 
-    if (req->isLastBlock) {
+    if (req.isLastBlock) {
         /* wolfCrypt (or cryptoCb) is responsible for last block padding */
         if (ret == 0) {
-            ret = wc_Sha256Update(sha256, req->inBlock, req->lastBlockLen);
+            ret = wc_Sha256Update(sha256, req.inBlock, req.lastBlockLen);
         }
         if (ret == 0) {
-            ret = wc_Sha256Final(sha256, res->hash);
+            ret = wc_Sha256Final(sha256, res.hash);
         }
     }
     else {
         /* Client always sends full blocks, unless it's the last block */
         if (ret == 0) {
-            ret = wc_Sha256Update(sha256, req->inBlock, WC_SHA256_BLOCK_SIZE);
+            ret = wc_Sha256Update(sha256, req.inBlock, WC_SHA256_BLOCK_SIZE);
         }
         /* Send the hash state back to the client */
         if (ret == 0) {
-            XMEMCPY(res->hash, sha256->digest, WC_SHA256_DIGEST_SIZE);
-            res->loLen = sha256->loLen;
-            res->hiLen = sha256->hiLen;
+            memcpy(res.hash, sha256->digest, WC_SHA256_DIGEST_SIZE);
+            res.loLen = sha256->loLen;
+            res.hiLen = sha256->hiLen;
+        }
+    }
+
+    /* Translate the response */
+    if (ret == 0) {
+        ret = wh_MessageCrypto_TranslateSha256Response(magic, &res,
+                                                       cryptoDataOut);
+        if (ret == 0) {
+            *outSize = sizeof(res);
         }
     }
 
@@ -1467,41 +1763,53 @@ static int _IsMlDsaLevelSupported(int level)
 }
 #endif /* WOLFSSL_DILITHIUM_NO_MAKE_KEY */
 
-static int _HandleMlDsaKeyGen(whServerContext* ctx, whPacket* packet,
-    uint16_t* out_size)
+static int _HandleMlDsaKeyGen(whServerContext* ctx, uint16_t magic,
+                              const void* cryptoDataIn, uint16_t inSize,
+                              void* cryptoDataOut, uint16_t* outSize)
 {
 #ifdef WOLFSSL_DILITHIUM_NO_MAKE_KEY
     (void)ctx;
-    (void)packet;
-    (void)out_size;
+    (void)magic;
+    (void)cryptoDataIn;
+    (void)inSize;
+    (void)cryptoDataOut;
+    (void)outSize;
     return WH_ERROR_NOHANDLER;
 #else
-    int ret = WH_ERROR_OK;
-    MlDsaKey key[1];
-    wh_Packet_pq_mldsa_kg_req* req = &packet->pqMldsaKgReq;
-    wh_Packet_pq_mldsa_kg_res* res = &packet->pqMldsaKgRes;
+    int                                 ret = WH_ERROR_OK;
+    MlDsaKey                            key[1];
+    whMessageCrypto_MlDsaKeyGenRequest  req;
+    whMessageCrypto_MlDsaKeyGenResponse res;
 
-    /* Request message */
-    int     key_size = req->sz;
+    /* Translate the request */
+    ret = wh_MessageCrypto_TranslateMlDsaKeyGenRequest(
+        magic, (whMessageCrypto_MlDsaKeyGenRequest*)cryptoDataIn, &req);
+    if (ret != 0) {
+        return ret;
+    }
+
+    /* Extract parameters from translated request */
+    int     key_size = req.sz;
     whKeyId key_id =
-        WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id, req->keyId);
-    int        level      = req->level;
-    whNvmFlags flags      = req->flags;
-    uint8_t*   label      = req->label;
+        WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id, req.keyId);
+    int        level      = req.level;
+    whNvmFlags flags      = req.flags;
+    uint8_t*   label      = req.label;
     uint16_t   label_size = WH_NVM_LABEL_LEN;
 
     /* Response message */
-    uint8_t* res_out    = (uint8_t*)(res + 1);
-    uint16_t max_size     = (uint16_t)(WOLFHSM_CFG_COMM_DATA_LEN -
-                            (res_out - (uint8_t*)packet));
-    uint16_t res_size   = 0;
+    uint8_t* res_out =
+        (uint8_t*)cryptoDataOut + sizeof(whMessageCrypto_MlDsaKeyGenResponse);
+    uint16_t max_size = (uint16_t)(WOLFHSM_CFG_COMM_DATA_LEN -
+                                   (res_out - (uint8_t*)cryptoDataOut));
+    uint16_t res_size = 0;
 
     /* TODO key_sz is not used. Should this instead be used as max_size? Figure
      * out the relation between all three */
     (void)key_size;
 
     /* Check the ML-DSA security level is valid and supported */
-    if (0 ==_IsMlDsaLevelSupported(level)) {
+    if (0 == _IsMlDsaLevelSupported(level)) {
         ret = WH_ERROR_BADARGS;
     }
     else {
@@ -1546,42 +1854,58 @@ static int _HandleMlDsaKeyGen(whServerContext* ctx, whPacket* packet,
         }
 
         if (ret == WH_ERROR_OK) {
-            res->keyId = WH_KEYID_ID(key_id);
-            res->len   = res_size;
-            *out_size  = WH_PACKET_STUB_SIZE + sizeof(*res) + res_size;
+            res.keyId = WH_KEYID_ID(key_id);
+            res.len   = res_size;
+
+            wh_MessageCrypto_TranslateMlDsaKeyGenResponse(magic, &res,
+                                                          cryptoDataOut);
+
+            *outSize = sizeof(whMessageCrypto_MlDsaKeyGenResponse) + res_size;
         }
     }
     return ret;
 #endif /* WOLFSSL_DILITHIUM_NO_MAKE_KEY */
 }
 
-static int _HandleMlDsaSign(whServerContext* ctx, whPacket* packet,
-        uint16_t *out_size)
+static int _HandleMlDsaSign(whServerContext* ctx, uint16_t magic,
+                            const void* cryptoDataIn, uint16_t inSize,
+                            void* cryptoDataOut, uint16_t* outSize)
 {
 #ifdef WOLFSSL_DILITHIUM_NO_SIGN
     (void)ctx;
-    (void)packet;
-    (void)out_size;
+    (void)magic;
+    (void)cryptoDataIn;
+    (void)inSize;
+    (void)cryptoDataOut;
+    (void)outSize;
     return WH_ERROR_NOHANDLER;
 #else
-    int                          ret;
-    MlDsaKey                     key[1];
-    wh_Packet_pq_mldsa_sign_req* req = &packet->pqMldsaSignReq;
-    wh_Packet_pq_mldsa_sign_res* res = &packet->pqMldsaSignRes;
+    int                                 ret;
+    MlDsaKey                            key[1];
+    whMessageCrypto_MlDsaSignRequest    req;
+    whMessageCrypto_MlDsaSignResponse   res;
 
-    /* Request message */
-    byte*   in = (uint8_t*)(req + 1);
+    /* Translate the request */
+    ret = wh_MessageCrypto_TranslateMlDsaSignRequest(
+        magic, (whMessageCrypto_MlDsaSignRequest*)cryptoDataIn, &req);
+    if (ret != 0) {
+        return ret;
+    }
+
+    /* Extract parameters from translated request */
+    byte*   in = (uint8_t*)(cryptoDataIn) + sizeof(whMessageCrypto_MlDsaSignRequest);
     whKeyId key_id =
-        WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id, req->keyId);
-    word32   in_len  = req->sz;
-    uint32_t options = req->options;
-    int      evict   = !!(options & WH_PACKET_PQ_MLDSA_SIGN_OPTIONS_EVICT);
+        WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id, req.keyId);
+    word32   in_len  = req.sz;
+    uint32_t options = req.options;
+    int      evict   = !!(options & WH_MESSAGE_CRYPTO_MLDSA_SIGN_OPTIONS_EVICT);
 
     /* Response message */
-    byte*        res_out = (uint8_t*)(res + 1);
-    const word32 max_len =
-        (word32)(WOLFHSM_CFG_COMM_DATA_LEN - (res_out - (uint8_t*)packet));
-    word32 res_len;
+    byte* res_out =
+        (uint8_t*)(cryptoDataOut) + sizeof(whMessageCrypto_MlDsaSignResponse);
+    const word32 max_len = (word32)(WOLFHSM_CFG_COMM_DATA_LEN -
+                                    (res_out - (uint8_t*)cryptoDataOut));
+    word32       res_len = max_len;
 
     /* init private key */
     ret = wc_MlDsaKey_Init(key, NULL, ctx->crypto->devId);
@@ -1590,7 +1914,6 @@ static int _HandleMlDsaSign(whServerContext* ctx, whPacket* packet,
         ret = wh_Server_MlDsaKeyCacheExport(ctx, key_id, key);
         if (ret == WH_ERROR_OK) {
             /* sign the input */
-            res_len = max_len;
             ret     = wc_MlDsaKey_Sign(key, res_out, &res_len, in, in_len,
                                        ctx->crypto->rng);
         }
@@ -1600,36 +1923,52 @@ static int _HandleMlDsaSign(whServerContext* ctx, whPacket* packet,
         (void)hsmEvictKey(ctx, key_id);
     }
     if (ret == 0) {
-        res->sz   = res_len;
-        *out_size = WH_PACKET_STUB_SIZE + sizeof(*res) + res_len;
+        res.sz   = res_len;
+
+        wh_MessageCrypto_TranslateMlDsaSignResponse(
+            magic, &res, (whMessageCrypto_MlDsaSignResponse*)cryptoDataOut);
+
+        *outSize = sizeof(whMessageCrypto_MlDsaSignResponse) + res_len;
     }
     return ret;
 #endif /* WOLFSSL_DILITHIUM_NO_SIGN */
 }
 
-static int _HandleMlDsaVerify(whServerContext* ctx, whPacket* packet,
-        uint16_t *out_size)
+static int _HandleMlDsaVerify(whServerContext* ctx, uint16_t magic,
+                              const void* cryptoDataIn, uint16_t inSize,
+                              void* cryptoDataOut, uint16_t* outSize)
 {
 #ifdef WOLFSSL_DILITHIUM_NO_VERIFY
     (void)ctx;
-    (void)packet;
-    (void)out_size;
+    (void)magic;
+    (void)cryptoDataIn;
+    (void)inSize;
+    (void)cryptoDataOut;
+    (void)outSize;
     return WH_ERROR_NOHANDLER;
 #else
-    int                            ret;
-    MlDsaKey                       key[1];
-    wh_Packet_pq_mldsa_verify_req* req = &packet->pqMldsaVerifyReq;
-    wh_Packet_pq_mldsa_verify_res* res = &packet->pqMldsaVerifyRes;
+    int                                 ret;
+    MlDsaKey                            key[1];
+    whMessageCrypto_MlDsaVerifyRequest  req;
+    whMessageCrypto_MlDsaVerifyResponse res;
 
-    /* Request Message */
-    uint32_t options = req->options;
+    /* Translate the request */
+    ret = wh_MessageCrypto_TranslateMlDsaVerifyRequest(
+        magic, (whMessageCrypto_MlDsaVerifyRequest*)cryptoDataIn, &req);
+    if (ret != 0) {
+        return ret;
+    }
+
+    /* Extract parameters from translated request */
+    uint32_t options = req.options;
     whKeyId  key_id =
-        WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id, req->keyId);
-    uint32_t hash_len = req->hashSz;
-    uint32_t sig_len  = req->sigSz;
-    byte*    req_sig  = (uint8_t*)(req + 1);
+        WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id, req.keyId);
+    uint32_t hash_len = req.hashSz;
+    uint32_t sig_len  = req.sigSz;
+    byte*    req_sig =
+        (uint8_t*)(cryptoDataIn) + sizeof(whMessageCrypto_MlDsaVerifyRequest);
     byte*    req_hash = req_sig + sig_len;
-    int      evict    = !!(options & WH_PACKET_PQ_MLDSAVERIFY_OPTIONS_EVICT);
+    int      evict = !!(options & WH_MESSAGE_CRYPTO_MLDSA_VERIFY_OPTIONS_EVICT);
 
     /* Response message */
     int result;
@@ -1651,44 +1990,59 @@ static int _HandleMlDsaVerify(whServerContext* ctx, whPacket* packet,
         (void)hsmEvictKey(ctx, key_id);
     }
     if (ret == 0) {
-        res->res  = result;
-        *out_size = WH_PACKET_STUB_SIZE + sizeof(*res);
+        res.res  = result;
+
+        wh_MessageCrypto_TranslateMlDsaVerifyResponse(
+            magic, &res, (whMessageCrypto_MlDsaVerifyResponse*)cryptoDataOut);
+
+        *outSize = sizeof(whMessageCrypto_MlDsaVerifyResponse);
     }
     return ret;
 #endif /* WOLFSSL_DILITHIUM_NO_VERIFY */
 }
 
-static int _HandleMlDsaCheckPrivKey(whServerContext* ctx, whPacket* packet,
-        uint16_t *out_size)
+static int _HandleMlDsaCheckPrivKey(whServerContext* ctx, uint16_t magic,
+                                    const void* cryptoDataIn, uint16_t inSize,
+                                    void* cryptoDataOut, uint16_t* outSize)
 {
     return WH_ERROR_NOHANDLER;
 }
 #endif /* HAVE_DILITHIUM */
 
 #if defined(HAVE_DILITHIUM) || defined(HAVE_FALCON)
-static int _HandlePqcSigAlgorithm(whServerContext* ctx, whPacket* packet,
-                                  uint16_t* size)
+static int _HandlePqcSigAlgorithm(whServerContext* ctx, uint16_t magic,
+                                  const void* cryptoDataIn,
+                                  uint16_t cryptoInSize, void* cryptoDataOut,
+                                  uint16_t* cryptoOutSize, uint32_t pkAlgoType,
+                                  uint32_t pqAlgoType)
 {
-    int                      ret = WH_ERROR_NOHANDLER;
-    wh_Packet_pk_pq_any_req* req = &packet->pkPqAnyReq;
+    int ret = WH_ERROR_NOHANDLER;
 
     /* Dispatch the appropriate algorithm handler based on the requested PK type
      * and the algorithm type. */
-    switch (req->pqAlgoType) {
+    switch (pqAlgoType) {
 #ifdef HAVE_DILITHIUM
         case WC_PQC_SIG_TYPE_DILITHIUM: {
-            switch (req->type) {
+            switch (pkAlgoType) {
                 case WC_PK_TYPE_PQC_SIG_KEYGEN:
-                    ret = _HandleMlDsaKeyGen(ctx, packet, size);
+                    ret = _HandleMlDsaKeyGen(ctx, magic, cryptoDataIn,
+                                             cryptoInSize, cryptoDataOut,
+                                             cryptoOutSize);
                     break;
                 case WC_PK_TYPE_PQC_SIG_SIGN:
-                    ret = _HandleMlDsaSign(ctx, packet, size);
+                    ret =
+                        _HandleMlDsaSign(ctx, magic, cryptoDataIn, cryptoInSize,
+                                         cryptoDataOut, cryptoOutSize);
                     break;
                 case WC_PK_TYPE_PQC_SIG_VERIFY:
-                    ret = _HandleMlDsaVerify(ctx, packet, size);
+                    ret = _HandleMlDsaVerify(ctx, magic, cryptoDataIn,
+                                             cryptoInSize, cryptoDataOut,
+                                             cryptoOutSize);
                     break;
                 case WC_PK_TYPE_PQC_SIG_CHECK_PRIV_KEY:
-                    ret = _HandleMlDsaCheckPrivKey(ctx, packet, size);
+                    ret = _HandleMlDsaCheckPrivKey(ctx, magic, cryptoDataIn,
+                                                   cryptoInSize, cryptoDataOut,
+                                                   cryptoOutSize);
                     break;
                 default:
                     ret = WH_ERROR_NOHANDLER;
@@ -1714,172 +2068,218 @@ static int _HandlePqcKemAlgorithm(whServerContext* ctx, whPacket* packet,
 }
 #endif
 
-int wh_Server_HandleCryptoRequest(whServerContext* ctx,
-    uint16_t action, uint8_t* data, uint16_t *inout_size, uint16_t seq)
+int wh_Server_HandleCryptoRequest(whServerContext* ctx, uint16_t magic,
+                                  uint16_t action, uint16_t seq,
+                                  uint16_t req_size, const void* req_packet,
+                                  uint16_t* out_resp_size, void* resp_packet)
 {
-    int ret = 0;
-    uint8_t* out;
-    whPacket* packet = (whPacket*)data;
+    int                                   ret        = 0;
+    whMessageCrypto_GenericRequestHeader  rqstHeader = {0};
+    whMessageCrypto_GenericResponseHeader respHeader = {0};
 
-    if (    (ctx == NULL) ||
-            (ctx->crypto == NULL) ||
-            (data == NULL) ||
-            (inout_size == NULL)) {
-        return BAD_FUNC_ARG;
+    const void* cryptoDataIn =
+        (uint8_t*)req_packet + sizeof(whMessageCrypto_GenericRequestHeader);
+    void* cryptoDataOut =
+        (uint8_t*)resp_packet + sizeof(whMessageCrypto_GenericResponseHeader);
+
+    /* Input and output sizes for data passed to crypto handlers. cryptoOutSize
+     * should be set by the crypto handler as an output parameter */
+    uint16_t cryptoInSize =
+        req_size - sizeof(whMessageCrypto_GenericResponseHeader);
+    uint16_t cryptoOutSize = 0;
+
+    if ((ctx == NULL) || (ctx->crypto == NULL) || (req_packet == NULL) ||
+        (resp_packet == NULL) || (out_resp_size == NULL)) {
+        return WH_ERROR_BADARGS;
     }
 
-#ifdef DEBUG_CRYPTOCB_VERBOSE
+    /* Translate the request message to get the algo type */
+    wh_MessageCrypto_TranslateGenericRequestHeader(
+        magic, (whMessageCrypto_GenericRequestHeader*)req_packet, &rqstHeader);
+
+
+#ifdef DEBUG_CRYPTOCB
     printf("[server] HandleCryptoRequest. Action:%u\n", action);
+#ifdef DEBUG_CRYPTOCB_VERBOSE
+    wh_Utils_Hexdump("[server] Crypto Request:\n", (const uint8_t*)req_packet,
+                     req_size);
 #endif
-    switch (action)
-    {
-    case WC_ALGO_TYPE_CIPHER:
-        switch (packet->cipherAnyReq.type)
-        {
+#endif
+    switch (action) {
+        case WC_ALGO_TYPE_CIPHER:
+            switch (rqstHeader.algoType) {
 #ifndef NO_AES
 #ifdef HAVE_AES_CBC
-        case WC_CIPHER_AES_CBC:
-            ret = _HandleAesCbc(ctx, packet, inout_size);
-            break;
+                case WC_CIPHER_AES_CBC:
+                    ret = _HandleAesCbc(ctx, magic, cryptoDataIn, cryptoInSize,
+                                        cryptoDataOut, &cryptoOutSize);
+                    break;
 #endif /* HAVE_AES_CBC */
 #ifdef HAVE_AESGCM
-        case WC_CIPHER_AES_GCM:
-            ret = _HandleAesGcm(ctx, packet, inout_size);
-            break;
+                case WC_CIPHER_AES_GCM:
+                    ret = _HandleAesGcm(ctx, magic, cryptoDataIn, cryptoInSize,
+                                        cryptoDataOut, &cryptoOutSize);
+                    break;
 #endif /* HAVE_AESGCM */
 #endif /* !NO_AES */
-        default:
-            ret = NOT_COMPILED_IN;
+                default:
+                    ret = NOT_COMPILED_IN;
+                    break;
+            }
             break;
-        }
-        break;
-    case WC_ALGO_TYPE_PK:
-    {
-        int type = (int)(packet->pkAnyReq.type);
+        case WC_ALGO_TYPE_PK: {
 #ifdef DEBUG_CRYPTOCB_VERBOSE
-        printf("[server] PK type:%d\n", type);
+            printf("[server] PK type:%d\n", rqstHeader.algoType);
 #endif
-        switch (type)
-        {
+            switch (rqstHeader.algoType) {
 #ifndef NO_RSA
 #ifdef WOLFSSL_KEY_GEN
-        case WC_PK_TYPE_RSA_KEYGEN:
-            ret = _HandleRsaKeyGen(ctx, packet, inout_size);
-            break;
-#endif  /* WOLFSSL_KEY_GEN */
-        case WC_PK_TYPE_RSA:
-            ret = _HandleRsaFunction(ctx, packet, inout_size);
-            break;
-        case WC_PK_TYPE_RSA_GET_SIZE:
-            ret = _HandleRsaGetSize(ctx, packet, inout_size);
-            break;
+                case WC_PK_TYPE_RSA_KEYGEN:
+                    ret =
+                        _HandleRsaKeyGen(ctx, magic, cryptoDataIn, cryptoInSize,
+                                         cryptoDataOut, &cryptoOutSize);
+                    break;
+#endif /* WOLFSSL_KEY_GEN */
+                case WC_PK_TYPE_RSA:
+                    ret = _HandleRsaFunction(ctx, magic, cryptoDataIn,
+                                             cryptoInSize, cryptoDataOut,
+                                             &cryptoOutSize);
+                    break;
+
+                case WC_PK_TYPE_RSA_GET_SIZE:
+                    ret = _HandleRsaGetSize(ctx, magic, cryptoDataIn,
+                                            cryptoInSize, cryptoDataOut,
+                                            &cryptoOutSize);
+                    break;
 #endif /* !NO_RSA */
+
 #ifdef HAVE_ECC
-        case WC_PK_TYPE_EC_KEYGEN:
-            ret = _HandleEccKeyGen(ctx, packet, inout_size);
-            break;
-        case WC_PK_TYPE_ECDH:
-            ret = _HandleEccSharedSecret(ctx, packet, inout_size);
-            break;
-        case WC_PK_TYPE_ECDSA_SIGN:
-            ret = _HandleEccSign(ctx, packet, inout_size);
-            break;
-        case WC_PK_TYPE_ECDSA_VERIFY:
-            ret = _HandleEccVerify(ctx, packet, inout_size);
-            break;
+                case WC_PK_TYPE_EC_KEYGEN:
+                    ret =
+                        _HandleEccKeyGen(ctx, magic, cryptoDataIn, cryptoInSize,
+                                         cryptoDataOut, &cryptoOutSize);
+                    break;
+                case WC_PK_TYPE_ECDH:
+                    ret = _HandleEccSharedSecret(ctx, magic, cryptoDataIn,
+                                                 cryptoInSize, cryptoDataOut,
+                                                 &cryptoOutSize);
+                    break;
+                case WC_PK_TYPE_ECDSA_SIGN:
+                    ret = _HandleEccSign(ctx, magic, cryptoDataIn, cryptoInSize,
+                                         cryptoDataOut, &cryptoOutSize);
+                    break;
+                case WC_PK_TYPE_ECDSA_VERIFY:
+                    ret = _HandleEccVerify(ctx, magic, cryptoDataIn, cryptoInSize,
+                                           cryptoDataOut, &cryptoOutSize);
+                    break;
 #if 0
         case WC_PK_TYPE_EC_CHECK_PRIV_KEY:
-            ret = _HandleEccCheckPrivKey(ctx, (whPacket*)data, inout_size);
+            ret = _HandleEccCheckPrivKey(ctx, magic, cryptoDataIn, cryptoInSize,
+                                          cryptoDataOut, &cryptoOutSize);
             break;
 #endif
 #endif /* HAVE_ECC */
 
 #ifdef HAVE_CURVE25519
-        case WC_PK_TYPE_CURVE25519_KEYGEN:
-            ret = _HandleCurve25519KeyGen(ctx,
-                    packet, inout_size);
-            break;
-        case WC_PK_TYPE_CURVE25519:
-            ret = _HandleCurve25519SharedSecret(ctx,
-                    packet, inout_size);
-            break;
+                case WC_PK_TYPE_CURVE25519_KEYGEN:
+                    ret = _HandleCurve25519KeyGen(ctx, magic, cryptoDataIn,
+                                                  cryptoInSize, cryptoDataOut,
+                                                  &cryptoOutSize);
+                    break;
+                case WC_PK_TYPE_CURVE25519:
+                    ret = _HandleCurve25519SharedSecret(
+                        ctx, magic, cryptoDataIn, cryptoInSize, cryptoDataOut,
+                        &cryptoOutSize);
+                    break;
 #endif /* HAVE_CURVE25519 */
 
 #if defined(HAVE_DILITHIUM) || defined(HAVE_FALCON)
-        case WC_PK_TYPE_PQC_SIG_KEYGEN:
-        case WC_PK_TYPE_PQC_SIG_SIGN:
-        case WC_PK_TYPE_PQC_SIG_VERIFY:
-        case WC_PK_TYPE_PQC_SIG_CHECK_PRIV_KEY:
-            ret = _HandlePqcSigAlgorithm(ctx, packet, inout_size);
-            break;
+                case WC_PK_TYPE_PQC_SIG_KEYGEN:
+                case WC_PK_TYPE_PQC_SIG_SIGN:
+                case WC_PK_TYPE_PQC_SIG_VERIFY:
+                case WC_PK_TYPE_PQC_SIG_CHECK_PRIV_KEY:
+                    ret = _HandlePqcSigAlgorithm(
+                        ctx, magic, cryptoDataIn, cryptoInSize, cryptoDataOut,
+                        &cryptoOutSize, rqstHeader.algoType,
+                        rqstHeader.algoSubType);
+                    break;
 #endif
 
 #if defined(HAVE_KYBER)
-        case WC_PK_TYPE_PQC_KEM_KEYGEN:
-        case WC_PK_TYPE_PQC_KEM_ENCAPS:
-        case WC_PK_TYPE_PQC_KEM_DECAPS:
-            ret = _HandlePqcKemAlgorithm(ctx, packet, inout_size);
+                case WC_PK_TYPE_PQC_KEM_KEYGEN:
+                case WC_PK_TYPE_PQC_KEM_ENCAPS:
+                case WC_PK_TYPE_PQC_KEM_DECAPS:
+                    ret =
+                        _HandlePqcKemAlgorithm(ctx, magic, cryptoDataIn, cryptoInSize,
+                                               cryptoDataOut, &cryptoOutSize);
+                    break;
+#endif
+
+                default:
+                    ret = NOT_COMPILED_IN;
+                    break;
+            }
+        }; break;
+
+#ifndef WC_NO_RNG
+        case WC_ALGO_TYPE_RNG:
+            ret = _HandleRng(ctx, magic, cryptoDataIn, cryptoInSize,
+                             cryptoDataOut, &cryptoOutSize);
+            break;
+#endif /* !WC_NO_RNG */
+
+#ifdef WOLFSSL_CMAC
+        case WC_ALGO_TYPE_CMAC:
+            ret = _HandleCmac(ctx, magic, seq, cryptoDataIn, cryptoInSize,
+                              cryptoDataOut, &cryptoOutSize);
             break;
 #endif
 
+        case WC_ALGO_TYPE_HASH:
+            switch (rqstHeader.algoType) {
+#ifndef NO_SHA256
+                case WC_HASH_TYPE_SHA256:
+#ifdef DEBUG_CRYPTOCB_VERBOSE
+                    printf("[server] SHA256 req recv. type:%u\n",
+                           rqstHeader.algoType);
+#endif
+                    ret = _HandleSha256(ctx, magic, cryptoDataIn, cryptoInSize,
+                                        cryptoDataOut, &cryptoOutSize);
+#ifdef DEBUG_CRYPTOCB_VERBOSE
+                    if (ret != 0) {
+                        printf("[server] SHA256 ret = %d\n", ret);
+                    }
+#endif
+                    break;
+#endif /* !NO_SHA256 */
+                default:
+                    ret = NOT_COMPILED_IN;
+                    break;
+            }
+            break;
+
+        case WC_ALGO_TYPE_NONE:
         default:
             ret = NOT_COMPILED_IN;
             break;
-        }
-    }; break;
-
-#ifndef WC_NO_RNG
-    case WC_ALGO_TYPE_RNG:
-        /* out is after the fixed size fields */
-        out = (uint8_t*)(&packet->rngRes + 1);
-        /* generate the bytes */
-        ret = wc_RNG_GenerateBlock(ctx->crypto->rng, out, packet->rngReq.sz);
-        if (ret == 0) {
-            *inout_size = WH_PACKET_STUB_SIZE + sizeof(packet->rngRes) +
-                packet->rngRes.sz;
-        }
-        break;
-#endif /* !WC_NO_RNG */
-#ifdef WOLFSSL_CMAC
-    case WC_ALGO_TYPE_CMAC:
-        ret = _HandleCmac(ctx, packet, inout_size, seq);
-        break;
-#endif
-
-    case WC_ALGO_TYPE_HASH:
-        switch (packet->hashAnyReq.type) {
-#ifndef NO_SHA256
-            case WC_HASH_TYPE_SHA256:
-#ifdef DEBUG_CRYPTOCB_VERBOSE
-                printf("[server] SHA256 req recv. type:%u\n",
-                       packet->hashSha256Req.type);
-#endif
-                ret = _HandleSha256(ctx, packet, inout_size);
-#ifdef DEBUG_CRYPTOCB_VERBOSE
-                if (ret != 0) {
-                    printf("[server] SHA256 ret = %d\n", ret);
-                }
-#endif
-                break;
-#endif /* !NO_SHA256 */
-
-            default:
-                ret = NOT_COMPILED_IN;
-                break;
-        }
-        break;
-
-    case WC_ALGO_TYPE_NONE:
-    default:
-        ret = NOT_COMPILED_IN;
-        break;
     }
 
-    /* Propagate error code to client in response packet */
-    packet->rc = ret;
+    /* Propagate error code to client in response packet header. Crypto handlers
+     * have already populated the response packet with the output data. */
+    respHeader.rc = ret;
+    respHeader.algoType = rqstHeader.algoType;
+    wh_MessageCrypto_TranslateGenericResponseHeader(
+        magic, &respHeader,
+        (whMessageCrypto_GenericResponseHeader*)resp_packet);
 
-    if (ret != 0)
-        *inout_size = WH_PACKET_STUB_SIZE;
+    /* Update the size of the response packet if crypto handler didn't fail */
+    if (ret != WH_ERROR_OK) {
+        *out_resp_size = sizeof(whMessageCrypto_GenericResponseHeader);
+    }
+    else {
+        *out_resp_size =
+            sizeof(whMessageCrypto_GenericResponseHeader) + cryptoOutSize;
+    }
 
 #ifdef DEBUG_CRYPTOCB
     printf("[server] %s End ret:%d\n", __func__, ret);
@@ -1889,7 +2289,7 @@ int wh_Server_HandleCryptoRequest(whServerContext* ctx,
      * packet, return success to the caller unless a cancellation has occurred
      */
     if (ret != WH_ERROR_CANCEL) {
-        ret = 0;
+        ret = WH_ERROR_OK;
     }
     return ret;
 }
@@ -1897,32 +2297,44 @@ int wh_Server_HandleCryptoRequest(whServerContext* ctx,
 #ifdef WOLFHSM_CFG_DMA
 
 #ifndef NO_SHA256
-static int _HandleSha256Dma(whServerContext* server, whPacket* packet,
-                            uint16_t* size)
+static int _HandleSha256Dma(whServerContext* ctx, uint16_t magic, uint16_t seq,
+                            const void* cryptoDataIn, uint16_t inSize,
+                            void* cryptoDataOut, uint16_t* outSize)
 {
-    int                            ret    = 0;
-    wh_Packet_hash_sha256_Dma_req* req    = &packet->hashSha256DmaReq;
-    wh_Packet_hash_sha256_Dma_res* res    = &packet->hashSha256DmaRes;
-    wc_Sha256*                     sha256 = server->crypto->algoCtx.sha256;
-    int        clientDevId;
+    int                               ret = 0;
+    whMessageCrypto_Sha256DmaRequest  req;
+    whMessageCrypto_Sha256DmaResponse res;
+    wc_Sha256*                        sha256 = ctx->crypto->algoCtx.sha256;
+    int                               clientDevId;
+
+    /* Translate the request */
+    ret = wh_MessageCrypto_TranslateSha256DmaRequest(
+        magic, (whMessageCrypto_Sha256DmaRequest*)cryptoDataIn, &req);
+    if (ret != WH_ERROR_OK) {
+        return ret;
+    }
 
     /* Ensure state sizes are the same */
-    if (req->state.sz != sizeof(*sha256)) {
-        res->dmaAddrStatus.badAddr = req->state;
-        return WH_ERROR_BADARGS;
+    if (req.state.sz != sizeof(*sha256)) {
+        res.dmaAddrStatus.badAddr = req.state;
+        ret                       = WH_ERROR_BADARGS;
     }
 
-    /* Copy the SHA256 context from client address space */
-    ret = whServerDma_CopyFromClient(server, sha256, req->state.addr,
-                                     req->state.sz, (whServerDmaFlags){0});
-    if (ret != WH_ERROR_OK) {
-        res->dmaAddrStatus.badAddr = req->state;
+    if (ret == WH_ERROR_OK) {
+        /* Copy the SHA256 context from client address space */
+        ret = whServerDma_CopyFromClient(ctx, sha256, req.state.addr,
+                                         req.state.sz, (whServerDmaFlags){0});
+        if (ret != WH_ERROR_OK) {
+            res.dmaAddrStatus.badAddr = req.state;
+        }
+        else {
+            /* Save the client devId to be restored later, when the context is
+             * copied back into client memory. */
+            clientDevId = sha256->devId;
+            /* overwrite the devId to that of the server for local crypto */
+            sha256->devId = ctx->crypto->devId;
+        }
     }
-    /* Save the client devId to be restored later, when the context is copied
-     * back into client memory. */
-    clientDevId = sha256->devId;
-    /* overwrite the devId to that of the server for local crypto */
-    sha256->devId = server->crypto->devId;
 
     /* TODO: perhaps we should sequentially update and finalize (need individual
      * flags as 0x0 could be a valid address?) just to future-proof, even though
@@ -1930,10 +2342,10 @@ static int _HandleSha256Dma(whServerContext* server, whPacket* packet,
 
     /* If finalize requested, finalize the SHA256 operation, wrapping client
      * address accesses with the associated DMA address processing */
-    if (ret == WH_ERROR_OK && req->finalize) {
+    if (ret == WH_ERROR_OK && req.finalize) {
         void* outAddr;
         ret = wh_Server_DmaProcessClientAddress(
-            server, req->output.addr, &outAddr, req->output.sz,
+            ctx, req.output.addr, &outAddr, req.output.sz,
             WH_DMA_OPER_CLIENT_WRITE_PRE, (whServerDmaFlags){0});
 
         /* Finalize the SHA256 operation */
@@ -1946,12 +2358,12 @@ static int _HandleSha256Dma(whServerContext* server, whPacket* packet,
 
         if (ret == WH_ERROR_OK) {
             ret = wh_Server_DmaProcessClientAddress(
-                server, req->output.addr, &outAddr, req->output.sz,
+                ctx, req.output.addr, &outAddr, req.output.sz,
                 WH_DMA_OPER_CLIENT_WRITE_POST, (whServerDmaFlags){0});
         }
 
         if (ret == WH_ERROR_ACCESS) {
-            res->dmaAddrStatus.badAddr = req->output;
+            res.dmaAddrStatus.badAddr = req.output;
         }
     }
     else if (ret == WH_ERROR_OK) {
@@ -1959,26 +2371,26 @@ static int _HandleSha256Dma(whServerContext* server, whPacket* packet,
          * address accesses with the associated DMA address processing */
         void* inAddr;
         ret = wh_Server_DmaProcessClientAddress(
-            server, req->input.addr, &inAddr, req->input.sz,
+            ctx, req.input.addr, &inAddr, req.input.sz,
             WH_DMA_OPER_CLIENT_READ_PRE, (whServerDmaFlags){0});
 
         /* Update the SHA256 operation */
         if (ret == WH_ERROR_OK) {
 #ifdef DEBUG_CRYPTOCB_VERBOSE
             printf("[server]   wc_Sha256Update: inAddr=%p, sz=%llu\n", inAddr,
-                   (long long unsigned int)req->input.sz);
+                   (long long unsigned int)req.input.sz);
 #endif
-            ret = wc_Sha256Update(sha256, inAddr, req->input.sz);
+            ret = wc_Sha256Update(sha256, inAddr, req.input.sz);
         }
 
         if (ret == WH_ERROR_OK) {
             ret = wh_Server_DmaProcessClientAddress(
-                server, req->input.addr, &inAddr, req->input.sz,
+                ctx, req.input.addr, &inAddr, req.input.sz,
                 WH_DMA_OPER_CLIENT_READ_POST, (whServerDmaFlags){0});
         }
 
         if (ret == WH_ERROR_ACCESS) {
-            res->dmaAddrStatus.badAddr = req->input;
+            res.dmaAddrStatus.badAddr = req.input;
         }
     }
 
@@ -1987,14 +2399,19 @@ static int _HandleSha256Dma(whServerContext* server, whPacket* packet,
          * to client memory */
         sha256->devId = clientDevId;
         /* Copy SHA256 context back into client memory */
-        ret = whServerDma_CopyToClient(server, req->state.addr, sha256,
-                                       req->state.sz, (whServerDmaFlags){0});
+        ret = whServerDma_CopyToClient(ctx, req.state.addr, sha256,
+                                       req.state.sz, (whServerDmaFlags){0});
         if (ret != WH_ERROR_OK) {
-            res->dmaAddrStatus.badAddr = req->state;
+            res.dmaAddrStatus.badAddr = req.state;
         }
     }
 
-    /* return value populates packet->rc */
+    /* Translate the response */
+    (void)wh_MessageCrypto_TranslateSha256DmaResponse(
+        magic, &res, (whMessageCrypto_Sha256DmaResponse*)cryptoDataOut);
+    *outSize = sizeof(res);
+
+    /* return value populates rc in response message */
     return ret;
 }
 #endif /* ! NO_SHA256 */
@@ -2002,13 +2419,17 @@ static int _HandleSha256Dma(whServerContext* server, whPacket* packet,
 
 #if defined(HAVE_DILITHIUM)
 
-static int _HandleMlDsaKeyGenDma(whServerContext* server, whPacket* packet,
-                                 uint16_t* size)
+static int _HandleMlDsaKeyGenDma(whServerContext* ctx, uint16_t magic,
+                                 const void* cryptoDataIn, uint16_t inSize,
+                                 void* cryptoDataOut, uint16_t* outSize)
 {
 #ifdef WOLFSSL_DILITHIUM_NO_MAKE_KEY
-    (void)server;
-    (void)packet;
-    (void)size;
+    (void)ctx;
+    (void)magic;
+    (void)cryptoDataIn;
+    (void)inSize;
+    (void)cryptoDataOut;
+    (void)outSize;
     return WH_ERROR_NOHANDLER;
 #else
     int      ret = WH_ERROR_OK;
@@ -2016,43 +2437,50 @@ static int _HandleMlDsaKeyGenDma(whServerContext* server, whPacket* packet,
     void*    clientOutAddr = NULL;
     uint16_t keySize       = 0;
 
-    wh_Packet_pq_mldsa_keygen_Dma_req* req = &packet->pqMldsaKeygenDmaReq;
-    wh_Packet_pq_mldsa_Dma_res*        res = &packet->pqMldsaDmaRes;
+    whMessageCrypto_MlDsaKeyGenDmaRequest req;
+    whMessageCrypto_MlDsaKeyGenDmaResponse res;
+
+    /* Translate the request */
+    ret = wh_MessageCrypto_TranslateMlDsaKeyGenDmaRequest(
+        magic, (whMessageCrypto_MlDsaKeyGenDmaRequest*)cryptoDataIn, &req);
+    if (ret != WH_ERROR_OK) {
+        return ret;
+    }
 
     /* Check the ML-DSA security level is valid and supported */
-    if (0 == _IsMlDsaLevelSupported(req->level)) {
+    if (0 == _IsMlDsaLevelSupported(req.level)) {
         ret = WH_ERROR_BADARGS;
     }
     else {
         /* init mldsa key */
-        ret = wc_MlDsaKey_Init(key, NULL, server->crypto->devId);
+        ret = wc_MlDsaKey_Init(key, NULL, ctx->crypto->devId);
         if (ret == 0) {
             /* Set the ML-DSA security level */
-            ret = wc_MlDsaKey_SetParams(key, req->level);
+            ret = wc_MlDsaKey_SetParams(key, req.level);
             if (ret == 0) {
                 /* generate the key */
-                ret = wc_MlDsaKey_MakeKey(key, server->crypto->rng);
+                ret = wc_MlDsaKey_MakeKey(key, ctx->crypto->rng);
                 if (ret == 0) {
                     /* Check incoming flags */
-                    if (req->flags & WH_NVM_FLAGS_EPHEMERAL) {
+                    if (req.flags & WH_NVM_FLAGS_EPHEMERAL) {
                         /* Must serialize the key into client memory */
                         ret = wh_Server_DmaProcessClientAddress(
-                            server, req->key.addr, &clientOutAddr, req->key.sz,
+                            ctx, req.key.addr, &clientOutAddr, req.key.sz,
                             WH_DMA_OPER_CLIENT_WRITE_PRE,
                             (whServerDmaFlags){0});
 
                         if (ret == 0) {
                             ret = wh_Crypto_MlDsaSerializeKeyDer(
-                                key, req->key.sz, clientOutAddr, &keySize);
+                                key, req.key.sz, clientOutAddr, &keySize);
                             if (ret == 0) {
-                                res->keyId   = WH_KEYID_ERASED;
-                                res->keySize = keySize;
+                                res.keyId   = WH_KEYID_ERASED;
+                                res.keySize = keySize;
                             }
                         }
 
                         if (ret == 0) {
                             ret = wh_Server_DmaProcessClientAddress(
-                                server, req->key.addr, &clientOutAddr, keySize,
+                                ctx, req.key.addr, &clientOutAddr, keySize,
                                 WH_DMA_OPER_CLIENT_WRITE_POST,
                                 (whServerDmaFlags){0});
                         }
@@ -2062,11 +2490,11 @@ static int _HandleMlDsaKeyGenDma(whServerContext* server, whPacket* packet,
                          */
                         whKeyId keyId =
                             WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
-                                          server->comm->client_id, req->keyId);
+                                          ctx->comm->client_id, req.keyId);
 
                         if (WH_KEYID_ISERASED(keyId)) {
                             /* Generate a new id */
-                            ret = hsmGetUniqueId(server, &keyId);
+                            ret = hsmGetUniqueId(ctx, &keyId);
 #ifdef DEBUG_CRYPTOCB
                             printf("[server] %s UniqueId: keyId:%u, ret:%d\n",
                                    __func__, keyId, ret);
@@ -2075,17 +2503,16 @@ static int _HandleMlDsaKeyGenDma(whServerContext* server, whPacket* packet,
 
                         if (ret == 0) {
                             ret = wh_Server_MlDsaKeyCacheImport(
-                                server, key, keyId, req->flags, req->labelSize,
-                                req->label);
+                                ctx, key, keyId, req.flags, req.labelSize,
+                                req.label);
 #ifdef DEBUG_CRYPTOCB
                             printf(
                                 "[server] %s CacheImport: keyId:%u, ret:%d\n",
                                 __func__, keyId, ret);
 #endif
                             if (ret == 0) {
-                                res->keyId   = WH_KEYID_ID(keyId);
-                                res->keySize = keySize;
-                                *size = WH_PACKET_STUB_SIZE + sizeof(res);
+                                res.keyId   = WH_KEYID_ID(keyId);
+                                res.keySize = keySize;
                             }
                         }
                     }
@@ -2096,20 +2523,30 @@ static int _HandleMlDsaKeyGenDma(whServerContext* server, whPacket* packet,
     }
 
     if (ret == WH_ERROR_ACCESS) {
-        res->dmaAddrStatus.badAddr = req->key;
+        res.dmaAddrStatus.badAddr = req.key;
     }
+
+    /* Translate the response */
+    (void)wh_MessageCrypto_TranslateMlDsaKeyGenDmaResponse(
+        magic, &res, (whMessageCrypto_MlDsaKeyGenDmaResponse*)cryptoDataOut);
+
+    *outSize = sizeof(res);
 
     return ret;
 #endif /* WOLFSSL_DILITHIUM_NO_MAKE_KEY */
 }
 
-static int _HandleMlDsaSignDma(whServerContext* ctx, whPacket* packet,
-                               uint16_t* out_size)
+static int _HandleMlDsaSignDma(whServerContext* ctx, uint16_t magic,
+                               const void* cryptoDataIn, uint16_t inSize,
+                               void* cryptoDataOut, uint16_t* outSize)
 {
 #ifdef WOLFSSL_DILITHIUM_NO_SIGN
     (void)ctx;
-    (void)packet;
-    (void)out_size;
+    (void)magic;
+    (void)cryptoDataIn;
+    (void)inSize;
+    (void)cryptoDataOut;
+    (void)outSize;
     return WH_ERROR_NOHANDLER;
 #else
     int      ret = 0;
@@ -2117,86 +2554,103 @@ static int _HandleMlDsaSignDma(whServerContext* ctx, whPacket* packet,
     void*    msgAddr = NULL;
     void*    sigAddr = NULL;
 
-    wh_Packet_pq_mldsa_sign_Dma_req* req = &packet->pqMldsaSignDmaReq;
-    wh_Packet_pq_mldsa_sign_Dma_res* res = &packet->pqMldsaSignDmaRes;
+    whMessageCrypto_MlDsaSignDmaRequest req;
+    whMessageCrypto_MlDsaSignDmaResponse res;
+
+    /* Translate the request */
+    ret = wh_MessageCrypto_TranslateMlDsaSignDmaRequest(
+        magic, (whMessageCrypto_MlDsaSignDmaRequest*)cryptoDataIn, &req);
+    if (ret != WH_ERROR_OK) {
+        return ret;
+    }
 
     /* Transaction state */
     whKeyId key_id;
     int     evict = 0;
 
-    if (ctx == NULL || packet == NULL || out_size == NULL) {
-        return WH_ERROR_BADARGS;
-    }
 
     /* Get key ID and evict flag */
-    key_id = WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id, req->keyId);
-    evict  = !!(req->options & WH_PACKET_PQ_MLDSA_SIGN_OPTIONS_EVICT);
+    key_id = WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id, req.keyId);
+    evict  = !!(req.options & WH_MESSAGE_CRYPTO_MLDSA_SIGN_OPTIONS_EVICT);
 
     /* Initialize key */
     ret = wc_MlDsaKey_Init(key, NULL, ctx->crypto->devId);
-    if (ret != 0) {
-        return ret;
-    }
-
-    /* Export key from cache */
-    /* TODO: sanity check security level against key pulled from cache? */
-    ret = wh_Server_MlDsaKeyCacheExport(ctx, key_id, key);
     if (ret == 0) {
-        /* Process client message buffer address */
-        ret = wh_Server_DmaProcessClientAddress(
-            ctx, (uintptr_t)req->msg.addr, &msgAddr, req->msg.sz,
-            WH_DMA_OPER_CLIENT_READ_PRE, (whServerDmaFlags){0});
-
+        /* Export key from cache */
+        /* TODO: sanity check security level against key pulled from cache? */
+        ret = wh_Server_MlDsaKeyCacheExport(ctx, key_id, key);
         if (ret == 0) {
-            /* Process client signature buffer address */
+            /* Process client message buffer address */
             ret = wh_Server_DmaProcessClientAddress(
-                ctx, (uintptr_t)req->sig.addr, &sigAddr, req->sig.sz,
-                WH_DMA_OPER_CLIENT_WRITE_PRE, (whServerDmaFlags){0});
+                ctx, (uintptr_t)req.msg.addr, &msgAddr, req.msg.sz,
+                WH_DMA_OPER_CLIENT_READ_PRE, (whServerDmaFlags){0});
 
             if (ret == 0) {
-                /* Sign the message */
-                word32 sigLen = req->sig.sz;
-                ret           = wc_MlDsaKey_Sign(key, sigAddr, &sigLen, msgAddr,
-                                                 req->msg.sz, ctx->crypto->rng);
+                /* Process client signature buffer address */
+                ret = wh_Server_DmaProcessClientAddress(
+                    ctx, (uintptr_t)req.sig.addr, &sigAddr, req.sig.sz,
+                    WH_DMA_OPER_CLIENT_WRITE_PRE, (whServerDmaFlags){0});
 
                 if (ret == 0) {
-                    /* Post-write processing of signature buffer */
-                    ret = wh_Server_DmaProcessClientAddress(
-                        ctx, (uintptr_t)req->sig.addr, &sigAddr, sigLen,
-                        WH_DMA_OPER_CLIENT_WRITE_POST, (whServerDmaFlags){0});
+                    /* Sign the message */
+                    word32 sigLen = req.sig.sz;
+                    ret = wc_MlDsaKey_Sign(key, sigAddr, &sigLen, msgAddr,
+                                           req.msg.sz, ctx->crypto->rng);
 
                     if (ret == 0) {
-                        /* Set response signature length */
-                        res->sigLen = sigLen;
-                        *out_size   = WH_PACKET_STUB_SIZE + sizeof(*res);
-                    }
+                        /* Post-write processing of signature buffer */
+                        ret = wh_Server_DmaProcessClientAddress(
+                            ctx, (uintptr_t)req.sig.addr, &sigAddr, sigLen,
+                            WH_DMA_OPER_CLIENT_WRITE_POST,
+                            (whServerDmaFlags){0});
 
-                    /* Post-read processing of message buffer */
-                    ret = wh_Server_DmaProcessClientAddress(
-                        ctx, (uintptr_t)req->msg.addr, &msgAddr, req->msg.sz,
-                        WH_DMA_OPER_CLIENT_READ_POST, (whServerDmaFlags){0});
+                        if (ret == 0) {
+                            /* Set response signature length */
+                            res.sigLen = sigLen;
+                            *outSize   = sizeof(res);
+                        }
+
+                        /* Post-read processing of message buffer */
+                        ret = wh_Server_DmaProcessClientAddress(
+                            ctx, (uintptr_t)req.msg.addr, &msgAddr,
+                            req.msg.sz, WH_DMA_OPER_CLIENT_READ_POST,
+                            (whServerDmaFlags){0});
+                    }
                 }
             }
-        }
 
-        /* Evict key if requested */
-        if (evict) {
-            (void)hsmEvictKey(ctx, key_id);
+            /* Evict key if requested */
+            if (evict) {
+                (void)hsmEvictKey(ctx, key_id);
+            }
         }
+        wc_MlDsaKey_Free(key);
     }
 
-    wc_MlDsaKey_Free(key);
+    if (ret == 0) {
+
+        /* Translate the response */
+        (void)wh_MessageCrypto_TranslateMlDsaSignDmaResponse(
+            magic, &res, (whMessageCrypto_MlDsaSignDmaResponse*)cryptoDataOut);
+
+        *outSize = sizeof(res);
+    }
+
     return ret;
 #endif /* WOLFSSL_DILITHIUM_NO_SIGN */
 }
 
-static int _HandleMlDsaVerifyDma(whServerContext* ctx, whPacket* packet,
-        uint16_t* out_size)
+static int _HandleMlDsaVerifyDma(whServerContext* ctx, uint16_t magic,
+                                 const void* cryptoDataIn, uint16_t inSize,
+                                 void* cryptoDataOut, uint16_t* outSize)
 {
 #ifdef WOLFSSL_DILITHIUM_NO_VERIFY
     (void)ctx;
-    (void)packet;
-    (void)out_size;
+    (void)magic;
+    (void)cryptoDataIn;
+    (void)inSize;
+    (void)cryptoDataOut;
+    (void)outSize;
     return WH_ERROR_NOHANDLER;
 #else
     int      ret = 0;
@@ -2205,20 +2659,23 @@ static int _HandleMlDsaVerifyDma(whServerContext* ctx, whPacket* packet,
     void*    sigAddr  = NULL;
     int      verified = 0;
 
-    wh_Packet_pq_mldsa_verify_Dma_req* req = &packet->pqMldsaVerifyDmaReq;
-    wh_Packet_pq_mldsa_verify_Dma_res* res = &packet->pqMldsaVerifyDmaRes;
+    whMessageCrypto_MlDsaVerifyDmaRequest req;
+    whMessageCrypto_MlDsaVerifyDmaResponse res;
+
+    /* Translate the request */
+    ret = wh_MessageCrypto_TranslateMlDsaVerifyDmaRequest(
+        magic, (whMessageCrypto_MlDsaVerifyDmaRequest*)cryptoDataIn, &req);
+    if (ret != WH_ERROR_OK) {
+        return ret;
+    }
 
     /* Transaction state */
     whKeyId key_id;
     int     evict = 0;
 
-    if (ctx == NULL || packet == NULL || out_size == NULL) {
-        return WH_ERROR_BADARGS;
-    }
-
     /* Get key ID and evict flag */
-    key_id = WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id, req->keyId);
-    evict  = !!(req->options & WH_PACKET_PQ_MLDSAVERIFY_OPTIONS_EVICT);
+    key_id = WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, ctx->comm->client_id, req.keyId);
+    evict  = !!(req.options & WH_MESSAGE_CRYPTO_MLDSA_VERIFY_OPTIONS_EVICT);
 
     /* Initialize key */
     ret = wc_MlDsaKey_Init(key, NULL, ctx->crypto->devId);
@@ -2231,37 +2688,36 @@ static int _HandleMlDsaVerifyDma(whServerContext* ctx, whPacket* packet,
     if (ret == 0) {
         /* Process client signature buffer address */
         ret = wh_Server_DmaProcessClientAddress(
-            ctx, (uintptr_t)req->sig.addr, &sigAddr, req->sig.sz,
+            ctx, (uintptr_t)req.sig.addr, &sigAddr, req.sig.sz,
             WH_DMA_OPER_CLIENT_READ_PRE, (whServerDmaFlags){0});
 
         if (ret == 0) {
             /* Process client message buffer address */
             ret = wh_Server_DmaProcessClientAddress(
-                ctx, (uintptr_t)req->msg.addr, &msgAddr, req->msg.sz,
+                ctx, (uintptr_t)req.msg.addr, &msgAddr, req.msg.sz,
                 WH_DMA_OPER_CLIENT_READ_PRE, (whServerDmaFlags){0});
 
             if (ret == 0) {
                 /* Verify the signature */
-                ret = wc_MlDsaKey_Verify(key, sigAddr, req->sig.sz, msgAddr,
-                                         req->msg.sz, &verified);
+                ret = wc_MlDsaKey_Verify(key, sigAddr, req.sig.sz, msgAddr,
+                                         req.msg.sz, &verified);
 
                 if (ret == 0) {
                     /* Post-read processing of signature buffer */
                     ret = wh_Server_DmaProcessClientAddress(
-                        ctx, (uintptr_t)req->sig.addr, &sigAddr, req->sig.sz,
+                        ctx, (uintptr_t)req.sig.addr, &sigAddr, req.sig.sz,
                         WH_DMA_OPER_CLIENT_READ_POST, (whServerDmaFlags){0});
 
                     if (ret == 0) {
                         /* Post-read processing of message buffer */
                         ret = wh_Server_DmaProcessClientAddress(
-                            ctx, (uintptr_t)req->msg.addr, &msgAddr,
-                            req->msg.sz, WH_DMA_OPER_CLIENT_READ_POST,
+                            ctx, (uintptr_t)req.msg.addr, &msgAddr,
+                            req.msg.sz, WH_DMA_OPER_CLIENT_READ_POST,
                             (whServerDmaFlags){0});
 
                         if (ret == 0) {
                             /* Set verification result */
-                            res->verifyResult = verified;
-                            *out_size = WH_PACKET_STUB_SIZE + sizeof(*res);
+                            res.verifyResult = verified;
                         }
                     }
                 }
@@ -2274,42 +2730,63 @@ static int _HandleMlDsaVerifyDma(whServerContext* ctx, whPacket* packet,
         }
     }
 
+    if (ret == 0) {
+        /* Translate the response */
+        (void)wh_MessageCrypto_TranslateMlDsaVerifyDmaResponse(
+            magic, &res,
+            (whMessageCrypto_MlDsaVerifyDmaResponse*)cryptoDataOut);
+
+        *outSize = sizeof(res);
+    }
+
     wc_MlDsaKey_Free(key);
     return ret;
 #endif /* WOLFSSL_DILITHIUM_NO_VERIFY */
 }
 
-static int _HandleMlDsaCheckPrivKeyDma(whServerContext* server, whPacket* packet,
-                                        uint16_t* size)
+static int _HandleMlDsaCheckPrivKeyDma(whServerContext* ctx, uint16_t magic,
+                                       const void* cryptoDataIn,
+                                       uint16_t inSize, void* cryptoDataOut,
+                                       uint16_t* outSize)
 {
     return WH_ERROR_NOHANDLER;
 }
 #endif /* HAVE_DILITHIUM */
 
 #if defined(HAVE_DILITHIUM) || defined(HAVE_FALCON)
-static int _HandlePqcSigAlgorithmDma(whServerContext* server, whPacket* packet,
-                                     uint16_t* size)
+static int _HandlePqcSigAlgorithmDma(whServerContext* ctx, uint16_t magic,
+                                     const void* cryptoDataIn,
+                                     uint16_t cryptoInSize, void* cryptoDataOut,
+                                     uint16_t* cryptoOutSize,
+                                     uint32_t pkAlgoType, uint32_t pqAlgoType)
 {
-    int                      ret = WH_ERROR_NOHANDLER;
-    wh_Packet_pk_pq_any_req* req = &packet->pkPqAnyReq;
+    int ret = WH_ERROR_NOHANDLER;
 
     /* Dispatch the appropriate algorithm handler based on the requested PK type
      * and the algorithm type. */
-    switch (req->pqAlgoType) {
+    switch (pqAlgoType) {
 #ifdef HAVE_DILITHIUM
         case WC_PQC_SIG_TYPE_DILITHIUM: {
-            switch (req->type) {
+            switch (pkAlgoType) {
                 case WC_PK_TYPE_PQC_SIG_KEYGEN:
-                    ret = _HandleMlDsaKeyGenDma(server, packet, size);
+                    ret = _HandleMlDsaKeyGenDma(ctx, magic, cryptoDataIn,
+                                                cryptoInSize, cryptoDataOut,
+                                                cryptoOutSize);
                     break;
                 case WC_PK_TYPE_PQC_SIG_SIGN:
-                    ret = _HandleMlDsaSignDma(server, packet, size);
+                    ret = _HandleMlDsaSignDma(ctx, magic, cryptoDataIn,
+                                              cryptoInSize, cryptoDataOut,
+                                              cryptoOutSize);
                     break;
                 case WC_PK_TYPE_PQC_SIG_VERIFY:
-                    ret = _HandleMlDsaVerifyDma(server, packet, size);
+                    ret = _HandleMlDsaVerifyDma(ctx, magic, cryptoDataIn,
+                                                cryptoInSize, cryptoDataOut,
+                                                cryptoOutSize);
                     break;
                 case WC_PK_TYPE_PQC_SIG_CHECK_PRIV_KEY:
-                    ret = _HandleMlDsaCheckPrivKeyDma(server, packet, size);
+                    ret = _HandleMlDsaCheckPrivKeyDma(
+                        ctx, magic, cryptoDataIn, cryptoInSize, cryptoDataOut,
+                        cryptoOutSize);
                     break;
                 default:
                     ret = WH_ERROR_NOHANDLER;
@@ -2327,13 +2804,22 @@ static int _HandlePqcSigAlgorithmDma(whServerContext* server, whPacket* packet,
 #endif /* HAVE_DILITHIUM || HAVE_FALCON */
 
 #ifdef WOLFSSL_CMAC
-static int _HandleCmacDma(whServerContext* server, whPacket* packet,
-                          uint16_t* size)
+static int _HandleCmacDma(whServerContext* ctx, uint16_t magic, uint16_t seq,
+                          const void* cryptoDataIn, uint16_t inSize,
+                          void* cryptoDataOut, uint16_t* outSize)
 {
     int ret = 0;
-    wh_Packet_cmac_Dma_req* req  = &packet->cmacDmaReq;
-    wh_Packet_cmac_Dma_res* res  = &packet->cmacDmaRes;
-    Cmac*                   cmac = server->crypto->algoCtx.cmac;
+    whMessageCrypto_CmacDmaRequest req;
+    whMessageCrypto_CmacDmaResponse res;
+
+    /* Translate request */
+    ret = wh_MessageCrypto_TranslateCmacDmaRequest(
+        magic, (whMessageCrypto_CmacDmaRequest*)cryptoDataIn, &req);
+    if (ret != WH_ERROR_OK) {
+        return ret;
+    }
+
+    Cmac*                   cmac = ctx->crypto->algoCtx.cmac;
     int                     clientDevId;
     whKeyId                 keyId;
     byte                    tmpKey[AES_256_KEY_SIZE];
@@ -2351,211 +2837,223 @@ static int _HandleCmacDma(whServerContext* server, whPacket* packet,
     word32 outSz   = 0;
 
     /* Ensure state sizes are the same */
-    if (req->state.sz != sizeof(*cmac)) {
-        res->dmaAddrStatus.badAddr = req->state;
-        return WH_ERROR_BADARGS;
+    if (req.state.sz != sizeof(*cmac)) {
+        res.dmaAddrStatus.badAddr = req.state;
+        ret = WH_ERROR_BADARGS;
     }
 
-    /* Copy the CMAC context from client address space */
-    ret = whServerDma_CopyFromClient(server, cmac, req->state.addr,
-                                     req->state.sz, (whServerDmaFlags){0});
-    if (ret != WH_ERROR_OK) {
-        res->dmaAddrStatus.badAddr = req->state;
-        return ret;
-    }
-    /* Save the client devId to be restored later */
-    clientDevId = cmac->devId;
-    /* overwrite the devId to that of the server for local crypto */
-    cmac->devId = server->crypto->devId;
-
-    /* Print out the state of req */
-#ifdef DEBUG_CRYPTOCB_VERBOSE
-    printf("[server] DMA CMAC req recv. type:%u keySz:%u inSz:%u outSz:%u "
-           "finalize:%u\n",
-           (unsigned int)req->type, (unsigned int)req->key.sz,
-           (unsigned int)req->input.sz, (unsigned int)req->output.sz,
-           (unsigned int)req->finalize);
-#endif
-
-    /* Translate all DMA addresses upfront */
-    if (req->input.sz != 0) {
-        ret = wh_Server_DmaProcessClientAddress(
-            server, req->input.addr, &inAddr, req->input.sz,
-            WH_DMA_OPER_CLIENT_READ_PRE, (whServerDmaFlags){0});
-        if (ret == WH_ERROR_ACCESS) {
-            res->dmaAddrStatus.badAddr = req->input;
-        }
-    }
-    if (ret == WH_ERROR_OK && req->output.sz != 0) {
-        ret = wh_Server_DmaProcessClientAddress(
-            server, req->output.addr, &outAddr, req->output.sz,
-            WH_DMA_OPER_CLIENT_WRITE_PRE, (whServerDmaFlags){0});
-        if (ret == WH_ERROR_ACCESS) {
-            res->dmaAddrStatus.badAddr = req->output;
-        }
-    }
-    if (ret == WH_ERROR_OK && req->key.sz != 0) {
-        ret = wh_Server_DmaProcessClientAddress(
-            server, req->key.addr, &keyAddr, req->key.sz,
-            WH_DMA_OPER_CLIENT_READ_PRE, (whServerDmaFlags){0});
-        if (ret == WH_ERROR_ACCESS) {
-            res->dmaAddrStatus.badAddr = req->key;
+    if (ret == WH_ERROR_OK) {
+        /* Copy the CMAC context from client address space */
+        ret = whServerDma_CopyFromClient(ctx, cmac, req.state.addr,
+                                         req.state.sz, (whServerDmaFlags){0});
+        if (ret != WH_ERROR_OK) {
+            res.dmaAddrStatus.badAddr = req.state;
         }
     }
 
     if (ret == WH_ERROR_OK) {
-        /* Check for one-shot operation (both input and output are non-NULL).
-         * There are three distinct cases we need to handle for one-shots:
-         * 1. Direct one-shot operation with key provided in request
-         * 2. One-shot operation with key referenced by context that needs to be
-         *     loaded from cache
-         * 3. One-shot operation with context already initialized with a key */
-        if (req->input.sz != 0 && req->output.sz != 0) {
+        /* Save the client devId to be restored later */
+        clientDevId = cmac->devId;
+        /* overwrite the devId to that of the server for local crypto */
+        cmac->devId = ctx->crypto->devId;
+
+        /* Print out the state of req */
 #ifdef DEBUG_CRYPTOCB_VERBOSE
-            printf("[server] CMAC one-shot operation detected\n");
+        printf("[server] DMA CMAC req recv. type:%u keySz:%u inSz:%u outSz:%u "
+               "finalize:%u\n",
+               (unsigned int)req.type, (unsigned int)req.key.sz,
+               (unsigned int)req.input.sz, (unsigned int)req.output.sz,
+               (unsigned int)req.finalize);
 #endif
 
-            /* Case 1: Direct one-shot operation with key provided in request
-             * This is the simplest case - we have the key directly and can use
-             * it immediately for the CMAC operation */
-            if (req->key.sz != 0) {
-                outSz = req->output.sz;
-                /* Perform one-shot CMAC operation with provided key */
-                ret = wc_AesCmacGenerate_ex(cmac, outAddr, &outSz, inAddr,
-                                            req->input.sz, keyAddr, req->key.sz,
-                                            NULL, server->crypto->devId);
-                cmacFinalized = 1;
-                res->outSz    = outSz;
+        /* Translate all DMA addresses upfront */
+        if (req.input.sz != 0) {
+            ret = wh_Server_DmaProcessClientAddress(
+                ctx, req.input.addr, &inAddr, req.input.sz,
+                WH_DMA_OPER_CLIENT_READ_PRE, (whServerDmaFlags){0});
+            if (ret == WH_ERROR_ACCESS) {
+                res.dmaAddrStatus.badAddr = req.input;
             }
-            /* Case 2 & 3: One-shot operation with key referenced by context
-             * We need to check if the context is already initialized or needs
-             * to be initialized with a key from cache */
-            else {
-                /* Check if there's a keyID in the context that we need to load
-                 */
-                whKeyId clientKeyId = WH_DEVCTX_TO_KEYID(cmac->devCtx);
-                if (clientKeyId != WH_KEYID_ERASED) {
-                    /* Case 2: Client-supplied context references a key ID that
-                     * needs to be loaded from cache This happens when the
-                     * client invokes the one-shot generate on a context that
-                     * has been initialized to use a keyId by reference. We need
-                     * to load the key from cache and initialize a new context
-                     * with it */
-                    keyId  = WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
-                                           server->comm->client_id, clientKeyId);
-                    keyLen = sizeof(tmpKey);
+        }
+        if (ret == WH_ERROR_OK && req.output.sz != 0) {
+            ret = wh_Server_DmaProcessClientAddress(
+                ctx, req.output.addr, &outAddr, req.output.sz,
+                WH_DMA_OPER_CLIENT_WRITE_PRE, (whServerDmaFlags){0});
+            if (ret == WH_ERROR_ACCESS) {
+                res.dmaAddrStatus.badAddr = req.output;
+            }
+        }
+        if (ret == WH_ERROR_OK && req.key.sz != 0) {
+            ret = wh_Server_DmaProcessClientAddress(
+                ctx, req.key.addr, &keyAddr, req.key.sz,
+                WH_DMA_OPER_CLIENT_READ_PRE, (whServerDmaFlags){0});
+            if (ret == WH_ERROR_ACCESS) {
+                res.dmaAddrStatus.badAddr = req.key;
+            }
+        }
 
-                    /* Load key from cache */
-                    ret = hsmReadKey(server, keyId, NULL, tmpKey, &keyLen);
-                    if (ret == WH_ERROR_OK) {
-                        /* Verify key size is valid for AES */
-                        if (keyLen != AES_128_KEY_SIZE &&
-                            keyLen != AES_192_KEY_SIZE &&
-                            keyLen != AES_256_KEY_SIZE) {
-                            ret = WH_ERROR_ABORTED;
+        if (ret == WH_ERROR_OK) {
+            /* Check for one-shot operation (both input and output are
+             * non-NULL). There are three distinct cases we need to handle for
+             * one-shots:
+             * 1. Direct one-shot operation with key provided in request
+             * 2. One-shot operation with key referenced by context that needs
+             * to be loaded from cache
+             * 3. One-shot operation with context already initialized with a key
+             */
+            if (req.input.sz != 0 && req.output.sz != 0) {
+#ifdef DEBUG_CRYPTOCB_VERBOSE
+                printf("[server] CMAC one-shot operation detected\n");
+#endif
+
+                /* Case 1: Direct one-shot operation with key provided in
+                 * request This is the simplest case - we have the key directly
+                 * and can use it immediately for the CMAC operation */
+                if (req.key.sz != 0) {
+                    outSz = req.output.sz;
+                    /* Perform one-shot CMAC operation with provided key */
+                    ret = wc_AesCmacGenerate_ex(
+                        cmac, outAddr, &outSz, inAddr, req.input.sz, keyAddr,
+                        req.key.sz, NULL, ctx->crypto->devId);
+                    cmacFinalized = 1;
+                    res.outSz    = outSz;
+                }
+                /* Case 2 & 3: One-shot operation with key referenced by context
+                 * We need to check if the context is already initialized or
+                 * needs to be initialized with a key from cache */
+                else {
+                    /* Check if there's a keyID in the context that we need to
+                     * load
+                     */
+                    whKeyId clientKeyId = WH_DEVCTX_TO_KEYID(cmac->devCtx);
+                    if (clientKeyId != WH_KEYID_ERASED) {
+                        /* Case 2: Client-supplied context references a key ID
+                         * that needs to be loaded from cache This happens when
+                         * the client invokes the one-shot generate on a context
+                         * that has been initialized to use a keyId by
+                         * reference. We need to load the key from cache and
+                         * initialize a new context with it */
+                        keyId =
+                            WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
+                                          ctx->comm->client_id, clientKeyId);
+                        keyLen = sizeof(tmpKey);
+
+                        /* Load key from cache */
+                        ret = hsmReadKey(ctx, keyId, NULL, tmpKey, &keyLen);
+                        if (ret == WH_ERROR_OK) {
+                            /* Verify key size is valid for AES */
+                            if (keyLen != AES_128_KEY_SIZE &&
+                                keyLen != AES_192_KEY_SIZE &&
+                                keyLen != AES_256_KEY_SIZE) {
+                                ret = WH_ERROR_ABORTED;
+                            }
+                            else {
+                                /* Initialize CMAC with loaded key */
+                                ctxHoldsLocalKey = 1;
+                                ret = wc_InitCmac_ex(cmac, tmpKey, keyLen,
+                                                     WC_CMAC_AES, NULL, NULL,
+                                                     ctx->crypto->devId);
+                                if (ret == WH_ERROR_OK) {
+                                    /* Perform one-shot CMAC operation */
+                                    outSz = req.output.sz;
+                                    ret   = wc_AesCmacGenerate_ex(
+                                        cmac, outAddr, &outSz, inAddr,
+                                        req.input.sz, NULL, 0, NULL,
+                                        ctx->crypto->devId);
+                                    res.outSz    = outSz;
+                                    cmacFinalized = 1;
+                                }
+                            }
                         }
-                        else {
-                            /* Initialize CMAC with loaded key */
-                            ctxHoldsLocalKey = 1;
-                            ret = wc_InitCmac_ex(cmac, tmpKey, keyLen,
-                                                 WC_CMAC_AES, NULL, NULL,
-                                                 server->crypto->devId);
-                            if (ret == WH_ERROR_OK) {
-                                /* Perform one-shot CMAC operation */
-                                outSz = req->output.sz;
-                                ret   = wc_AesCmacGenerate_ex(
-                                    cmac, outAddr, &outSz, inAddr,
-                                    req->input.sz, NULL, 0, NULL,
-                                    server->crypto->devId);
-                                res->outSz    = outSz;
-                                cmacFinalized = 1;
+                    }
+                    else {
+                        /* Case 3: Context is already initialized with a key
+                         * This happens when invoking the one-shot generate on a
+                         * context that has been initialized with a previous
+                         * wc_InitCmac_ex call where the key was already loaded
+                         * into the context. We can use the context directly
+                         * without needing to load or initialize anything */
+                        outSz = req.output.sz;
+                        ret   = wc_AesCmacGenerate_ex(
+                            cmac, outAddr, &outSz, inAddr, req.input.sz, NULL,
+                            0, NULL, ctx->crypto->devId);
+                        res.outSz    = outSz;
+                        cmacFinalized = 1;
+                    }
+                }
+            }
+            /* Otherwise, process the request as an incremental operation */
+            else {
+                /* Incremental: Initialize CMAC with key if provided */
+                if (req.key.sz != 0) {
+                    ret = wc_InitCmac_ex(cmac, keyAddr, req.key.sz, req.type,
+                                         NULL, NULL, ctx->crypto->devId);
+                }
+                /* Check for deferred initialization with cached key */
+                else if (req.input.sz != 0 || req.finalize) {
+                    /* Check if there's a key ID in the context that needs to be
+                     * loaded
+                     */
+                    whNvmId nvmId = WH_DEVCTX_TO_KEYID(cmac->devCtx);
+                    if (nvmId != WH_KEYID_ERASED) {
+                        /* Get key ID from CMAC context */
+                        keyId  = WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
+                                               ctx->comm->client_id, nvmId);
+                        keyLen = sizeof(tmpKey);
+
+                        /* Load key from cache */
+                        ret = hsmReadKey(ctx, keyId, NULL, tmpKey, &keyLen);
+                        if (ret == WH_ERROR_OK) {
+                            /* Verify key size is valid for AES */
+                            if (keyLen != AES_128_KEY_SIZE &&
+                                keyLen != AES_192_KEY_SIZE &&
+                                keyLen != AES_256_KEY_SIZE) {
+                                ret = WH_ERROR_ABORTED;
+                            }
+                            else {
+                                ctxHoldsLocalKey = 1;
+
+                                /* Save CMAC state so we can resume operation
+                                 * after initialization with key, as reinit will
+                                 * clear the state */
+                                byte   savedBuffer[AES_BLOCK_SIZE];
+                                byte   savedDigest[AES_BLOCK_SIZE];
+                                word32 savedBufferSz = cmac->bufferSz;
+                                word32 savedTotalSz  = cmac->totalSz;
+                                memcpy(savedBuffer, cmac->buffer,
+                                       AES_BLOCK_SIZE);
+                                memcpy(savedDigest, cmac->digest,
+                                       AES_BLOCK_SIZE);
+
+                                ret = wc_InitCmac_ex(cmac, tmpKey, keyLen,
+                                                     WC_CMAC_AES, NULL, NULL,
+                                                     ctx->crypto->devId);
+
+                                /* Restore CMAC state */
+                                memcpy(cmac->buffer, savedBuffer,
+                                       AES_BLOCK_SIZE);
+                                memcpy(cmac->digest, savedDigest,
+                                       AES_BLOCK_SIZE);
+                                cmac->bufferSz = savedBufferSz;
+                                cmac->totalSz  = savedTotalSz;
+                                cmac->devCtx   = (void*)(uintptr_t)nvmId;
                             }
                         }
                     }
                 }
-                else {
-                    /* Case 3: Context is already initialized with a key
-                     * This happens when invoking the one-shot generate on a
-                     * context that has been initialized with a previous
-                     * wc_InitCmac_ex call where the key was already loaded into
-                     * the context. We can use the context directly without
-                     * needing to load or initialize anything */
-                    outSz = req->output.sz;
-                    ret   = wc_AesCmacGenerate_ex(cmac, outAddr, &outSz, inAddr,
-                                                  req->input.sz, NULL, 0, NULL,
-                                                  server->crypto->devId);
-                    res->outSz    = outSz;
+
+                /* Process update if requested */
+                if (ret == WH_ERROR_OK && req.input.sz != 0) {
+                    ret = wc_CmacUpdate(cmac, inAddr, req.input.sz);
+                }
+
+                /* Process finalize if requested */
+                if (ret == WH_ERROR_OK && req.finalize) {
+                    word32 len    = (word32)req.output.sz;
+                    ret           = wc_CmacFinal(cmac, outAddr, &len);
                     cmacFinalized = 1;
+                    res.outSz    = len;
                 }
-            }
-        }
-        /* Otherwise, process the request as an incremental operation */
-        else {
-            /* Incremental: Initialize CMAC with key if provided */
-            if (req->key.sz != 0) {
-                ret = wc_InitCmac_ex(cmac, keyAddr, req->key.sz, req->type,
-                                     NULL, NULL, server->crypto->devId);
-            }
-            /* Check for deferred initialization with cached key */
-            else if (req->input.sz != 0 || req->finalize) {
-                /* Check if there's a key ID in the context that needs to be
-                 * loaded
-                 */
-                whNvmId nvmId = WH_DEVCTX_TO_KEYID(cmac->devCtx);
-                if (nvmId != WH_KEYID_ERASED) {
-                    /* Get key ID from CMAC context */
-                    keyId  = WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
-                                           server->comm->client_id, nvmId);
-                    keyLen = sizeof(tmpKey);
-
-                    /* Load key from cache */
-                    ret = hsmReadKey(server, keyId, NULL, tmpKey, &keyLen);
-                    if (ret == WH_ERROR_OK) {
-                        /* Verify key size is valid for AES */
-                        if (keyLen != AES_128_KEY_SIZE &&
-                            keyLen != AES_192_KEY_SIZE &&
-                            keyLen != AES_256_KEY_SIZE) {
-                            ret = WH_ERROR_ABORTED;
-                        }
-                        else {
-                            ctxHoldsLocalKey = 1;
-
-                            /* Save CMAC state so we can resume operation after
-                             * initialization with key, as reinit will clear the
-                             * state */
-                            byte   savedBuffer[AES_BLOCK_SIZE];
-                            byte   savedDigest[AES_BLOCK_SIZE];
-                            word32 savedBufferSz = cmac->bufferSz;
-                            word32 savedTotalSz  = cmac->totalSz;
-                            memcpy(savedBuffer, cmac->buffer, AES_BLOCK_SIZE);
-                            memcpy(savedDigest, cmac->digest, AES_BLOCK_SIZE);
-
-                            ret = wc_InitCmac_ex(cmac, tmpKey, keyLen,
-                                                 WC_CMAC_AES, NULL, NULL,
-                                                 server->crypto->devId);
-
-                            /* Restore CMAC state */
-                            memcpy(cmac->buffer, savedBuffer, AES_BLOCK_SIZE);
-                            memcpy(cmac->digest, savedDigest, AES_BLOCK_SIZE);
-                            cmac->bufferSz = savedBufferSz;
-                            cmac->totalSz  = savedTotalSz;
-                            cmac->devCtx   = (void*)(uintptr_t)nvmId;
-                        }
-                    }
-                }
-            }
-
-            /* Process update if requested */
-            if (ret == WH_ERROR_OK && req->input.sz != 0) {
-                ret = wc_CmacUpdate(cmac, inAddr, req->input.sz);
-            }
-
-            /* Process finalize if requested */
-            if (ret == WH_ERROR_OK && req->finalize) {
-                word32 len    = (word32)req->output.sz;
-                ret           = wc_CmacFinal(cmac, outAddr, &len);
-                cmacFinalized = 1;
-                res->outSz    = len;
             }
         }
     }
@@ -2563,7 +3061,7 @@ static int _HandleCmacDma(whServerContext* server, whPacket* packet,
     /* Clean up all DMA addresses */
     if (inAddr != NULL) {
         if (wh_Server_DmaProcessClientAddress(
-                server, req->input.addr, &inAddr, req->input.sz,
+                ctx, req.input.addr, &inAddr, req.input.sz,
                 WH_DMA_OPER_CLIENT_READ_POST,
                 (whServerDmaFlags){0}) != WH_ERROR_OK) {
 #ifdef DEBUG_CRYPTOCB_VERBOSE
@@ -2574,7 +3072,7 @@ static int _HandleCmacDma(whServerContext* server, whPacket* packet,
 
     if (outAddr != NULL) {
         if (wh_Server_DmaProcessClientAddress(
-                server, req->output.addr, &outAddr, req->output.sz,
+                ctx, req.output.addr, &outAddr, req.output.sz,
                 WH_DMA_OPER_CLIENT_WRITE_POST,
                 (whServerDmaFlags){0}) != WH_ERROR_OK) {
 #ifdef DEBUG_CRYPTOCB_VERBOSE
@@ -2585,7 +3083,7 @@ static int _HandleCmacDma(whServerContext* server, whPacket* packet,
 
     if (keyAddr != NULL) {
         if (wh_Server_DmaProcessClientAddress(
-                server, req->key.addr, &keyAddr, req->key.sz,
+                ctx, req.key.addr, &keyAddr, req.key.sz,
                 WH_DMA_OPER_CLIENT_READ_POST,
                 (whServerDmaFlags){0}) != WH_ERROR_OK) {
 #ifdef DEBUG_CRYPTOCB_VERBOSE
@@ -2594,7 +3092,7 @@ static int _HandleCmacDma(whServerContext* server, whPacket* packet,
         }
     }
 
-    /* Reset the devId in the local context */
+    /* Reset the devId and type in the local context */
     cmac->devId = clientDevId;
 
     /* If we are using HSM-local keys, sanitize the key material from the CMAC
@@ -2605,72 +3103,115 @@ static int _HandleCmacDma(whServerContext* server, whPacket* packet,
 
     /* Copy CMAC context back into client memory */
     if (ret == WH_ERROR_OK && !cmacFinalized) {
-        ret = whServerDma_CopyToClient(server, req->state.addr, cmac,
-                                       req->state.sz, (whServerDmaFlags){0});
+        ret = whServerDma_CopyToClient(ctx, req.state.addr, cmac,
+                                       req.state.sz, (whServerDmaFlags){0});
         if (ret != WH_ERROR_OK) {
-            res->dmaAddrStatus.badAddr = req->state;
+            res.dmaAddrStatus.badAddr = req.state;
         }
     }
 
-    /* return value populates packet->rc */
+    /* Translate response */
+    (void)wh_MessageCrypto_TranslateCmacDmaResponse(
+        magic, &res, (whMessageCrypto_CmacDmaResponse*)cryptoDataOut);
+    *outSize = sizeof(res);
+
+    /* return value populates rc in response message */
     return ret;
 }
 #endif /* WOLFHSM_CFG_DMA */
 
-int wh_Server_HandleCryptoDmaRequest(whServerContext* server,
-    uint16_t action, uint8_t* data, uint16_t* size, uint16_t seq)
+int wh_Server_HandleCryptoDmaRequest(whServerContext* ctx, uint16_t magic,
+                                     uint16_t action, uint16_t seq,
+                                     uint16_t req_size, const void* req_packet,
+                                     uint16_t* out_resp_size, void* resp_packet)
 {
-    int ret = 0;
-    whPacket* packet = (whPacket*)data;
+    int                                   ret        = 0;
+    whMessageCrypto_GenericRequestHeader  rqstHeader = {0};
+    whMessageCrypto_GenericResponseHeader respHeader = {0};
 
-    switch (action) {
-    case WC_ALGO_TYPE_HASH:
-        switch (packet->hashAnyReq.type) {
-#ifndef NO_SHA256
-            case WC_HASH_TYPE_SHA256:
-#ifdef DEBUG_CRYPTOCB_VERBOSE
-                printf("[server] DMA SHA256 req recv. type:%u\n",
-                       (unsigned int)packet->hashSha256Req.type);
-#endif
-                ret = _HandleSha256Dma(server, (whPacket*)data, size);
-#ifdef DEBUG_CRYPTOCB_VERBOSE
-                if (ret != 0) {
-                    printf("[server] DMA SHA256 ret = %d\n", ret);
-                }
-#endif
-                break;
-#endif /* !NO_SHA256 */
-        }
-        break; /* WC_ALGO_TYPE_HASH */
+    const void* cryptoDataIn =
+        (uint8_t*)req_packet + sizeof(whMessageCrypto_GenericRequestHeader);
+    void* cryptoDataOut =
+        (uint8_t*)resp_packet + sizeof(whMessageCrypto_GenericResponseHeader);
 
-    case WC_ALGO_TYPE_PK:
-        switch (packet->pkAnyReq.type) {
-#if defined(HAVE_DILITHIUM) || defined(HAVE_FALCON)
-            case WC_PK_TYPE_PQC_SIG_KEYGEN:
-            case WC_PK_TYPE_PQC_SIG_SIGN:
-            case WC_PK_TYPE_PQC_SIG_VERIFY:
-            case WC_PK_TYPE_PQC_SIG_CHECK_PRIV_KEY:
-                ret = _HandlePqcSigAlgorithmDma(server, packet, size);
-                break;
-#endif /* HAVE_DILITHIUM || HAVE_FALCON */
-        }
-        break; /* WC_ALGO_TYPE_PK */
+    /* Input and output sizes for data passed to crypto handlers. cryptoOutSize
+     * should be set by the crypto handler as an output parameter */
+    uint16_t cryptoInSize =
+        req_size - sizeof(whMessageCrypto_GenericResponseHeader);
+    uint16_t cryptoOutSize = 0;
 
-    case WC_ALGO_TYPE_CMAC:
-        ret = _HandleCmacDma(server, packet, size);
-        break;
-
-    case WC_ALGO_TYPE_NONE:
-    default:
-        ret = NOT_COMPILED_IN;
-        break;
+    if ((ctx == NULL) || (ctx->crypto == NULL) || (req_packet == NULL) ||
+        (resp_packet == NULL) || (out_resp_size == NULL)) {
+        return WH_ERROR_BADARGS;
     }
 
-    /* Propagate error code to client in response packet */
-    packet->rc = ret;
+    /* Translate the request message to get the algo type */
+    wh_MessageCrypto_TranslateGenericRequestHeader(
+        magic, (whMessageCrypto_GenericRequestHeader*)req_packet, &rqstHeader);
 
-    if (ret != 0)
-        *size = WH_PACKET_STUB_SIZE + sizeof(packet->rc);
+
+    switch (action) {
+        case WC_ALGO_TYPE_HASH:
+            switch (rqstHeader.algoType) {
+#ifndef NO_SHA256
+                case WC_HASH_TYPE_SHA256:
+                    ret = _HandleSha256Dma(ctx, magic, seq, cryptoDataIn,
+                                           cryptoInSize, cryptoDataOut,
+                                           &cryptoOutSize);
+#ifdef DEBUG_CRYPTOCB_VERBOSE
+                    if (ret != 0) {
+                        printf("[server] DMA SHA256 ret = %d\n", ret);
+                    }
+#endif
+                    break;
+#endif /* !NO_SHA256 */
+            }
+            break; /* WC_ALGO_TYPE_HASH */
+
+        case WC_ALGO_TYPE_PK:
+            switch (rqstHeader.algoType) {
+#if defined(HAVE_DILITHIUM) || defined(HAVE_FALCON)
+                case WC_PK_TYPE_PQC_SIG_KEYGEN:
+                case WC_PK_TYPE_PQC_SIG_SIGN:
+                case WC_PK_TYPE_PQC_SIG_VERIFY:
+                case WC_PK_TYPE_PQC_SIG_CHECK_PRIV_KEY:
+                    ret = _HandlePqcSigAlgorithmDma(
+                        ctx, magic, cryptoDataIn, cryptoInSize, cryptoDataOut,
+                        &cryptoOutSize, rqstHeader.algoType,
+                        rqstHeader.algoSubType);
+                    break;
+#endif /* HAVE_DILITHIUM || HAVE_FALCON */
+            }
+            break; /* WC_ALGO_TYPE_PK */
+
+        case WC_ALGO_TYPE_CMAC:
+            ret = _HandleCmacDma(ctx, magic, seq, cryptoDataIn, cryptoInSize,
+                                 cryptoDataOut, &cryptoOutSize);
+            break;
+
+        case WC_ALGO_TYPE_NONE:
+        default:
+            ret = NOT_COMPILED_IN;
+            break;
+    }
+
+    /* Propagate error code to client in response packet header. Crypto handlers
+     * have already populated the response packet with the output data. */
+    respHeader.rc       = ret;
+    respHeader.algoType = rqstHeader.algoType;
+    wh_MessageCrypto_TranslateGenericResponseHeader(
+        magic, &respHeader,
+        (whMessageCrypto_GenericResponseHeader*)resp_packet);
+
+    /* Update the size of the response packet if crypto handler didn't fail */
+    if (ret != WH_ERROR_OK) {
+        *out_resp_size = sizeof(whMessageCrypto_GenericResponseHeader);
+    }
+    else {
+        *out_resp_size =
+            sizeof(whMessageCrypto_GenericResponseHeader) + cryptoOutSize;
+    }
+
 
 #ifdef DEBUG_CRYPTOCB_VERBOSE
     printf("[server] Crypto DMA request. Action:%u\n", action);
@@ -2679,7 +3220,7 @@ int wh_Server_HandleCryptoDmaRequest(whServerContext* server,
      * packet, return success to the caller unless a cancellation has occurred
      */
     if (ret != WH_ERROR_CANCEL) {
-        ret = 0;
+        ret = WH_ERROR_OK;
     }
     return ret;
 }

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -522,13 +522,8 @@ int wh_Server_CacheImportCurve25519Key(whServerContext* server,
     uint8_t*       cacheBuf;
     whNvmMetadata* cacheMeta;
     int            ret;
-    /* Max size of a DER encoded curve25519 keypair with SubjectPublicKeyInfo
-     * included. Determined by experiment */
-    const uint16_t MAX_DER_SIZE = 128;
-    uint16_t       keySz        = keySz;
-
-    uint8_t der_buf[MAX_DER_SIZE];
-
+    uint8_t        der_buf[CURVE25519_MAX_KEY_TO_DER_SZ];
+    uint16_t       keySz = sizeof(der_buf);
 
     if ((server == NULL) || (key == NULL) || (WH_KEYID_ISERASED(keyId)) ||
         ((label != NULL) && (label_len > sizeof(cacheMeta->label)))) {
@@ -922,7 +917,7 @@ static int _HandleEccVerify(whServerContext* ctx, uint16_t magic,
 
     /* Response message */
     byte* res_pub =
-        (uint8_t*)(cryptoDataOut + sizeof(whMessageCrypto_EccVerifyResponse));
+        (uint8_t*)(cryptoDataOut) + sizeof(whMessageCrypto_EccVerifyResponse);
     word32   max_size = (word32)(WOLFHSM_CFG_COMM_DATA_LEN -
                                (res_pub - (uint8_t*)cryptoDataOut));
     uint32_t pub_size = 0;
@@ -1240,12 +1235,12 @@ static int _HandleAesCbc(whServerContext* ctx, uint16_t magic, const void* crypt
 
     /* in, key, iv, and out are after fixed size fields */
     uint8_t* in =
-        (uint8_t*)(cryptoDataIn + sizeof(whMessageCrypto_AesCbcRequest));
+        (uint8_t*)(cryptoDataIn) + sizeof(whMessageCrypto_AesCbcRequest);
     uint8_t* key = in + len;
     uint8_t* iv  = key + key_len;
 
     uint8_t* out =
-        (uint8_t*)(cryptoDataOut + sizeof(whMessageCrypto_AesCbcResponse));
+        (uint8_t*)(cryptoDataOut) + sizeof(whMessageCrypto_AesCbcResponse);
 
     /* Debug printouts */
 #ifdef DEBUG_CRYPTOCB_VERBOSE

--- a/src/wh_server_keystore.c
+++ b/src/wh_server_keystore.c
@@ -38,7 +38,7 @@
 #include "wolfhsm/wh_common.h"
 #include "wolfhsm/wh_error.h"
 #include "wolfhsm/wh_message.h"
-#include "wolfhsm/wh_packet.h"
+#include "wolfhsm/wh_message_keystore.h"
 #include "wolfhsm/wh_utils.h"
 #include "wolfhsm/wh_server.h"
 
@@ -270,6 +270,12 @@ int hsmCacheKey(whServerContext* server, whNvmMetadata* meta, uint8_t* in)
     if (foundIndex == -1) {
         return WH_ERROR_NOSPACE;
     }
+#if defined(DEBUG_CRYPTOCB) && defined(DEBUG_CRYPTOCB_VERBOSE)
+    else {
+        printf("[server] hsmCacheKey: cached keyid=0x%X in slot %d, len=%u\n",
+               meta->id, foundIndex, meta->len);
+    }
+#endif
     return 0;
 }
 
@@ -457,6 +463,9 @@ int hsmEvictKey(whServerContext* server, whNvmId keyId)
 
     ret = _FindInCache(server, keyId, NULL, NULL, NULL, &meta);
     if (ret == 0) {
+#if defined(DEBUG_CRYPTOCB) && defined(DEBUG_CRYPTOCB_VERBOSE)
+        printf("[server] hsmEvictKey: evicted keyid=0x%X\n", keyId);
+#endif
         meta->id = WH_KEYID_ERASED;
     }
     return ret;
@@ -505,163 +514,271 @@ int hsmEraseKey(whServerContext* server, whNvmId keyId)
 }
 
 int wh_Server_HandleKeyRequest(whServerContext* server, uint16_t magic,
-                               uint16_t action, uint16_t seq, uint8_t* data,
-                               uint16_t* size)
+                               uint16_t action, uint16_t req_size,
+                               const void* req_packet, uint16_t* out_resp_size,
+                               void* resp_packet)
 {
-    int           ret = 0;
-    uint32_t      field;
+    int           ret = WH_ERROR_OK;
     uint8_t*      in;
     uint8_t*      out;
-    whPacket*     packet  = (whPacket*)data;
     whNvmMetadata meta[1] = {{0}};
 
     /* validate args, even though these functions are only supposed to be
      * called by internal functions */
-    if ((server == NULL) || (data == NULL) || (size == NULL)) {
+    if ((server == NULL) || (req_packet == NULL) || (out_resp_size == NULL)) {
         return WH_ERROR_BADARGS;
     }
 
     switch (action) {
-        case WH_KEY_CACHE:
+        case WH_KEY_CACHE: {
+            whMessageKeystore_CacheRequest  req;
+            whMessageKeystore_CacheResponse resp;
+
+            /* translate request */
+            (void)wh_MessageKeystore_TranslateCacheRequest(
+                magic, (whMessageKeystore_CacheRequest*)req_packet, &req);
+
             /* in is after fixed size fields */
-            in = (uint8_t*)(&packet->keyCacheReq + 1);
+            in = (uint8_t*)req_packet + sizeof(req);
+
             /* set the metadata fields */
             meta->id = WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, server->comm->client_id,
-                                     packet->keyCacheReq.id);
+                                     req.id);
             meta->access = WH_NVM_ACCESS_ANY;
-            meta->flags  = packet->keyCacheReq.flags;
-            meta->len    = packet->keyCacheReq.sz;
+            meta->flags  = req.flags;
+            meta->len    = req.sz;
             /* validate label sz */
-            if (packet->keyCacheReq.labelSz > WH_NVM_LABEL_LEN) {
+            if (req.labelSz > WH_NVM_LABEL_LEN) {
                 ret = WH_ERROR_BADARGS;
             }
             else {
-                memcpy(meta->label, packet->keyCacheReq.label,
-                        packet->keyCacheReq.labelSz);
+                memcpy(meta->label, req.label, req.labelSz);
             }
             /* get a new id if one wasn't provided */
             if (WH_KEYID_ISERASED(meta->id)) {
-                ret = hsmGetUniqueId(server, &meta->id);
+                ret     = hsmGetUniqueId(server, &meta->id);
+                resp.rc = ret;
+                /* TODO: Are there any fatal server errors? */
+                ret = WH_ERROR_OK;
             }
             /* write the key */
             if (ret == WH_ERROR_OK) {
-                ret = hsmCacheKey(server, meta, in);
+                ret     = hsmCacheKey(server, meta, in);
+                resp.rc = ret;
+                /* TODO: Are there any fatal server errors? */
+                ret = WH_ERROR_OK;
             }
-            if (ret == 0) {
+            if (ret == WH_ERROR_OK) {
                 /* remove the client_id, client may set type */
-                packet->keyCacheRes.id = WH_KEYID_ID(meta->id);
-                *size = WH_PACKET_STUB_SIZE + sizeof(packet->keyCacheRes);
+                resp.id = WH_KEYID_ID(meta->id);
+
+                (void)wh_MessageKeystore_TranslateCacheResponse(
+                    magic, &resp,
+                    (whMessageKeystore_CacheResponse*)resp_packet);
+
+                *out_resp_size = sizeof(resp);
             }
-            break;
+        } break;
 
 #ifdef WOLFHSM_CFG_DMA
 
-        case WH_KEY_CACHE_DMA:
+        case WH_KEY_CACHE_DMA: {
+            whMessageKeystore_CacheDmaRequest  req;
+            whMessageKeystore_CacheDmaResponse resp;
+
+            /* translate request */
+            (void)wh_MessageKeystore_TranslateCacheDmaRequest(
+                magic, (whMessageKeystore_CacheDmaRequest*)req_packet, &req);
+
             /* set the metadata fields */
             meta->id = WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO, server->comm->client_id,
-                                     packet->keyCacheDmaReq.id);
+                                     req.id);
             meta->access = WH_NVM_ACCESS_ANY;
-            meta->flags  = packet->keyCacheDmaReq.flags;
-            meta->len    = packet->keyCacheDmaReq.sz;
+            meta->flags  = req.flags;
+            meta->len    = req.key.sz;
+
             /* validate label sz */
-            if (packet->keyCacheDmaReq.labelSz > WH_NVM_LABEL_LEN) {
+            if (req.labelSz > WH_NVM_LABEL_LEN) {
                 ret = WH_ERROR_BADARGS;
             }
             else {
-                memcpy(meta->label, packet->keyCacheDmaReq.label,
-                        packet->keyCacheDmaReq.labelSz);
+                memcpy(meta->label, req.label, req.labelSz);
             }
+
             /* get a new id if one wasn't provided */
             if (WH_KEYID_ISERASED(meta->id)) {
-                ret = hsmGetUniqueId(server, &meta->id);
+                ret     = hsmGetUniqueId(server, &meta->id);
+                resp.rc = ret;
             }
+
             /* write the key using DMA */
             if (ret == WH_ERROR_OK) {
-                ret = hsmCacheKeyDma(server, meta,
-                                     packet->keyCacheDmaReq.key.addr);
+                ret     = hsmCacheKeyDma(server, meta, req.key.addr);
+                resp.rc = ret;
+                /* propagate bad address to client if DMA operation failed */
+                if (ret != WH_ERROR_OK) {
+                    resp.dmaAddrStatus.badAddr.addr = req.key.addr;
+                    resp.dmaAddrStatus.badAddr.sz   = req.key.sz;
+                }
+                /* TODO: Are there any fatal server errors? */
+                ret = WH_ERROR_OK;
             }
-            if (ret == 0) {
-                /* remove the client_id, client may set type */
-                packet->keyCacheDmaRes.id = WH_KEYID_ID(meta->id);
-                *size = WH_PACKET_STUB_SIZE + sizeof(packet->keyCacheDmaRes);
-            }
-            break;
 
-        case WH_KEY_EXPORT_DMA:
-            ret = hsmExportKeyDma(server,
-                                  WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
-                                                server->comm->client_id,
-                                                packet->keyExportDmaReq.id),
-                                  packet->keyExportDmaReq.key.addr,
-                                  packet->keyExportDmaReq.key.sz, meta);
-            if (ret == 0) {
-                /* set key len */
-                packet->keyExportDmaRes.len = packet->keyExportDmaReq.key.sz;
-                /* set label */
-                memcpy(packet->keyExportDmaRes.label, meta->label,
-                       sizeof(meta->label));
-                *size = WH_PACKET_STUB_SIZE + sizeof(packet->keyExportDmaRes);
+            /* remove the client_id, client may set type */
+            resp.id = WH_KEYID_ID(meta->id);
+
+            (void)wh_MessageKeystore_TranslateCacheDmaResponse(
+                magic, &resp, (whMessageKeystore_CacheDmaResponse*)resp_packet);
+
+            *out_resp_size = sizeof(resp);
+        } break;
+
+        case WH_KEY_EXPORT_DMA: {
+            whMessageKeystore_ExportDmaRequest  req;
+            whMessageKeystore_ExportDmaResponse resp;
+
+            /* translate request */
+            (void)wh_MessageKeystore_TranslateExportDmaRequest(
+                magic, (whMessageKeystore_ExportDmaRequest*)req_packet, &req);
+
+            ret =
+                hsmExportKeyDma(server,
+                                WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
+                                              server->comm->client_id, req.id),
+                                req.key.addr, req.key.sz, meta);
+            resp.rc = ret;
+            /* propagate bad address to client if DMA operation failed */
+            if (ret != WH_ERROR_OK) {
+                resp.dmaAddrStatus.badAddr.addr = req.key.addr;
+                resp.dmaAddrStatus.badAddr.sz   = req.key.sz;
             }
-            break;
+            /* TODO: Are there any fatal server errors? */
+            ret = WH_ERROR_OK;
+
+            if (ret == WH_ERROR_OK) {
+                resp.len = req.key.sz;
+                memcpy(resp.label, meta->label, sizeof(meta->label));
+            }
+
+            (void)wh_MessageKeystore_TranslateExportDmaResponse(
+                magic, &resp,
+                (whMessageKeystore_ExportDmaResponse*)resp_packet);
+
+            *out_resp_size = sizeof(resp);
+        } break;
 #endif /* WOLFHSM_CFG_DMA */
 
-        case WH_KEY_EVICT:
-            ret = hsmEvictKey(server, WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
-                                                    server->comm->client_id,
-                                                    packet->keyEvictReq.id));
-            if (ret == 0) {
-                packet->keyEvictRes.ok = 0;
-                *size = WH_PACKET_STUB_SIZE + sizeof(packet->keyEvictRes);
-            }
-            break;
-        case WH_KEY_EXPORT:
+        case WH_KEY_EVICT: {
+            whMessageKeystore_EvictRequest  req;
+            whMessageKeystore_EvictResponse resp;
+
+            (void)wh_MessageKeystore_TranslateEvictRequest(
+                magic, (whMessageKeystore_EvictRequest*)req_packet, &req);
+
+            ret     = hsmEvictKey(server,
+                                  WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
+                                                server->comm->client_id, req.id));
+            resp.rc = ret;
+            /* TODO: Are there any fatal server errors? */
+            ret = WH_ERROR_OK;
+
+            (void)wh_MessageKeystore_TranslateEvictResponse(
+                magic, &resp, (whMessageKeystore_EvictResponse*)resp_packet);
+            *out_resp_size = sizeof(resp);
+        } break;
+
+        case WH_KEY_EXPORT: {
+            whMessageKeystore_ExportRequest  req;
+            whMessageKeystore_ExportResponse resp;
+            uint32_t                         keySz;
+
+            /* translate request */
+            (void)wh_MessageKeystore_TranslateExportRequest(
+                magic, (whMessageKeystore_ExportRequest*)req_packet, &req);
+
             /* out is after fixed size fields */
-            out   = (uint8_t*)(&packet->keyExportRes + 1);
-            field = WOLFHSM_CFG_COMM_DATA_LEN -
-                    (WH_PACKET_STUB_SIZE + sizeof(packet->keyExportRes));
+            out   = (uint8_t*)resp_packet + sizeof(resp);
+            keySz = WOLFHSM_CFG_COMM_DATA_LEN - sizeof(resp);
+
             /* read the key */
-            ret = hsmReadKey(server,
-                             WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
-                                           server->comm->client_id,
-                                           packet->keyExportReq.id),
-                             meta, out, &field);
-            if (ret == 0) {
-                /* set key len */
-                packet->keyExportRes.len = field;
-                /* set label */
-                memcpy(packet->keyExportRes.label, meta->label,
-                        sizeof(meta->label));
-                *size =
-                    WH_PACKET_STUB_SIZE + sizeof(packet->keyExportRes) + field;
+            ret     = hsmReadKey(server,
+                                 WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
+                                               server->comm->client_id, req.id),
+                                 meta, out, &keySz);
+            resp.rc = ret;
+            /* TODO: Are there any fatal server errors? */
+            ret = WH_ERROR_OK;
+
+            if (ret == WH_ERROR_OK) {
+                resp.len = keySz;
+                memcpy(resp.label, meta->label, sizeof(meta->label));
+
+                (void)wh_MessageKeystore_TranslateExportResponse(
+                    magic, &resp,
+                    (whMessageKeystore_ExportResponse*)resp_packet);
+
+                *out_resp_size = sizeof(resp) + keySz;
             }
-            break;
-        case WH_KEY_COMMIT:
-            /* commit the cached key */
-            ret = hsmCommitKey(server, WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
-                                                     server->comm->client_id,
-                                                     packet->keyCommitReq.id));
-            if (ret == 0) {
-                packet->keyCommitRes.ok = 0;
-                *size = WH_PACKET_STUB_SIZE + sizeof(packet->keyCommitRes);
+        } break;
+
+        case WH_KEY_COMMIT: {
+            whMessageKeystore_CommitRequest  req;
+            whMessageKeystore_CommitResponse resp;
+
+            /* translate request */
+            (void)wh_MessageKeystore_TranslateCommitRequest(
+                magic, (whMessageKeystore_CommitRequest*)req_packet, &req);
+
+            ret     = hsmCommitKey(server,
+                                   WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
+                                                 server->comm->client_id, req.id));
+            resp.rc = ret;
+            /* TODO: Are there any fatal server errors? */
+            ret = WH_ERROR_OK;
+
+            if (ret == WH_ERROR_OK) {
+                resp.ok = 0;
+
+                (void)wh_MessageKeystore_TranslateCommitResponse(
+                    magic, &resp,
+                    (whMessageKeystore_CommitResponse*)resp_packet);
+
+                *out_resp_size = sizeof(resp);
             }
-            break;
-        case WH_KEY_ERASE:
-            ret = hsmEraseKey(server, WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
-                                                    server->comm->client_id,
-                                                    packet->keyEraseReq.id));
-            if (ret == 0) {
-                packet->keyEraseRes.ok = 0;
-                *size = WH_PACKET_STUB_SIZE + sizeof(packet->keyEraseRes);
+        } break;
+
+        case WH_KEY_ERASE: {
+            whMessageKeystore_EraseRequest  req;
+            whMessageKeystore_EraseResponse resp;
+
+            /* translate request */
+            (void)wh_MessageKeystore_TranslateEraseRequest(
+                magic, (whMessageKeystore_EraseRequest*)req_packet, &req);
+
+            ret     = hsmEraseKey(server,
+                                  WH_MAKE_KEYID(WH_KEYTYPE_CRYPTO,
+                                                server->comm->client_id, req.id));
+            resp.rc = ret;
+            /* TODO: Are there any fatal server errors? */
+            ret = WH_ERROR_OK;
+
+            if (ret == WH_ERROR_OK) {
+                resp.ok = 0;
+
+                (void)wh_MessageKeystore_TranslateEraseResponse(
+                    magic, &resp,
+                    (whMessageKeystore_EraseResponse*)resp_packet);
+
+                *out_resp_size = sizeof(resp);
             }
-            break;
+        } break;
+
         default:
             ret = WH_ERROR_BADARGS;
             break;
     }
-    packet->rc = ret;
-    (void)magic;
-    (void)seq;
-    return 0;
+
+    return ret;
 }
 
 #ifdef WOLFHSM_CFG_DMA

--- a/src/wh_server_she.c
+++ b/src/wh_server_she.c
@@ -30,7 +30,6 @@
 #include <string.h>  /* For memset, memcpy */
 
 #include "wolfhsm/wh_message.h"
-#include "wolfhsm/wh_packet.h"
 #include "wolfhsm/wh_error.h"
 #include "wolfhsm/wh_utils.h"
 #include "wolfhsm/wh_server.h"
@@ -49,6 +48,8 @@
 #include "wolfhsm/wh_she_common.h"
 #include "wolfhsm/wh_she_crypto.h"
 #include "wolfhsm/wh_server_she.h"
+#include "wolfhsm/wh_message.h"
+#include "wolfhsm/wh_message_she.h"
 
 #ifndef WOLFHSM_CFG_NO_CRYPTO
 
@@ -70,38 +71,80 @@ enum WH_SHE_SB_STATE {
 static int wh_AesMp16(whServerContext* server, uint8_t* in, word32 inSz,
         uint8_t* out);
 static uint16_t hsmShePopAuthId(uint8_t* messageOne);
+static uint16_t hsmShePopId(uint8_t* messageOne);
 static uint32_t hsmShePopFlags(uint8_t* messageTwo);
-static int hsmSheSetUid(whServerContext* server, whPacket* packet);
-static int hsmSheSecureBootInit(whServerContext* server, whPacket* packet,
-        uint16_t* size);
-static int hsmSheSecureBootUpdate(whServerContext* server, whPacket* packet,
-    uint16_t* size);
-static int hsmSheSecureBootFinish(whServerContext* server, whPacket* packet,
-    uint16_t* size);
-static int hsmSheGetStatus(whServerContext* server, whPacket* packet,
-    uint16_t* size);
-static int hsmSheLoadKey(whServerContext* server, whPacket* packet,
-    uint16_t* size);
-static int hsmSheLoadPlainKey(whServerContext* server, whPacket* packet,
-    uint16_t* size);
-static int hsmSheExportRamKey(whServerContext* server, whPacket* packet,
-    uint16_t* size);
-static int hsmSheRnd(whServerContext* server, whPacket* packet, uint16_t* size);
-static int hsmSheExtendSeed(whServerContext* server, whPacket* packet,
-    uint16_t* size);
-static int hsmSheEncEcb(whServerContext* server, whPacket* packet,
-        uint16_t* size);
-static int hsmSheEncCbc(whServerContext* server, whPacket* packet,
-    uint16_t* size);
-static int hsmSheDecEcb(whServerContext* server, whPacket* packet,
-    uint16_t* size);
-static int hsmSheDecCbc(whServerContext* server, whPacket* packet,
-    uint16_t* size);
-static int hsmSheGenerateMac(whServerContext* server, whPacket* packet,
-    uint16_t* size);
-
+static int hsmSheSetUid(whServerContext* server, uint16_t magic,
+                        uint16_t req_size, const void* req_packet,
+                        uint16_t* out_resp_size, void* resp_packet);
+static int      hsmSheSecureBootInit(whServerContext* server, uint16_t magic,
+                                     uint16_t req_size, const void* req_packet,
+                                     uint16_t* out_resp_size, void* resp_packet);
+static int      hsmSheSecureBootUpdate(whServerContext* server, uint16_t magic,
+                                       uint16_t req_size, const void* req_packet,
+                                       uint16_t* out_resp_size, void* resp_packet);
+static int      hsmSheSecureBootFinish(whServerContext* server, uint16_t magic,
+                                       uint16_t req_size, const void* req_packet,
+                                       uint16_t* out_resp_size, void* resp_packet);
+static int hsmSheGetStatus(whServerContext* server, uint16_t magic,
+                           uint16_t req_size, const void* req_packet,
+                           uint16_t* out_resp_size, void* resp_packet);
+static int hsmSheLoadKey(whServerContext* server, uint16_t magic,
+                         uint16_t req_size, const void* req_packet,
+                         uint16_t* out_resp_size, void* resp_packet);
+static int      hsmSheLoadPlainKey(whServerContext* server, uint16_t magic,
+                                   uint16_t req_size, const void* req_packet,
+                                   uint16_t* out_resp_size, void* resp_packet);
+static int      hsmSheExportRamKey(whServerContext* server, uint16_t magic,
+                                   uint16_t req_size, const void* req_packet,
+                                   uint16_t* out_resp_size, void* resp_packet);
+static int      hsmSheInitRnd(whServerContext* server, uint16_t magic,
+                              uint16_t req_size, const void* req_packet,
+                              uint16_t* out_resp_size, void* resp_packet);
+static int hsmSheRnd(whServerContext* server, uint16_t magic, uint16_t req_size,
+                     const void* req_packet, uint16_t* out_resp_size,
+                     void* resp_packet);
+static int      hsmSheExtendSeed(whServerContext* server, uint16_t magic,
+                                 uint16_t req_size, const void* req_packet,
+                                 uint16_t* out_resp_size, void* resp_packet);
+static int      hsmSheEncEcb(whServerContext* server, uint16_t magic,
+                             uint16_t req_size, const void* req_packet,
+                             uint16_t* out_resp_size, void* resp_packet);
+static int      hsmSheEncCbc(whServerContext* server, uint16_t magic,
+                             uint16_t req_size, const void* req_packet,
+                             uint16_t* out_resp_size, void* resp_packet);
+static int      hsmSheDecEcb(whServerContext* server, uint16_t magic,
+                             uint16_t req_size, const void* req_packet,
+                             uint16_t* out_resp_size, void* resp_packet);
+static int      hsmSheDecCbc(whServerContext* server, uint16_t magic,
+                             uint16_t req_size, const void* req_packet,
+                             uint16_t* out_resp_size, void* resp_packet);
+static int      hsmSheGenerateMac(whServerContext* server, uint16_t magic,
+                                  uint16_t req_size, const void* req_packet,
+                                  uint16_t* out_resp_size, void* resp_packet);
+static int      hsmSheVerifyMac(whServerContext* server, uint16_t magic,
+                                uint16_t req_size, const void* req_packet,
+                                uint16_t* out_resp_size, void* resp_packet);
+static int _translateSheReturnCode(int ret);
 
 /** Local Implementations */
+static int _translateSheReturnCode(int ret)
+{
+    /* if a handler didn't set a specific error, set general error */
+    if (ret != WH_SHE_ERC_NO_ERROR) {
+        if (ret != WH_SHE_ERC_SEQUENCE_ERROR &&
+            ret != WH_SHE_ERC_KEY_NOT_AVAILABLE &&
+            ret != WH_SHE_ERC_KEY_INVALID && ret != WH_SHE_ERC_KEY_EMPTY &&
+            ret != WH_SHE_ERC_NO_SECURE_BOOT &&
+            ret != WH_SHE_ERC_WRITE_PROTECTED &&
+            ret != WH_SHE_ERC_KEY_UPDATE_ERROR && ret != WH_SHE_ERC_RNG_SEED &&
+            ret != WH_SHE_ERC_NO_DEBUGGING && ret != WH_SHE_ERC_BUSY &&
+            ret != WH_SHE_ERC_MEMORY_FAILURE) {
+            /* set general error */
+            ret = WH_SHE_ERC_GENERAL_ERROR;
+        }
+    }
+    return ret;
+}
 
 /* kdf function based on the Miyaguchi-Preneel one-way compression function */
 static int wh_AesMp16(whServerContext* server, uint8_t* in, word32 inSz,
@@ -133,31 +176,50 @@ static uint32_t hsmShePopFlags(uint8_t* messageTwo)
     return (((messageTwo[3] & 0x0f) << 4) | ((messageTwo[4] & 0x80) >> 7));
 }
 
-static int hsmSheSetUid(whServerContext* server, whPacket* packet)
+static int hsmSheSetUid(whServerContext* server, uint16_t magic,
+                        uint16_t req_size, const void* req_packet,
+                        uint16_t* out_resp_size, void* resp_packet)
 {
-    int ret = 0;
-    if (server->she->uidSet == 1)
+    int ret = WH_SHE_ERC_NO_ERROR;
+    whMessageShe_SetUidRequest  req;
+    whMessageShe_SetUidResponse resp;
+
+    (void)wh_MessageShe_TranslateSetUidRequest(
+        magic, (whMessageShe_SetUidRequest*)req_packet, &req);
+
+
+    if (server->she->uidSet == 1) {
         ret = WH_SHE_ERC_SEQUENCE_ERROR;
-    if (ret == 0) {
-        XMEMCPY(server->she->uid, packet->sheSetUidReq.uid,
-            sizeof(packet->sheSetUidReq.uid));
+    }
+    if (ret == WH_SHE_ERC_NO_ERROR) {
+        memcpy(server->she->uid, req.uid, sizeof(req.uid));
         server->she->uidSet = 1;
     }
+
+    resp.rc = ret;
+    (void)wh_MessageShe_TranslateSetUidResponse(magic, &resp, resp_packet);
+
     return ret;
 }
 
-static int hsmSheSecureBootInit(whServerContext* server, whPacket* packet,
-    uint16_t* size)
+static int hsmSheSecureBootInit(whServerContext* server, uint16_t magic,
+                                uint16_t req_size, const void* req_packet,
+                                uint16_t* out_resp_size, void* resp_packet)
 {
     int ret = 0;
     uint32_t keySz;
     uint8_t macKey[WH_SHE_KEY_SZ];
+    whMessageShe_SecureBootInitRequest req;
+    whMessageShe_SecureBootInitResponse resp;
+
+    (void)wh_MessageShe_TranslateSecureBootInitRequest(magic, req_packet, &req);
+
     /* if we aren't looking for init return error */
     if (server->she->sbState != WH_SHE_SB_INIT)
         ret = WH_SHE_ERC_SEQUENCE_ERROR;
     if (ret == 0) {
         /* set the expected size */
-        server->she->blSize = packet->sheSecureBootInitReq.sz;
+        server->she->blSize = req.sz;
         /* check if the boot mac key is empty */
         keySz = sizeof(macKey);
         ret = hsmReadKey(server, WH_MAKE_KEYID(WH_KEYTYPE_SHE,
@@ -195,112 +257,154 @@ static int hsmSheSecureBootInit(whServerContext* server, whPacket* packet,
         /* advance to the next state */
         server->she->sbState = WH_SHE_SB_UPDATE;
         /* set ERC_NO_ERROR */
-        packet->sheSecureBootInitRes.status = WH_SHE_ERC_NO_ERROR;
-        *size = WH_PACKET_STUB_SIZE +
-            sizeof(packet->sheSecureBootInitRes);
+        resp.status = WH_SHE_ERC_NO_ERROR;
     }
+    else {
+        resp.status = WH_SHE_ERC_GENERAL_ERROR;
+    }
+
+    resp.rc = _translateSheReturnCode(ret);
+    (void)wh_MessageShe_TranslateSecureBootInitResponse(magic, &resp, resp_packet);
+    *out_resp_size = sizeof(resp);
+
     return ret;
 }
 
-static int hsmSheSecureBootUpdate(whServerContext* server, whPacket* packet,
-    uint16_t* size)
+static int hsmSheSecureBootUpdate(whServerContext* server, uint16_t magic,
+                                  uint16_t req_size, const void* req_packet,
+                                  uint16_t* out_resp_size, void* resp_packet)
 {
     int ret = 0;
     uint8_t* in;
+    whMessageShe_SecureBootUpdateRequest req;
+    whMessageShe_SecureBootUpdateResponse resp;
+
+    (void)wh_MessageShe_TranslateSecureBootUpdateRequest(magic, req_packet, &req);
+
     /* if we aren't looking for update return error */
     if (server->she->sbState != WH_SHE_SB_UPDATE)
         ret = WH_SHE_ERC_SEQUENCE_ERROR;
     if (ret == 0) {
         /* the bootloader chunk is after the fixed fields */
-        in = (uint8_t*)(&packet->sheSecureBootUpdateReq + 1);
+        in = (uint8_t*)req_packet + sizeof(req);
         /* increment blSizeReceived */
-        server->she->blSizeReceived += packet->sheSecureBootUpdateReq.sz;
+        server->she->blSizeReceived += req.sz;
         /* check that we didn't exceed the expected bootloader size */
         if (server->she->blSizeReceived > server->she->blSize)
             ret = WH_SHE_ERC_SEQUENCE_ERROR;
     }
     /* update with the new input */
     if (ret == 0)
-        ret = wc_CmacUpdate(server->she->sheCmac, in, packet->sheSecureBootUpdateReq.sz);
+        ret = wc_CmacUpdate(server->she->sheCmac, in, req.sz);
     if (ret == 0) {
         /* advance to the next state if we've cmaced the entire image */
         if (server->she->blSizeReceived == server->she->blSize)
             server->she->sbState = WH_SHE_SB_FINISH;
         /* set ERC_NO_ERROR */
-        packet->sheSecureBootUpdateRes.status = WH_SHE_ERC_NO_ERROR;
-        *size = WH_PACKET_STUB_SIZE +
-            sizeof(packet->sheSecureBootUpdateRes);
+        resp.status = WH_SHE_ERC_NO_ERROR;
     }
+    else {
+        resp.status = WH_SHE_ERC_GENERAL_ERROR;
+    }
+
+    resp.rc = _translateSheReturnCode(ret);
+    (void)wh_MessageShe_TranslateSecureBootUpdateResponse(magic, &resp, resp_packet);
+    *out_resp_size = sizeof(resp);
+
     return ret;
 }
 
-static int hsmSheSecureBootFinish(whServerContext* server, whPacket* packet,
-    uint16_t* size)
+static int hsmSheSecureBootFinish(whServerContext* server, uint16_t magic,
+                                  uint16_t req_size, const void* req_packet,
+                                  uint16_t* out_resp_size, void* resp_packet)
 {
-    int ret = 0;
+    int      ret = 0;
     uint32_t keySz;
     uint32_t field;
-    uint8_t cmacOutput[AES_BLOCK_SIZE];
-    uint8_t macDigest[WH_SHE_KEY_SZ];
+    uint8_t  cmacOutput[AES_BLOCK_SIZE];
+    uint8_t  macDigest[WH_SHE_KEY_SZ];
+
+    whMessageShe_SecureBootFinishResponse resp;
+
     /* if we aren't looking for finish return error */
-    if (server->she->sbState != WH_SHE_SB_FINISH)
+    if (server->she->sbState != WH_SHE_SB_FINISH) {
         ret = WH_SHE_ERC_SEQUENCE_ERROR;
+    }
     /* call final */
     if (ret == 0) {
         field = AES_BLOCK_SIZE;
-        ret = wc_CmacFinal(server->she->sheCmac, cmacOutput, (word32*)&field);
+        ret   = wc_CmacFinal(server->she->sheCmac, cmacOutput, (word32*)&field);
     }
     /* load the cmac to check */
     if (ret == 0) {
         keySz = sizeof(macDigest);
-        ret = hsmReadKey(server, WH_MAKE_KEYID(WH_KEYTYPE_SHE,
-            server->comm->client_id, WH_SHE_BOOT_MAC), NULL, macDigest,
-            &keySz);
-        if (ret != 0)
+        ret   = hsmReadKey(server,
+                           WH_MAKE_KEYID(WH_KEYTYPE_SHE, server->comm->client_id,
+                                         WH_SHE_BOOT_MAC),
+                           NULL, macDigest, &keySz);
+        if (ret != 0) {
             ret = WH_SHE_ERC_KEY_NOT_AVAILABLE;
+        }
     }
     if (ret == 0) {
         /* compare and set either success or failure */
         ret = XMEMCMP(cmacOutput, macDigest, field);
         if (ret == 0) {
             server->she->sbState = WH_SHE_SB_SUCCESS;
-            packet->sheSecureBootFinishRes.status = WH_SHE_ERC_NO_ERROR;
-            *size = WH_PACKET_STUB_SIZE +
-                sizeof(packet->sheSecureBootFinishRes);
+            resp.status          = WH_SHE_ERC_NO_ERROR;
         }
         else {
             server->she->sbState = WH_SHE_SB_FAILURE;
-            ret = WH_SHE_ERC_GENERAL_ERROR;
+            ret                  = WH_SHE_ERC_GENERAL_ERROR;
+            resp.status          = WH_SHE_ERC_GENERAL_ERROR;
         }
     }
+
+    resp.rc = _translateSheReturnCode(ret);
+    (void)wh_MessageShe_TranslateSecureBootFinishResponse(magic, &resp,
+                                                          resp_packet);
+    *out_resp_size = sizeof(resp);
+
     return ret;
 }
 
-static int hsmSheGetStatus(whServerContext* server, whPacket* packet,
-    uint16_t* size)
+static int hsmSheGetStatus(whServerContext* server, uint16_t magic,
+                           uint16_t req_size, const void* req_packet,
+                           uint16_t* out_resp_size, void* resp_packet)
 {
+    whMessageShe_GetStatusResponse resp;
+
     /* TODO do we care about all the sreg fields? */
-    packet->sheGetStatusRes.sreg = 0;
+    resp.sreg = 0;
     /* SECURE_BOOT */
-    if (server->she->cmacKeyFound)
-        packet->sheGetStatusRes.sreg |= WH_SHE_SREG_SECURE_BOOT;
+    if (server->she->cmacKeyFound) {
+        resp.sreg |= WH_SHE_SREG_SECURE_BOOT;
+    }
+
     /* BOOT_FINISHED */
     if (server->she->sbState == WH_SHE_SB_SUCCESS ||
         server->she->sbState == WH_SHE_SB_FAILURE) {
-        packet->sheGetStatusRes.sreg |= WH_SHE_SREG_BOOT_FINISHED;
+        resp.sreg |= WH_SHE_SREG_BOOT_FINISHED;
     }
     /* BOOT_OK */
-    if (server->she->sbState == WH_SHE_SB_SUCCESS)
-        packet->sheGetStatusRes.sreg |= WH_SHE_SREG_BOOT_OK;
+    if (server->she->sbState == WH_SHE_SB_SUCCESS) {
+        resp.sreg |= WH_SHE_SREG_BOOT_OK;
+    }
     /* RND_INIT */
-    if (server->she->rndInited == 1)
-        packet->sheGetStatusRes.sreg |= WH_SHE_SREG_RND_INIT;
-    *size = WH_PACKET_STUB_SIZE + sizeof(packet->sheGetStatusRes);
+    if (server->she->rndInited == 1) {
+        resp.sreg |= WH_SHE_SREG_RND_INIT;
+    }
+
+    *out_resp_size = sizeof(resp);
+    resp.rc = WH_SHE_ERC_NO_ERROR;
+    (void)wh_MessageShe_TranslateGetStatusResponse(magic, &resp, resp_packet);
+
     return 0;
 }
 
-static int hsmSheLoadKey(whServerContext* server, whPacket* packet,
-    uint16_t* size)
+static int hsmSheLoadKey(whServerContext* server, uint16_t magic,
+                         uint16_t req_size, const void* req_packet,
+                         uint16_t* out_resp_size, void* resp_packet)
 {
     int ret;
     int keyRet = 0;
@@ -314,11 +418,20 @@ static int hsmSheLoadKey(whServerContext* server, whPacket* packet,
     uint32_t she_meta_flags = 0;
     uint32_t* msg_counter_BE;
 
+    whMessageShe_LoadKeyRequest req = {0};
+    whMessageShe_LoadKeyResponse resp = {0};
+    /* Buffer for counter operations */
+    uint8_t counter_buffer[WH_SHE_KEY_SZ] = {0};  
+
+    /* translate the request */
+    (void)wh_MessageShe_TranslateLoadKeyRequest(magic, req_packet, &req);
+
+
     /* read the auth key by AuthID */
     keySz = sizeof(kdfInput);
     ret = hsmReadKey(server, WH_MAKE_KEYID(WH_KEYTYPE_SHE,
         server->comm->client_id,
-        hsmShePopAuthId(packet->sheLoadKeyReq.messageOne)), NULL, kdfInput,
+        hsmShePopAuthId(req.messageOne)), NULL, kdfInput,
         &keySz);
     /* make K2 using AES-MP(authKey | WH_SHE_KEY_UPDATE_MAC_C) */
     if (ret == 0) {
@@ -333,15 +446,19 @@ static int hsmSheLoadKey(whServerContext* server, whPacket* packet,
         ret = WH_SHE_ERC_KEY_NOT_AVAILABLE;
     /* cmac messageOne and messageTwo using K2 as the cmac key */
     if (ret == 0) {
+        uint8_t cmacInput[sizeof(req.messageOne) + sizeof(req.messageTwo)];
+        /* Concatenate messageOne and messageTwo for CMAC */
+        memcpy(cmacInput, req.messageOne, sizeof(req.messageOne));
+        memcpy(cmacInput + sizeof(req.messageOne), req.messageTwo, sizeof(req.messageTwo));
+        
         field = AES_BLOCK_SIZE;
-        ret = wc_AesCmacGenerate_ex(server->she->sheCmac, cmacOutput, (word32*)&field,
-            (uint8_t*)&packet->sheLoadKeyReq,
-            sizeof(packet->sheLoadKeyReq.messageOne) +
-            sizeof(packet->sheLoadKeyReq.messageTwo), tmpKey,
-            WH_SHE_KEY_SZ, NULL, server->crypto->devId);
+        ret = wc_AesCmacGenerate_ex(
+            server->she->sheCmac, cmacOutput, (word32*)&field,
+            cmacInput, sizeof(cmacInput),
+            tmpKey, WH_SHE_KEY_SZ, NULL, server->crypto->devId);
     }
     /* compare digest to M3 */
-    if (ret == 0 && XMEMCMP(packet->sheLoadKeyReq.messageThree,
+    if (ret == 0 && XMEMCMP(req.messageThree,
         cmacOutput, field) != 0) {
         ret = WH_SHE_ERC_KEY_UPDATE_ERROR;
     }
@@ -363,9 +480,9 @@ static int hsmSheLoadKey(whServerContext* server, whPacket* packet,
     }
     if (ret == 0) {
         ret = wc_AesCbcDecrypt(server->she->sheAes,
-            packet->sheLoadKeyReq.messageTwo,
-            packet->sheLoadKeyReq.messageTwo,
-            sizeof(packet->sheLoadKeyReq.messageTwo));
+            req.messageTwo,
+            req.messageTwo,
+            sizeof(req.messageTwo));
     }
     /* free aes for protection */
     wc_AesFree(server->she->sheAes);
@@ -373,7 +490,7 @@ static int hsmSheLoadKey(whServerContext* server, whPacket* packet,
     if (ret == 0) {
         ret = hsmReadKey(server, WH_MAKE_KEYID(WH_KEYTYPE_SHE,
             server->comm->client_id,
-            hsmShePopId(packet->sheLoadKeyReq.messageOne)), meta, kdfInput,
+            hsmShePopId(req.messageOne)), meta, kdfInput,
             &keySz);
         /* Extract count and flags from the label, even if it failed */
         wh_She_Label2Meta(meta->label, &she_meta_count, &she_meta_flags);
@@ -387,7 +504,7 @@ static int hsmSheLoadKey(whServerContext* server, whPacket* packet,
             ret = WH_SHE_ERC_WRITE_PROTECTED;
     }
     /* check UID == 0 */
-    if (ret == 0 && wh_Utils_memeqzero(packet->sheLoadKeyReq.messageOne,
+    if (ret == 0 && wh_Utils_memeqzero(req.messageOne,
         WH_SHE_UID_SZ) == 1) {
         /* check wildcard */
         if ((she_meta_flags & WH_SHE_FLAG_WILDCARD) == 0) {
@@ -395,12 +512,12 @@ static int hsmSheLoadKey(whServerContext* server, whPacket* packet,
         }
     }
     /* compare to UID */
-    else if (ret == 0 && XMEMCMP(packet->sheLoadKeyReq.messageOne,
+    else if (ret == 0 && XMEMCMP(req.messageOne,
         server->she->uid, sizeof(server->she->uid)) != 0) {
         ret = WH_SHE_ERC_KEY_UPDATE_ERROR;
     }
     /* verify msg_counter_BE is greater than stored value */
-    msg_counter_BE = (uint32_t*)packet->sheLoadKeyReq.messageTwo;
+    msg_counter_BE = (uint32_t*)req.messageTwo;
     if (ret == 0 &&
         keyRet != WH_ERROR_NOTFOUND &&
         wh_Utils_ntohl(*msg_counter_BE) >> 4 <= she_meta_count) {
@@ -410,26 +527,25 @@ static int hsmSheLoadKey(whServerContext* server, whPacket* packet,
     if (ret == 0) {
         meta->id = WH_MAKE_KEYID(WH_KEYTYPE_SHE,
             server->comm->client_id,
-            hsmShePopId(packet->sheLoadKeyReq.messageOne));
+            hsmShePopId(req.messageOne));
         she_meta_flags =
-            hsmShePopFlags(packet->sheLoadKeyReq.messageTwo);
+            hsmShePopFlags(req.messageTwo);
         she_meta_count = wh_Utils_ntohl(*msg_counter_BE) >> 4;
         /* Update the meta label with new values */
         wh_She_Meta2Label(she_meta_count, she_meta_flags, meta->label);
         meta->len = WH_SHE_KEY_SZ;
         /* cache if ram key, overwrite otherwise */
         if (WH_KEYID_ID(meta->id) == WH_SHE_RAM_KEY_ID) {
-            ret = hsmCacheKey(server, meta, packet->sheLoadKeyReq.messageTwo
-                + WH_SHE_KEY_SZ);
+            ret = hsmCacheKey(server, meta, req.messageTwo + WH_SHE_KEY_SZ);
         }
         else {
             ret = wh_Nvm_AddObject(server->nvm, meta, meta->len,
-                packet->sheLoadKeyReq.messageTwo + WH_SHE_KEY_SZ);
+                req.messageTwo + WH_SHE_KEY_SZ);
             /* read the evicted back from nvm */
             if (ret == 0) {
                 keySz = WH_SHE_KEY_SZ;
                 ret = hsmReadKey(server, meta->id, meta,
-                    packet->sheLoadKeyReq.messageTwo + WH_SHE_KEY_SZ,
+                    req.messageTwo + WH_SHE_KEY_SZ,
                     &keySz);
                 /* Extract count and flags from the label, even if it failed */
                 wh_She_Label2Meta(meta->label, &she_meta_count, &she_meta_flags);
@@ -441,7 +557,7 @@ static int hsmSheLoadKey(whServerContext* server, whPacket* packet,
     /* generate K3 using the updated key */
     if (ret == 0) {
         /* copy new key to kdfInput */
-        XMEMCPY(kdfInput, packet->sheLoadKeyReq.messageTwo +
+        XMEMCPY(kdfInput, req.messageTwo +
             WH_SHE_KEY_SZ, WH_SHE_KEY_SZ);
         /* add WH_SHE_KEY_UPDATE_ENC_C to the input */
         XMEMCPY(kdfInput + meta->len, _SHE_KEY_UPDATE_ENC_C,
@@ -457,21 +573,26 @@ static int hsmSheLoadKey(whServerContext* server, whPacket* packet,
             NULL, AES_ENCRYPTION);
     }
     if (ret == 0) {
-        /* reset messageTwo with the nvm read msg_counter_BE, pad with a 1 bit */
+        /* Prepare counter in separate buffer */
+        msg_counter_BE = (uint32_t*)counter_buffer;
         *msg_counter_BE = wh_Utils_htonl(she_meta_count << 4);
-        packet->sheLoadKeyReq.messageTwo[3] |= 0x08;
-        /* encrypt the new msg_counter_BE */
+        counter_buffer[3] |= 0x08;
+
+        /* First copy UID into messageFour */
+        XMEMCPY(resp.messageFour, server->she->uid, sizeof(server->she->uid));
+        /* Set ID and AuthID in last byte */
+        resp.messageFour[15] = ((hsmShePopId(req.messageOne) << 4) | 
+                               hsmShePopAuthId(req.messageOne));
+
+        /* Then encrypt counter into second half of messageFour */
         ret = wc_AesEncryptDirect(server->she->sheAes,
-            packet->sheLoadKeyRes.messageFour + WH_SHE_KEY_SZ,
-            packet->sheLoadKeyReq.messageTwo);
+            resp.messageFour + WH_SHE_KEY_SZ,
+            counter_buffer);
     }
     /* free aes for protection */
     wc_AesFree(server->she->sheAes);
     /* generate K4 using the updated key */
     if (ret == 0) {
-        /* set our UID, ID and AUTHID are already set from messageOne */
-        XMEMCPY(packet->sheLoadKeyRes.messageFour, server->she->uid,
-            sizeof(server->she->uid));
         /* add WH_SHE_KEY_UPDATE_MAC_C to the input */
         XMEMCPY(kdfInput + meta->len, _SHE_KEY_UPDATE_MAC_C,
             sizeof(_SHE_KEY_UPDATE_MAC_C));
@@ -482,679 +603,1028 @@ static int hsmSheLoadKey(whServerContext* server, whPacket* packet,
     /* cmac messageFour using K4 as the cmac key */
     if (ret == 0) {
         field = AES_BLOCK_SIZE;
-        ret = wc_AesCmacGenerate_ex(server->she->sheCmac, packet->sheLoadKeyRes.messageFive,
-            (word32*)&field, packet->sheLoadKeyRes.messageFour,
-            sizeof(packet->sheLoadKeyRes.messageFour), tmpKey,
+        ret = wc_AesCmacGenerate_ex(server->she->sheCmac, resp.messageFive,
+            (word32*)&field, resp.messageFour,
+            sizeof(resp.messageFour), tmpKey,
             WH_SHE_KEY_SZ, NULL, server->crypto->devId);
     }
     if (ret == 0) {
-        *size = WH_PACKET_STUB_SIZE + sizeof(packet->sheLoadKeyRes);
         /* mark if the ram key was loaded */
         if (WH_KEYID_ID(meta->id) == WH_SHE_RAM_KEY_ID)
             server->she->ramKeyPlain = 1;
     }
+
+    *out_resp_size = sizeof(resp);
+    resp.rc = _translateSheReturnCode(ret);
+    (void)wh_MessageShe_TranslateLoadKeyResponse(magic, &resp, resp_packet);
+
     return ret;
 }
 
-static int hsmSheLoadPlainKey(whServerContext* server, whPacket* packet,
-    uint16_t* size)
+static int hsmSheLoadPlainKey(whServerContext* server, uint16_t magic,
+                              uint16_t req_size, const void* req_packet,
+                              uint16_t* out_resp_size, void* resp_packet)
 {
-    int ret = 0;
+    int           ret     = 0;
     whNvmMetadata meta[1] = {{0}};
-    meta->id = WH_MAKE_KEYID(WH_KEYTYPE_SHE,
-        server->comm->client_id, WH_SHE_RAM_KEY_ID);
+
+    whMessageShe_LoadPlainKeyRequest  req;
+    whMessageShe_LoadPlainKeyResponse resp;
+
+    (void)wh_MessageShe_TranslateLoadPlainKeyRequest(magic, req_packet, &req);
+
+    meta->id  = WH_MAKE_KEYID(WH_KEYTYPE_SHE, server->comm->client_id,
+                              WH_SHE_RAM_KEY_ID);
     meta->len = WH_SHE_KEY_SZ;
+
     /* cache if ram key, overwrite otherwise */
-    ret = hsmCacheKey(server, meta, packet->sheLoadPlainKeyReq.key);
+    ret = hsmCacheKey(server, meta, req.key);
     if (ret == 0) {
-        *size = WH_PACKET_STUB_SIZE;
         server->she->ramKeyPlain = 1;
     }
+
+    resp.rc = _translateSheReturnCode(ret);
+    (void)wh_MessageShe_TranslateLoadPlainKeyResponse(magic, &resp,
+                                                      resp_packet);
+    *out_resp_size = sizeof(resp);
+
     return ret;
 }
 
 
-static int hsmSheExportRamKey(whServerContext* server, whPacket* packet,
-    uint16_t* size)
+static int hsmSheExportRamKey(whServerContext* server, uint16_t magic,
+                              uint16_t req_size, const void* req_packet,
+                              uint16_t* out_resp_size, void* resp_packet)
 {
-    int ret = 0;
-    uint32_t keySz;
-    uint32_t field;
-    uint8_t kdfInput[WH_SHE_KEY_SZ * 2];
-    uint8_t cmacOutput[AES_BLOCK_SIZE];
-    uint8_t tmpKey[WH_SHE_KEY_SZ];
-    whNvmMetadata meta[1];
-    uint32_t* counter;
+    int                               ret = 0;
+    uint32_t                          keySz;
+    uint32_t                          field;
+    uint8_t                           kdfInput[WH_SHE_KEY_SZ * 2];
+    uint8_t                           cmacOutput[AES_BLOCK_SIZE];
+    uint8_t                           tmpKey[WH_SHE_KEY_SZ];
+    whNvmMetadata                     meta[1];
+    uint32_t*                         counter;
+    whMessageShe_ExportRamKeyResponse resp;
 
     /* check if ram key was loaded by CMD_LOAD_PLAIN_KEY */
-    if (server->she->ramKeyPlain == 0)
+    if (server->she->ramKeyPlain == 0) {
         ret = WH_SHE_ERC_KEY_INVALID;
+    }
     /* read the auth key by AuthID */
     if (ret == 0) {
         keySz = WH_SHE_KEY_SZ;
-        ret = hsmReadKey(server, WH_MAKE_KEYID(WH_KEYTYPE_SHE,
-            server->comm->client_id, WH_SHE_SECRET_KEY_ID), meta,
-            kdfInput, &keySz);
-        if (ret != 0)
+        ret   = hsmReadKey(server,
+                           WH_MAKE_KEYID(WH_KEYTYPE_SHE, server->comm->client_id,
+                                         WH_SHE_SECRET_KEY_ID),
+                           meta, kdfInput, &keySz);
+        if (ret != 0) {
             ret = WH_SHE_ERC_KEY_NOT_AVAILABLE;
+        }
     }
     if (ret == 0) {
         /* set UID, key id and authId */
-        XMEMCPY(packet->sheExportRamKeyRes.messageOne, server->she->uid,
-            sizeof(server->she->uid));
-        packet->sheExportRamKeyRes.messageOne[15] =
+        XMEMCPY(resp.messageOne, server->she->uid, sizeof(server->she->uid));
+        resp.messageOne[15] =
             ((WH_SHE_RAM_KEY_ID << 4) | (WH_SHE_SECRET_KEY_ID));
         /* add WH_SHE_KEY_UPDATE_ENC_C to the input */
         XMEMCPY(kdfInput + meta->len, _SHE_KEY_UPDATE_ENC_C,
-            sizeof(_SHE_KEY_UPDATE_ENC_C));
+                sizeof(_SHE_KEY_UPDATE_ENC_C));
         /* generate K1 */
         ret = wh_AesMp16(server, kdfInput,
-            meta->len + sizeof(_SHE_KEY_UPDATE_ENC_C), tmpKey);
+                         meta->len + sizeof(_SHE_KEY_UPDATE_ENC_C), tmpKey);
     }
     /* build cleartext M2 */
     if (ret == 0) {
         /* set the counter, flags and ram key */
-        XMEMSET(packet->sheExportRamKeyRes.messageTwo, 0,
-            sizeof(packet->sheExportRamKeyRes.messageTwo));
+        XMEMSET(resp.messageTwo, 0, sizeof(resp.messageTwo));
         /* set count to 1 */
-        counter = (uint32_t*)packet->sheExportRamKeyRes.messageTwo;
+        counter  = (uint32_t*)resp.messageTwo;
         *counter = (wh_Utils_htonl(1) << 4);
-        keySz = WH_SHE_KEY_SZ;
-        ret = hsmReadKey(server, WH_MAKE_KEYID(WH_KEYTYPE_SHE,
-            server->comm->client_id, WH_SHE_RAM_KEY_ID), meta,
-            packet->sheExportRamKeyRes.messageTwo + WH_SHE_KEY_SZ,
-            &keySz);
-        if (ret != 0)
+        keySz    = WH_SHE_KEY_SZ;
+        ret      = hsmReadKey(server,
+                              WH_MAKE_KEYID(WH_KEYTYPE_SHE, server->comm->client_id,
+                                            WH_SHE_RAM_KEY_ID),
+                              meta, resp.messageTwo + WH_SHE_KEY_SZ, &keySz);
+        if (ret != 0) {
             ret = WH_SHE_ERC_KEY_NOT_AVAILABLE;
+        }
     }
     /* encrypt M2 with K1 */
-    if (ret == 0)
+    if (ret == 0) {
         ret = wc_AesInit(server->she->sheAes, NULL, server->crypto->devId);
+    }
     if (ret == 0) {
         ret = wc_AesSetKey(server->she->sheAes, tmpKey, WH_SHE_KEY_SZ, NULL,
-            AES_ENCRYPTION);
+                           AES_ENCRYPTION);
     }
     if (ret == 0) {
         /* copy the ram key to cmacOutput before it gets encrypted */
-        XMEMCPY(cmacOutput,
-            packet->sheExportRamKeyRes.messageTwo + WH_SHE_KEY_SZ,
-            WH_SHE_KEY_SZ);
-        ret = wc_AesCbcEncrypt(server->she->sheAes,
-            packet->sheExportRamKeyRes.messageTwo,
-            packet->sheExportRamKeyRes.messageTwo,
-            sizeof(packet->sheExportRamKeyRes.messageTwo));
+        XMEMCPY(cmacOutput, resp.messageTwo + WH_SHE_KEY_SZ, WH_SHE_KEY_SZ);
+        ret = wc_AesCbcEncrypt(server->she->sheAes, resp.messageTwo,
+                               resp.messageTwo, sizeof(resp.messageTwo));
     }
     /* free aes for protection */
     wc_AesFree(server->she->sheAes);
     if (ret == 0) {
         /* add WH_SHE_KEY_UPDATE_MAC_C to the input */
         XMEMCPY(kdfInput + meta->len, _SHE_KEY_UPDATE_MAC_C,
-            sizeof(_SHE_KEY_UPDATE_MAC_C));
+                sizeof(_SHE_KEY_UPDATE_MAC_C));
         /* generate K2 */
         ret = wh_AesMp16(server, kdfInput,
-            meta->len + sizeof(_SHE_KEY_UPDATE_MAC_C), tmpKey);
+                         meta->len + sizeof(_SHE_KEY_UPDATE_MAC_C), tmpKey);
     }
     /* cmac messageOne and messageTwo using K2 as the cmac key */
     if (ret == 0) {
+        uint8_t cmacInput[sizeof(resp.messageOne) + sizeof(resp.messageTwo)];
+        /* Concatenate messageOne and messageTwo for CMAC */
+        memcpy(cmacInput, resp.messageOne, sizeof(resp.messageOne));
+        memcpy(cmacInput + sizeof(resp.messageOne), resp.messageTwo,
+               sizeof(resp.messageTwo));
+
         field = AES_BLOCK_SIZE;
-        ret = wc_AesCmacGenerate_ex(server->she->sheCmac,
-            packet->sheExportRamKeyRes.messageThree, (word32*)&field,
-            (uint8_t*)&packet->sheExportRamKeyRes,
-            sizeof(packet->sheExportRamKeyRes.messageOne) +
-            sizeof(packet->sheExportRamKeyRes.messageTwo), tmpKey,
-            WH_SHE_KEY_SZ, NULL, server->crypto->devId);
+        ret   = wc_AesCmacGenerate_ex(server->she->sheCmac, resp.messageThree,
+                                      (word32*)&field, cmacInput,
+                                      sizeof(cmacInput), tmpKey, WH_SHE_KEY_SZ,
+                                      NULL, server->crypto->devId);
     }
     if (ret == 0) {
         /* copy the ram key to kdfInput */
         XMEMCPY(kdfInput, cmacOutput, WH_SHE_KEY_SZ);
         /* add WH_SHE_KEY_UPDATE_ENC_C to the input */
         XMEMCPY(kdfInput + WH_SHE_KEY_SZ, _SHE_KEY_UPDATE_ENC_C,
-            sizeof(_SHE_KEY_UPDATE_ENC_C));
+                sizeof(_SHE_KEY_UPDATE_ENC_C));
         /* generate K3 */
         ret = wh_AesMp16(server, kdfInput,
-            WH_SHE_KEY_SZ + sizeof(_SHE_KEY_UPDATE_ENC_C), tmpKey);
+                         WH_SHE_KEY_SZ + sizeof(_SHE_KEY_UPDATE_ENC_C), tmpKey);
     }
     /* set K3 as encryption key */
-    if (ret == 0)
-        ret = wc_AesInit(server->she->sheAes, NULL, server->crypto->devId);
     if (ret == 0) {
-        ret = wc_AesSetKey(server->she->sheAes, tmpKey, WH_SHE_KEY_SZ,
-            NULL, AES_ENCRYPTION);
+        ret = wc_AesInit(server->she->sheAes, NULL, server->crypto->devId);
     }
     if (ret == 0) {
-        XMEMSET(packet->sheExportRamKeyRes.messageFour, 0,
-            sizeof(packet->sheExportRamKeyRes.messageFour));
+        ret = wc_AesSetKey(server->she->sheAes, tmpKey, WH_SHE_KEY_SZ, NULL,
+                           AES_ENCRYPTION);
+    }
+    if (ret == 0) {
+        XMEMSET(resp.messageFour, 0, sizeof(resp.messageFour));
         /* set counter to 1, pad with 1 bit */
-        counter = (uint32_t*)(packet->sheExportRamKeyRes.messageFour +
-                WH_SHE_KEY_SZ);
+        counter  = (uint32_t*)(resp.messageFour + WH_SHE_KEY_SZ);
         *counter = (wh_Utils_htonl(1) << 4);
-        packet->sheExportRamKeyRes.messageFour[WH_SHE_KEY_SZ + 3] |=
-            0x08;
+        resp.messageFour[WH_SHE_KEY_SZ + 3] |= 0x08;
         /* encrypt the new counter */
         ret = wc_AesEncryptDirect(server->she->sheAes,
-            packet->sheExportRamKeyRes.messageFour + WH_SHE_KEY_SZ,
-            packet->sheExportRamKeyRes.messageFour + WH_SHE_KEY_SZ);
+                                  resp.messageFour + WH_SHE_KEY_SZ,
+                                  resp.messageFour + WH_SHE_KEY_SZ);
     }
     /* free aes for protection */
     wc_AesFree(server->she->sheAes);
     if (ret == 0) {
         /* set UID, key id and authId */
-        XMEMCPY(packet->sheExportRamKeyRes.messageFour, server->she->uid,
-            sizeof(server->she->uid));
-        packet->sheExportRamKeyRes.messageFour[15] =
+        XMEMCPY(resp.messageFour, server->she->uid, sizeof(server->she->uid));
+        resp.messageFour[15] =
             ((WH_SHE_RAM_KEY_ID << 4) | (WH_SHE_SECRET_KEY_ID));
         /* add WH_SHE_KEY_UPDATE_MAC_C to the input */
         XMEMCPY(kdfInput + WH_SHE_KEY_SZ, _SHE_KEY_UPDATE_MAC_C,
-            sizeof(_SHE_KEY_UPDATE_MAC_C));
+                sizeof(_SHE_KEY_UPDATE_MAC_C));
         /* generate K4 */
         ret = wh_AesMp16(server, kdfInput,
-            WH_SHE_KEY_SZ + sizeof(_SHE_KEY_UPDATE_MAC_C), tmpKey);
+                         WH_SHE_KEY_SZ + sizeof(_SHE_KEY_UPDATE_MAC_C), tmpKey);
     }
     /* cmac messageFour using K4 as the cmac key */
     if (ret == 0) {
         field = AES_BLOCK_SIZE;
-        ret = wc_AesCmacGenerate_ex(server->she->sheCmac,
-            packet->sheExportRamKeyRes.messageFive, (word32*)&field,
-            packet->sheExportRamKeyRes.messageFour,
-            sizeof(packet->sheExportRamKeyRes.messageFour), tmpKey,
-            WH_SHE_KEY_SZ, NULL, server->crypto->devId);
+        ret   = wc_AesCmacGenerate_ex(server->she->sheCmac, resp.messageFive,
+                                      (word32*)&field, resp.messageFour,
+                                      sizeof(resp.messageFour), tmpKey,
+                                      WH_SHE_KEY_SZ, NULL, server->crypto->devId);
     }
-    if (ret == 0)
-        *size = WH_PACKET_STUB_SIZE + sizeof(packet->sheExportRamKeyRes);
+
+    resp.rc = _translateSheReturnCode(ret);
+    (void)wh_MessageShe_TranslateExportRamKeyResponse(magic, &resp,
+                                                      resp_packet);
+    *out_resp_size = sizeof(resp);
+
     return ret;
 }
 
-static int hsmSheInitRnd(whServerContext* server, whPacket* packet,
-    uint16_t* size)
+static int hsmSheInitRnd(whServerContext* server, uint16_t magic,
+                        uint16_t req_size, const void* req_packet,
+                        uint16_t* out_resp_size, void* resp_packet)
 {
-    int ret = 0;
-    uint32_t keySz;
-    uint8_t kdfInput[WH_SHE_KEY_SZ * 2];
-    uint8_t cmacOutput[AES_BLOCK_SIZE];
-    uint8_t tmpKey[WH_SHE_KEY_SZ];
-    whNvmMetadata meta[1];
+    int                          ret = 0;
+    uint32_t                     keySz;
+    uint8_t                      kdfInput[WH_SHE_KEY_SZ * 2];
+    uint8_t                      cmacOutput[AES_BLOCK_SIZE];
+    uint8_t                      tmpKey[WH_SHE_KEY_SZ];
+    whNvmMetadata                meta[1];
+    whMessageShe_InitRngResponse resp;
+
     /* check that init hasn't already been called since startup */
-    if (server->she->rndInited == 1)
+    if (server->she->rndInited == 1) {
         ret = WH_SHE_ERC_SEQUENCE_ERROR;
+    }
     /* read secret key */
     if (ret == 0) {
         keySz = WH_SHE_KEY_SZ;
-        ret = hsmReadKey(server, WH_MAKE_KEYID(WH_KEYTYPE_SHE,
-            server->comm->client_id, WH_SHE_SECRET_KEY_ID), meta,
-            kdfInput, &keySz);
-        if (ret != 0)
+        ret   = hsmReadKey(server,
+                           WH_MAKE_KEYID(WH_KEYTYPE_SHE, server->comm->client_id,
+                                         WH_SHE_SECRET_KEY_ID),
+                           meta, kdfInput, &keySz);
+        if (ret != 0) {
             ret = WH_SHE_ERC_KEY_NOT_AVAILABLE;
+        }
     }
     if (ret == 0) {
         /* add PRNG_SEED_KEY_C */
         XMEMCPY(kdfInput + WH_SHE_KEY_SZ, _SHE_PRNG_SEED_KEY_C,
-            sizeof(_SHE_PRNG_SEED_KEY_C));
+                sizeof(_SHE_PRNG_SEED_KEY_C));
         /* generate PRNG_SEED_KEY */
         ret = wh_AesMp16(server, kdfInput,
-            WH_SHE_KEY_SZ + sizeof(_SHE_PRNG_SEED_KEY_C), tmpKey);
+                         WH_SHE_KEY_SZ + sizeof(_SHE_PRNG_SEED_KEY_C), tmpKey);
     }
     /* read the current PRNG_SEED, i - 1, to cmacOutput */
     if (ret == 0) {
         keySz = WH_SHE_KEY_SZ;
-        ret = hsmReadKey(server, WH_MAKE_KEYID(WH_KEYTYPE_SHE,
-            server->comm->client_id, WH_SHE_PRNG_SEED_ID), meta,
-            cmacOutput, &keySz);
-        if (ret != 0)
+        ret   = hsmReadKey(server,
+                           WH_MAKE_KEYID(WH_KEYTYPE_SHE, server->comm->client_id,
+                                         WH_SHE_PRNG_SEED_ID),
+                           meta, cmacOutput, &keySz);
+        if (ret != 0) {
             ret = WH_SHE_ERC_KEY_NOT_AVAILABLE;
+        }
     }
     /* set up aes */
-    if (ret == 0)
-        ret = wc_AesInit(server->she->sheAes, NULL, server->crypto->devId);
     if (ret == 0) {
-        ret = wc_AesSetKey(server->she->sheAes, tmpKey, WH_SHE_KEY_SZ,
-            NULL, AES_ENCRYPTION);
+        ret = wc_AesInit(server->she->sheAes, NULL, server->crypto->devId);
+    }
+    if (ret == 0) {
+        ret = wc_AesSetKey(server->she->sheAes, tmpKey, WH_SHE_KEY_SZ, NULL,
+                           AES_ENCRYPTION);
     }
     /* encrypt to the PRNG_SEED, i */
     if (ret == 0) {
         ret = wc_AesCbcEncrypt(server->she->sheAes, cmacOutput, cmacOutput,
-            WH_SHE_KEY_SZ);
+                               WH_SHE_KEY_SZ);
     }
     /* free aes for protection */
     wc_AesFree(server->she->sheAes);
     /* save PRNG_SEED, i */
     if (ret == 0) {
-        meta->id = WH_MAKE_KEYID(WH_KEYTYPE_SHE,
-            server->comm->client_id, WH_SHE_PRNG_SEED_ID);
+        meta->id  = WH_MAKE_KEYID(WH_KEYTYPE_SHE, server->comm->client_id,
+                                  WH_SHE_PRNG_SEED_ID);
         meta->len = WH_SHE_KEY_SZ;
-        ret = wh_Nvm_AddObject(server->nvm, meta, meta->len, cmacOutput);
-        if (ret != 0)
+        ret       = wh_Nvm_AddObject(server->nvm, meta, meta->len, cmacOutput);
+        if (ret != 0) {
             ret = WH_SHE_ERC_KEY_UPDATE_ERROR;
+        }
     }
     if (ret == 0) {
         /* set PRNG_STATE */
         XMEMCPY(server->she->prngState, cmacOutput, WH_SHE_KEY_SZ);
         /* add PRNG_KEY_C to the kdf input */
         XMEMCPY(kdfInput + WH_SHE_KEY_SZ, _SHE_PRNG_KEY_C,
-            sizeof(_SHE_PRNG_KEY_C));
+                sizeof(_SHE_PRNG_KEY_C));
         /* generate PRNG_KEY */
         ret = wh_AesMp16(server, kdfInput,
-            WH_SHE_KEY_SZ + sizeof(_SHE_PRNG_KEY_C),
-            server->she->prngKey);
+                         WH_SHE_KEY_SZ + sizeof(_SHE_PRNG_KEY_C),
+                         server->she->prngKey);
     }
     if (ret == 0) {
         /* set init rng to 1 */
         server->she->rndInited = 1;
-        /* set ERC_NO_ERROR */
-        packet->sheInitRngRes.status = WH_SHE_ERC_NO_ERROR;
-        *size = WH_PACKET_STUB_SIZE + sizeof(packet->sheInitRngRes);
     }
+
+    /* TODO: In the original code we don't set the status on failure. I took
+     * the liberty to set it and doesn't appear to have any negative side
+     * effects. */
+    resp.status = (ret == 0) ? WH_SHE_ERC_NO_ERROR : WH_SHE_ERC_GENERAL_ERROR;
+    resp.rc = _translateSheReturnCode(ret);
+    (void)wh_MessageShe_TranslateInitRngResponse(magic, &resp, resp_packet);
+    *out_resp_size = sizeof(resp);
+
     return ret;
 }
 
 
-static int hsmSheRnd(whServerContext* server, whPacket* packet, uint16_t* size)
+static int hsmSheRnd(whServerContext* server, uint16_t magic, uint16_t req_size,
+                     const void* req_packet, uint16_t* out_resp_size,
+                     void* resp_packet)
 {
-    int ret = 0;
+    int                      ret = 0;
+    whMessageShe_RndResponse resp;
+
     /* check that rng has been inited */
-    if (server->she->rndInited == 0)
+    if (server->she->rndInited == 0) {
         ret = WH_SHE_ERC_RNG_SEED;
+    }
+
     /* set up aes */
-    if (ret == 0)
+    if (ret == 0) {
         ret = wc_AesInit(server->she->sheAes, NULL, server->crypto->devId);
+    }
+
     /* use PRNG_KEY as the encryption key */
     if (ret == 0) {
         ret = wc_AesSetKey(server->she->sheAes, server->she->prngKey,
-            WH_SHE_KEY_SZ, NULL, AES_ENCRYPTION);
+                           WH_SHE_KEY_SZ, NULL, AES_ENCRYPTION);
     }
+
     /* encrypt the PRNG_STATE, i - 1 to i */
     if (ret == 0) {
         ret = wc_AesCbcEncrypt(server->she->sheAes, server->she->prngState,
-            server->she->prngState, WH_SHE_KEY_SZ);
+                               server->she->prngState, WH_SHE_KEY_SZ);
     }
+
     /* free aes for protection */
     wc_AesFree(server->she->sheAes);
+
     if (ret == 0) {
         /* copy PRNG_STATE */
-        XMEMCPY(packet->sheRndRes.rnd, server->she->prngState,
-            WH_SHE_KEY_SZ);
-        *size = WH_PACKET_STUB_SIZE + sizeof(packet->sheRndRes);
+        XMEMCPY(resp.rnd, server->she->prngState, WH_SHE_KEY_SZ);
     }
+
+    resp.rc = _translateSheReturnCode(ret);
+    (void)wh_MessageShe_TranslateRndResponse(magic, &resp, resp_packet);
+    *out_resp_size = sizeof(resp);
+
     return ret;
 }
 
-static int hsmSheExtendSeed(whServerContext* server, whPacket* packet,
-    uint16_t* size)
+static int hsmSheExtendSeed(whServerContext* server, uint16_t magic,
+                            uint16_t req_size, const void* req_packet,
+                            uint16_t* out_resp_size, void* resp_packet)
 {
-    int ret = 0;
-    uint32_t keySz;
-    uint8_t kdfInput[WH_SHE_KEY_SZ * 2];
-    whNvmMetadata meta[1];
+    int                             ret = 0;
+    uint32_t                        keySz;
+    uint8_t                         kdfInput[WH_SHE_KEY_SZ * 2];
+    whNvmMetadata                   meta[1];
+    whMessageShe_ExtendSeedRequest  req;
+    whMessageShe_ExtendSeedResponse resp;
+
+    (void)wh_MessageShe_TranslateExtendSeedRequest(magic, req_packet, &req);
+
     /* check that rng has been inited */
-    if (server->she->rndInited == 0)
+    if (server->she->rndInited == 0) {
         ret = WH_SHE_ERC_RNG_SEED;
+    }
     if (ret == 0) {
         /* set kdfInput to PRNG_STATE */
         XMEMCPY(kdfInput, server->she->prngState, WH_SHE_KEY_SZ);
         /* add the user supplied entropy to kdfInput */
-        XMEMCPY(kdfInput + WH_SHE_KEY_SZ,
-            packet->sheExtendSeedReq.entropy,
-            sizeof(packet->sheExtendSeedReq.entropy));
+        XMEMCPY(kdfInput + WH_SHE_KEY_SZ, req.entropy, sizeof(req.entropy));
         /* extend PRNG_STATE */
-        ret = wh_AesMp16(server, kdfInput,
-            WH_SHE_KEY_SZ + sizeof(packet->sheExtendSeedReq.entropy),
-            server->she->prngState);
+        ret = wh_AesMp16(server, kdfInput, WH_SHE_KEY_SZ + sizeof(req.entropy),
+                         server->she->prngState);
     }
     /* read the PRNG_SEED into kdfInput */
     if (ret == 0) {
         keySz = WH_SHE_KEY_SZ;
-        ret = hsmReadKey(server, WH_MAKE_KEYID(WH_KEYTYPE_SHE,
-            server->comm->client_id, WH_SHE_PRNG_SEED_ID), meta,
-            kdfInput, &keySz);
-        if (ret != 0)
+        ret   = hsmReadKey(server,
+                           WH_MAKE_KEYID(WH_KEYTYPE_SHE, server->comm->client_id,
+                                         WH_SHE_PRNG_SEED_ID),
+                           meta, kdfInput, &keySz);
+        if (ret != 0) {
             ret = WH_SHE_ERC_KEY_NOT_AVAILABLE;
+        }
     }
     if (ret == 0) {
         /* extend PRNG_STATE */
-        ret = wh_AesMp16(server, kdfInput,
-            WH_SHE_KEY_SZ + sizeof(packet->sheExtendSeedReq.entropy),
-            kdfInput);
+        ret = wh_AesMp16(server, kdfInput, WH_SHE_KEY_SZ + sizeof(req.entropy),
+                         kdfInput);
     }
     /* save PRNG_SEED */
     if (ret == 0) {
-        meta->id = WH_MAKE_KEYID(WH_KEYTYPE_SHE,
-            server->comm->client_id, WH_SHE_PRNG_SEED_ID);
+        meta->id  = WH_MAKE_KEYID(WH_KEYTYPE_SHE, server->comm->client_id,
+                                  WH_SHE_PRNG_SEED_ID);
         meta->len = WH_SHE_KEY_SZ;
-        ret = wh_Nvm_AddObject(server->nvm, meta, meta->len, kdfInput);
-        if (ret != 0)
+        ret       = wh_Nvm_AddObject(server->nvm, meta, meta->len, kdfInput);
+        if (ret != 0) {
             ret = WH_SHE_ERC_KEY_UPDATE_ERROR;
+        }
     }
-    if (ret == 0) {
-        /* set ERC_NO_ERROR */
-        packet->sheExtendSeedRes.status = WH_SHE_ERC_NO_ERROR;
-        *size = WH_PACKET_STUB_SIZE + sizeof(packet->sheExtendSeedRes);
-    }
+
+    /* TODO: In the original code we don't set the status on failure. I took
+     * the liberty to set it and doesn't appear to have any negative side
+     * effects. */
+    resp.status = (ret == 0) ? WH_SHE_ERC_NO_ERROR : WH_SHE_ERC_RNG_SEED;
+    resp.rc     = _translateSheReturnCode(ret);
+    (void)wh_MessageShe_TranslateExtendSeedResponse(magic, &resp, resp_packet);
+    *out_resp_size = sizeof(resp);
+
     return ret;
 }
 
-static int hsmSheEncEcb(whServerContext* server, whPacket* packet,
-    uint16_t* size)
+static int hsmSheEncEcb(whServerContext* server, uint16_t magic,
+                        uint16_t req_size, const void* req_packet,
+                        uint16_t* out_resp_size, void* resp_packet)
 {
-    int ret;
+    int      ret;
     uint32_t field;
     uint32_t keySz;
     uint8_t* in;
     uint8_t* out;
-    uint8_t tmpKey[WH_SHE_KEY_SZ];
+    uint8_t  tmpKey[WH_SHE_KEY_SZ];
+
+    whMessageShe_EncEcbRequest  req;
+    whMessageShe_EncEcbResponse resp;
+
     /* in and out are after the fixed sized fields */
-    in = (uint8_t*)(&packet->sheEncEcbReq + 1);
-    out = (uint8_t*)(&packet->sheEncEcbRes + 1);
+    in  = (uint8_t*)req_packet + sizeof(req);
+    out = (uint8_t*)resp_packet + sizeof(resp);
+
+    (void)wh_MessageShe_TranslateEncEcbRequest(magic, req_packet, &req);
+
     /* load the key */
     keySz = WH_SHE_KEY_SZ;
-    field = packet->sheEncEcbReq.sz;
+    field = req.sz;
     /* only process a multiple of block size */
     field -= (field % AES_BLOCK_SIZE);
-    ret = hsmReadKey(server, WH_MAKE_KEYID(WH_KEYTYPE_SHE,
-        server->comm->client_id, packet->sheEncEcbReq.keyId), NULL,
+    ret = hsmReadKey(
+        server,
+        WH_MAKE_KEYID(WH_KEYTYPE_SHE, server->comm->client_id, req.keyId), NULL,
         tmpKey, &keySz);
-    if (ret == 0)
+    if (ret == 0) {
         ret = wc_AesInit(server->she->sheAes, NULL, server->crypto->devId);
-    else
+    }
+    else {
         ret = WH_SHE_ERC_KEY_NOT_AVAILABLE;
-    if (ret == 0)
-        ret = wc_AesSetKey(server->she->sheAes, tmpKey, keySz, NULL, AES_ENCRYPTION);
-    if (ret == 0)
+    }
+    if (ret == 0) {
+        ret = wc_AesSetKey(server->she->sheAes, tmpKey, keySz, NULL,
+                           AES_ENCRYPTION);
+    }
+    if (ret == 0) {
         ret = wc_AesEcbEncrypt(server->she->sheAes, out, in, field);
+    }
     /* free aes for protection */
     wc_AesFree(server->she->sheAes);
     if (ret == 0) {
-        packet->sheEncEcbRes.sz = field;
-        *size = WH_PACKET_STUB_SIZE + sizeof(packet->sheEncEcbRes) + field;
+        resp.sz        = field;
+        *out_resp_size = sizeof(resp) + field;
     }
+    else {
+        resp.sz        = 0;
+        *out_resp_size = sizeof(resp);
+    }
+    resp.rc = _translateSheReturnCode(ret);
+    (void)wh_MessageShe_TranslateEncEcbResponse(magic, &resp, resp_packet);
     return ret;
 }
 
-static int hsmSheEncCbc(whServerContext* server, whPacket* packet,
-    uint16_t* size)
+static int hsmSheEncCbc(whServerContext* server, uint16_t magic,
+                        uint16_t req_size, const void* req_packet,
+                        uint16_t* out_resp_size, void* resp_packet)
 {
-    int ret;
-    uint32_t field;
-    uint32_t keySz;
-    uint8_t* in;
-    uint8_t* out;
-    uint8_t tmpKey[WH_SHE_KEY_SZ];
+    int                         ret;
+    uint32_t                    field;
+    uint32_t                    keySz;
+    uint8_t*                    in;
+    uint8_t*                    out;
+    uint8_t                     tmpKey[WH_SHE_KEY_SZ];
+    whMessageShe_EncCbcRequest  req;
+    whMessageShe_EncCbcResponse resp;
+
     /* in and out are after the fixed sized fields */
-    in = (uint8_t*)(&packet->sheEncCbcReq + 1);
-    out = (uint8_t*)(&packet->sheEncCbcRes + 1);
+    in  = (uint8_t*)req_packet + sizeof(req);
+    out = (uint8_t*)resp_packet + sizeof(resp);
+
+    (void)wh_MessageShe_TranslateEncCbcRequest(magic, req_packet, &req);
+
     /* load the key */
     keySz = WH_SHE_KEY_SZ;
-    field = packet->sheEncCbcReq.sz;
+    field = req.sz;
     /* only process a multiple of block size */
     field -= (field % AES_BLOCK_SIZE);
-    ret = hsmReadKey(server, WH_MAKE_KEYID(WH_KEYTYPE_SHE,
-        server->comm->client_id, packet->sheEncCbcReq.keyId), NULL,
+    ret = hsmReadKey(
+        server,
+        WH_MAKE_KEYID(WH_KEYTYPE_SHE, server->comm->client_id, req.keyId), NULL,
         tmpKey, &keySz);
-    if (ret == 0)
-        ret = wc_AesInit(server->she->sheAes, NULL, server->crypto->devId);
-    else
-        ret = WH_SHE_ERC_KEY_NOT_AVAILABLE;
+
     if (ret == 0) {
-        ret = wc_AesSetKey(server->she->sheAes, tmpKey, keySz, packet->sheEncCbcReq.iv,
-            AES_ENCRYPTION);
+        ret = wc_AesInit(server->she->sheAes, NULL, server->crypto->devId);
     }
-    if (ret == 0)
+    else {
+        ret = WH_SHE_ERC_KEY_NOT_AVAILABLE;
+    }
+
+    if (ret == 0) {
+        ret = wc_AesSetKey(server->she->sheAes, tmpKey, keySz, req.iv,
+                           AES_ENCRYPTION);
+    }
+
+    if (ret == 0) {
         ret = wc_AesCbcEncrypt(server->she->sheAes, out, in, field);
+    }
+
     /* free aes for protection */
     wc_AesFree(server->she->sheAes);
+
     if (ret == 0) {
-        packet->sheEncEcbRes.sz = field;
-        *size = WH_PACKET_STUB_SIZE + sizeof(packet->sheEncCbcRes) + field;
+        resp.sz        = field;
+        *out_resp_size = sizeof(resp) + field;
     }
+    else {
+        resp.sz        = 0;
+        *out_resp_size = sizeof(resp);
+    }
+
+    resp.rc = _translateSheReturnCode(ret);
+    (void)wh_MessageShe_TranslateEncCbcResponse(magic, &resp, resp_packet);
+
     return ret;
 }
 
-static int hsmSheDecEcb(whServerContext* server, whPacket* packet,
-    uint16_t* size)
+static int hsmSheDecEcb(whServerContext* server, uint16_t magic,
+                        uint16_t req_size, const void* req_packet,
+                        uint16_t* out_resp_size, void* resp_packet)
 {
-    int ret;
+    int      ret;
     uint32_t field;
     uint32_t keySz;
     uint8_t* in;
     uint8_t* out;
-    uint8_t tmpKey[WH_SHE_KEY_SZ];
+    uint8_t  tmpKey[WH_SHE_KEY_SZ];
+
+    whMessageShe_DecEcbRequest  req;
+    whMessageShe_DecEcbResponse resp;
+
     /* in and out are after the fixed sized fields */
-    in = (uint8_t*)(&packet->sheDecEcbReq + 1);
-    out = (uint8_t*)(&packet->sheDecEcbRes + 1);
+    in  = (uint8_t*)req_packet + sizeof(req);
+    out = (uint8_t*)resp_packet + sizeof(resp);
+
+    (void)wh_MessageShe_TranslateDecEcbRequest(magic, req_packet, &req);
+
     /* load the key */
     keySz = WH_SHE_KEY_SZ;
-    field = packet->sheDecEcbReq.sz;
+    field = req.sz;
     /* only process a multiple of block size */
     field -= (field % AES_BLOCK_SIZE);
-    ret = hsmReadKey(server, WH_MAKE_KEYID(WH_KEYTYPE_SHE,
-        server->comm->client_id, packet->sheDecEcbReq.keyId), NULL,
+    ret = hsmReadKey(
+        server,
+        WH_MAKE_KEYID(WH_KEYTYPE_SHE, server->comm->client_id, req.keyId), NULL,
         tmpKey, &keySz);
-    if (ret == 0)
+    if (ret == 0) {
         ret = wc_AesInit(server->she->sheAes, NULL, server->crypto->devId);
-    else
+    }
+    else {
         ret = WH_SHE_ERC_KEY_NOT_AVAILABLE;
-    if (ret == 0)
-        ret = wc_AesSetKey(server->she->sheAes, tmpKey, keySz, NULL, AES_DECRYPTION);
-    if (ret == 0)
+    }
+
+    if (ret == 0) {
+        ret = wc_AesSetKey(server->she->sheAes, tmpKey, keySz, NULL,
+                           AES_DECRYPTION);
+    }
+    if (ret == 0) {
         ret = wc_AesEcbDecrypt(server->she->sheAes, out, in, field);
+    }
+
     /* free aes for protection */
     wc_AesFree(server->she->sheAes);
+
     if (ret == 0) {
-        packet->sheDecEcbRes.sz = field;
-        *size = WH_PACKET_STUB_SIZE + sizeof(packet->sheDecEcbRes) + field;
+        resp.sz        = field;
+        *out_resp_size = sizeof(resp) + field;
     }
+    else {
+        resp.sz        = 0;
+        *out_resp_size = sizeof(resp);
+    }
+
+    resp.rc = _translateSheReturnCode(ret);
+    (void)wh_MessageShe_TranslateDecEcbResponse(magic, &resp, resp_packet);
+
     return ret;
 }
 
-static int hsmSheDecCbc(whServerContext* server, whPacket* packet,
-    uint16_t* size)
+static int hsmSheDecCbc(whServerContext* server, uint16_t magic,
+                        uint16_t req_size, const void* req_packet,
+                        uint16_t* out_resp_size, void* resp_packet)
 {
-    int ret;
-    uint32_t field;
-    uint32_t keySz;
-    uint8_t* in;
-    uint8_t* out;
-    uint8_t tmpKey[WH_SHE_KEY_SZ];
+    int                         ret;
+    uint32_t                    field;
+    uint32_t                    keySz;
+    uint8_t*                    in;
+    uint8_t*                    out;
+    uint8_t                     tmpKey[WH_SHE_KEY_SZ];
+    whMessageShe_DecCbcRequest  req;
+    whMessageShe_DecCbcResponse resp;
+
     /* in and out are after the fixed sized fields */
-    in = (uint8_t*)(&packet->sheDecCbcReq + 1);
-    out = (uint8_t*)(&packet->sheDecCbcRes + 1);
+    in  = (uint8_t*)req_packet + sizeof(req);
+    out = (uint8_t*)resp_packet + sizeof(resp);
+
+    (void)wh_MessageShe_TranslateDecCbcRequest(magic, req_packet, &req);
+
     /* load the key */
     keySz = WH_SHE_KEY_SZ;
-    field = packet->sheDecCbcReq.sz;
+    field = req.sz;
     /* only process a multiple of block size */
     field -= (field % AES_BLOCK_SIZE);
-    ret = hsmReadKey(server, WH_MAKE_KEYID(WH_KEYTYPE_SHE,
-        server->comm->client_id, packet->sheDecCbcReq.keyId), NULL,
+    ret = hsmReadKey(
+        server,
+        WH_MAKE_KEYID(WH_KEYTYPE_SHE, server->comm->client_id, req.keyId), NULL,
         tmpKey, &keySz);
-    if (ret == 0)
-        ret = wc_AesInit(server->she->sheAes, NULL, server->crypto->devId);
-    else
-        ret = WH_SHE_ERC_KEY_NOT_AVAILABLE;
+
     if (ret == 0) {
-        ret = wc_AesSetKey(server->she->sheAes, tmpKey, keySz, packet->sheDecCbcReq.iv,
-            AES_DECRYPTION);
+        ret = wc_AesInit(server->she->sheAes, NULL, server->crypto->devId);
     }
-    if (ret == 0)
+    else {
+        ret = WH_SHE_ERC_KEY_NOT_AVAILABLE;
+    }
+
+    if (ret == 0) {
+        ret = wc_AesSetKey(server->she->sheAes, tmpKey, keySz, req.iv,
+                           AES_DECRYPTION);
+    }
+
+    if (ret == 0) {
         ret = wc_AesCbcDecrypt(server->she->sheAes, out, in, field);
+    }
+
     /* free aes for protection */
     wc_AesFree(server->she->sheAes);
+
     if (ret == 0) {
-        packet->sheDecCbcRes.sz = field;
-        *size = WH_PACKET_STUB_SIZE + sizeof(packet->sheDecCbcRes) + field;
+        resp.sz        = field;
+        *out_resp_size = sizeof(resp) + field;
     }
+    else {
+        resp.sz        = 0;
+        *out_resp_size = sizeof(resp);
+    }
+
+    resp.rc = _translateSheReturnCode(ret);
+    (void)wh_MessageShe_TranslateDecCbcResponse(magic, &resp, resp_packet);
+
     return ret;
 }
 
-static int hsmSheGenerateMac(whServerContext* server, whPacket* packet,
-    uint16_t* size)
+static int hsmSheGenerateMac(whServerContext* server, uint16_t magic,
+                             uint16_t req_size, const void* req_packet,
+                             uint16_t* out_resp_size, void* resp_packet)
 {
-    int ret;
-    uint32_t field = AES_BLOCK_SIZE;
-    uint32_t keySz;
-    uint8_t* in;
-    uint8_t tmpKey[WH_SHE_KEY_SZ];
+    int                         ret;
+    uint32_t                    field = AES_BLOCK_SIZE;
+    uint32_t                    keySz;
+    uint8_t*                    in;
+    uint8_t                     tmpKey[WH_SHE_KEY_SZ];
+    whMessageShe_GenMacRequest  req;
+    whMessageShe_GenMacResponse resp;
+
     /* in and out are after the fixed sized fields */
-    in = (uint8_t*)(&packet->sheGenMacReq + 1);
+    in = (uint8_t*)req_packet + sizeof(req);
+
+    (void)wh_MessageShe_TranslateGenMacRequest(magic, req_packet, &req);
+
     /* load the key */
     keySz = WH_SHE_KEY_SZ;
-    ret = hsmReadKey(server, WH_MAKE_KEYID(WH_KEYTYPE_SHE,
-        server->comm->client_id, packet->sheGenMacReq.keyId), NULL, tmpKey,
-        &keySz);
+    ret   = hsmReadKey(
+        server,
+        WH_MAKE_KEYID(WH_KEYTYPE_SHE, server->comm->client_id, req.keyId), NULL,
+        tmpKey, &keySz);
     /* hash the message */
     if (ret == 0) {
-        ret = wc_AesCmacGenerate_ex(server->she->sheCmac, packet->sheGenMacRes.mac, (word32*)&field,
-            in, packet->sheGenMacReq.sz, tmpKey, WH_SHE_KEY_SZ, NULL,
-            server->crypto->devId);
+        ret = wc_AesCmacGenerate_ex(server->she->sheCmac, resp.mac,
+                                    (word32*)&field, in, req.sz, tmpKey,
+                                    WH_SHE_KEY_SZ, NULL, server->crypto->devId);
     }
-    else
+    else {
         ret = WH_SHE_ERC_KEY_NOT_AVAILABLE;
-    if (ret == 0)
-        *size = WH_PACKET_STUB_SIZE + sizeof(packet->sheGenMacRes);
+    }
+
+    resp.rc = _translateSheReturnCode(ret);
+    (void)wh_MessageShe_TranslateGenMacResponse(magic, &resp, resp_packet);
+    *out_resp_size = sizeof(resp);
+
     return ret;
 }
 
-static int hsmSheVerifyMac(whServerContext* server, whPacket* packet,
-    uint16_t* size)
+static int hsmSheVerifyMac(whServerContext* server, uint16_t magic,
+                           uint16_t req_size, const void* req_packet,
+                           uint16_t* out_resp_size, void* resp_packet)
 {
-    int ret;
-    uint32_t keySz;
-    uint8_t* message;
-    uint8_t* mac;
-    uint8_t tmpKey[WH_SHE_KEY_SZ];
+    int                            ret;
+    uint32_t                       keySz;
+    uint8_t*                       message;
+    uint8_t*                       mac;
+    uint8_t                        tmpKey[WH_SHE_KEY_SZ];
+    whMessageShe_VerifyMacRequest  req;
+    whMessageShe_VerifyMacResponse resp;
+
+
+    (void)wh_MessageShe_TranslateVerifyMacRequest(magic, req_packet, &req);
+
     /* in and mac are after the fixed sized fields */
-    message = (uint8_t*)(&packet->sheVerifyMacReq + 1);
-    mac = message + packet->sheVerifyMacReq.messageLen;
+    message = (uint8_t*)req_packet + sizeof(req);
+    mac     = message + req.messageLen;
+
     /* load the key */
     keySz = WH_SHE_KEY_SZ;
-    ret = hsmReadKey(server, WH_MAKE_KEYID(WH_KEYTYPE_SHE,
-        server->comm->client_id, packet->sheVerifyMacReq.keyId), NULL, tmpKey,
-        &keySz);
+    ret   = hsmReadKey(
+        server,
+        WH_MAKE_KEYID(WH_KEYTYPE_SHE, server->comm->client_id, req.keyId), NULL,
+        tmpKey, &keySz);
     /* verify the mac */
     if (ret == 0) {
-        ret = wc_AesCmacVerify_ex(server->she->sheCmac, mac, packet->sheVerifyMacReq.macLen,
-            message, packet->sheVerifyMacReq.messageLen, tmpKey, keySz, NULL,
-            server->crypto->devId);
+        ret = wc_AesCmacVerify_ex(server->she->sheCmac, mac, req.macLen,
+                                  message, req.messageLen, tmpKey, keySz, NULL,
+                                  server->crypto->devId);
         /* only evaluate if key was found */
-        if (ret == 0)
-            packet->sheVerifyMacRes.status = 0;
-        else
-            packet->sheVerifyMacRes.status = 1;
-        *size = WH_PACKET_STUB_SIZE + sizeof(packet->sheVerifyMacRes);
+        if (ret == 0) {
+            resp.status = 0;
+        }
+        else {
+            resp.status = 1;
+        }
     }
-    else
+    else {
         ret = WH_SHE_ERC_KEY_NOT_AVAILABLE;
+    }
+
+    resp.rc = _translateSheReturnCode(ret);
+    (void)wh_MessageShe_TranslateVerifyMacResponse(magic, &resp, resp_packet);
+    *out_resp_size = sizeof(resp);
+
     return ret;
 }
 
-int wh_Server_HandleSheRequest(whServerContext* server,
-    uint16_t action, uint8_t* data, uint16_t* size)
+
+/* TODO: This is terrible, but without implementing a SHE sub-protocol like we
+ * do for crypto layer, there is no way to return non-request specific error
+ * codes */
+int _reportInvalidSheState(whServerContext* server, uint16_t magic,
+                           uint16_t action, uint16_t req_size,
+                           const void* req_packet, uint16_t* out_resp_size,
+                           void* resp_packet)
 {
-    int ret = 0;
-    whPacket* packet = (whPacket*)data;
-
-    if (server == NULL || data == NULL || size == NULL)
-        return WH_ERROR_BADARGS;
-
     /* TODO does SHE specify what this error should be? */
     /* if we haven't secure booted, only allow secure boot requests */
     if ((server->she->sbState != WH_SHE_SB_SUCCESS &&
-        (action != WH_SHE_SECURE_BOOT_INIT &&
-        action != WH_SHE_SECURE_BOOT_UPDATE &&
-        action != WH_SHE_SECURE_BOOT_FINISH &&
-        action != WH_SHE_GET_STATUS &&
-        action != WH_SHE_SET_UID)) ||
+         (action != WH_SHE_SECURE_BOOT_INIT &&
+          action != WH_SHE_SECURE_BOOT_UPDATE &&
+          action != WH_SHE_SECURE_BOOT_FINISH && action != WH_SHE_GET_STATUS &&
+          action != WH_SHE_SET_UID)) ||
         (action != WH_SHE_SET_UID && server->she->uidSet == 0)) {
-        packet->rc = WH_SHE_ERC_SEQUENCE_ERROR;
-        *size = WH_PACKET_STUB_SIZE + sizeof(packet->rc);
-        return 0;
+        /* Create an error response based on the action */
+        switch (action) {
+            case WH_SHE_SET_UID: {
+                whMessageShe_SetUidResponse resp;
+                resp.rc = WH_SHE_ERC_SEQUENCE_ERROR;
+                (void)wh_MessageShe_TranslateSetUidResponse(magic, &resp,
+                                                            resp_packet);
+                *out_resp_size = sizeof(resp);
+                break;
+            }
+            case WH_SHE_SECURE_BOOT_INIT: {
+                whMessageShe_SecureBootInitResponse resp;
+                resp.rc = WH_SHE_ERC_SEQUENCE_ERROR;
+                (void)wh_MessageShe_TranslateSecureBootInitResponse(
+                    magic, &resp, resp_packet);
+                *out_resp_size = sizeof(resp);
+                break;
+            }
+            case WH_SHE_SECURE_BOOT_UPDATE: {
+                whMessageShe_SecureBootUpdateResponse resp;
+                resp.rc = WH_SHE_ERC_SEQUENCE_ERROR;
+                (void)wh_MessageShe_TranslateSecureBootUpdateResponse(
+                    magic, &resp, resp_packet);
+                *out_resp_size = sizeof(resp);
+                break;
+            }
+            case WH_SHE_SECURE_BOOT_FINISH: {
+                whMessageShe_SecureBootFinishResponse resp;
+                resp.rc = WH_SHE_ERC_SEQUENCE_ERROR;
+                (void)wh_MessageShe_TranslateSecureBootFinishResponse(
+                    magic, &resp, resp_packet);
+                *out_resp_size = sizeof(resp);
+                break;
+            }
+            case WH_SHE_GET_STATUS: {
+                whMessageShe_GetStatusResponse resp;
+                resp.rc   = WH_SHE_ERC_SEQUENCE_ERROR;
+                resp.sreg = 0;
+                (void)wh_MessageShe_TranslateGetStatusResponse(magic, &resp,
+                                                               resp_packet);
+                *out_resp_size = sizeof(resp);
+                break;
+            }
+            case WH_SHE_LOAD_KEY: {
+                whMessageShe_LoadKeyResponse resp;
+                resp.rc = WH_SHE_ERC_SEQUENCE_ERROR;
+                (void)wh_MessageShe_TranslateLoadKeyResponse(magic, &resp,
+                                                             resp_packet);
+                *out_resp_size = sizeof(resp);
+                break;
+            }
+            case WH_SHE_LOAD_PLAIN_KEY: {
+                whMessageShe_LoadPlainKeyResponse resp;
+                resp.rc = WH_SHE_ERC_SEQUENCE_ERROR;
+                (void)wh_MessageShe_TranslateLoadPlainKeyResponse(magic, &resp,
+                                                                  resp_packet);
+                *out_resp_size = sizeof(resp);
+                break;
+            }
+            case WH_SHE_EXPORT_RAM_KEY: {
+                whMessageShe_ExportRamKeyResponse resp;
+                resp.rc = WH_SHE_ERC_SEQUENCE_ERROR;
+                (void)wh_MessageShe_TranslateExportRamKeyResponse(magic, &resp,
+                                                                  resp_packet);
+                *out_resp_size = sizeof(resp);
+                break;
+            }
+            case WH_SHE_INIT_RND: {
+                whMessageShe_InitRngResponse resp;
+                resp.rc = WH_SHE_ERC_SEQUENCE_ERROR;
+                (void)wh_MessageShe_TranslateInitRngResponse(magic, &resp,
+                                                             resp_packet);
+                *out_resp_size = sizeof(resp);
+                break;
+            }
+            case WH_SHE_RND: {
+                whMessageShe_RndResponse resp;
+                resp.rc = WH_SHE_ERC_SEQUENCE_ERROR;
+                (void)wh_MessageShe_TranslateRndResponse(magic, &resp,
+                                                         resp_packet);
+                *out_resp_size = sizeof(resp);
+                break;
+            }
+            case WH_SHE_EXTEND_SEED: {
+                whMessageShe_ExtendSeedResponse resp;
+                resp.rc = WH_SHE_ERC_SEQUENCE_ERROR;
+                (void)wh_MessageShe_TranslateExtendSeedResponse(magic, &resp,
+                                                                resp_packet);
+                *out_resp_size = sizeof(resp);
+                break;
+            }
+            case WH_SHE_ENC_ECB: {
+                whMessageShe_EncEcbResponse resp;
+                resp.rc = WH_SHE_ERC_SEQUENCE_ERROR;
+                (void)wh_MessageShe_TranslateEncEcbResponse(magic, &resp,
+                                                            resp_packet);
+                *out_resp_size = sizeof(resp);
+                break;
+            }
+            case WH_SHE_ENC_CBC: {
+                whMessageShe_EncCbcResponse resp;
+                resp.rc = WH_SHE_ERC_SEQUENCE_ERROR;
+                (void)wh_MessageShe_TranslateEncCbcResponse(magic, &resp,
+                                                            resp_packet);
+                *out_resp_size = sizeof(resp);
+                break;
+            }
+            case WH_SHE_DEC_ECB: {
+                whMessageShe_DecEcbResponse resp;
+                resp.rc = WH_SHE_ERC_SEQUENCE_ERROR;
+                (void)wh_MessageShe_TranslateDecEcbResponse(magic, &resp,
+                                                            resp_packet);
+                *out_resp_size = sizeof(resp);
+                break;
+            }
+            case WH_SHE_DEC_CBC: {
+                whMessageShe_DecCbcResponse resp;
+                resp.rc = WH_SHE_ERC_SEQUENCE_ERROR;
+                (void)wh_MessageShe_TranslateDecCbcResponse(magic, &resp,
+                                                            resp_packet);
+                *out_resp_size = sizeof(resp);
+                break;
+            }
+            case WH_SHE_GEN_MAC: {
+                whMessageShe_GenMacResponse resp;
+                resp.rc = WH_SHE_ERC_SEQUENCE_ERROR;
+                (void)wh_MessageShe_TranslateGenMacResponse(magic, &resp,
+                                                            resp_packet);
+                *out_resp_size = sizeof(resp);
+                break;
+            }
+            case WH_SHE_VERIFY_MAC: {
+                whMessageShe_VerifyMacResponse resp;
+                resp.rc     = WH_SHE_ERC_SEQUENCE_ERROR;
+                resp.status = 1; /* Verification failed */
+                (void)wh_MessageShe_TranslateVerifyMacResponse(magic, &resp,
+                                                               resp_packet);
+                *out_resp_size = sizeof(resp);
+                break;
+            }
+        }
+        return WH_SHE_ERC_SEQUENCE_ERROR;
+    }
+    return 0;
+}
+
+int wh_Server_HandleSheRequest(whServerContext* server, uint16_t magic,
+                               uint16_t action, uint16_t req_size,
+                               const void* req_packet, uint16_t* out_resp_size,
+                               void* resp_packet)
+{
+    int ret = 0;
+
+    if (server == NULL || req_packet == NULL || out_resp_size == NULL) {
+        return WH_ERROR_BADARGS;
     }
 
-    switch (action)
-    {
-    case WH_SHE_SET_UID:
-        ret = hsmSheSetUid(server, packet);
-        break;
-    case WH_SHE_SECURE_BOOT_INIT:
-        ret = hsmSheSecureBootInit(server, packet, size);
-        break;
-    case WH_SHE_SECURE_BOOT_UPDATE:
-        ret = hsmSheSecureBootUpdate(server, packet, size);
-        break;
-    case WH_SHE_SECURE_BOOT_FINISH:
-        ret = hsmSheSecureBootFinish(server, packet, size);
-        break;
-    case WH_SHE_GET_STATUS:
-        ret = hsmSheGetStatus(server, packet, size);
-        break;
-    case WH_SHE_LOAD_KEY:
-        ret = hsmSheLoadKey(server, packet, size);
-        break;
-    case WH_SHE_LOAD_PLAIN_KEY:
-        ret = hsmSheLoadPlainKey(server, packet, size);
-        break;
-    case WH_SHE_EXPORT_RAM_KEY:
-        ret = hsmSheExportRamKey(server, packet, size);
-        break;
-    case WH_SHE_INIT_RND:
-        ret = hsmSheInitRnd(server, packet, size);
-        break;
-    case WH_SHE_RND:
-        ret = hsmSheRnd(server, packet, size);
-        break;
-    case WH_SHE_EXTEND_SEED:
-        ret = hsmSheExtendSeed(server, packet, size);
-        break;
-    case WH_SHE_ENC_ECB:
-        ret = hsmSheEncEcb(server, packet, size);
-        break;
-    case WH_SHE_ENC_CBC:
-        ret = hsmSheEncCbc(server, packet, size);
-        break;
-    case WH_SHE_DEC_ECB:
-        ret = hsmSheDecEcb(server, packet, size);
-        break;
-    case WH_SHE_DEC_CBC:
-        ret = hsmSheDecCbc(server, packet, size);
-        break;
-    case WH_SHE_GEN_MAC:
-        ret = hsmSheGenerateMac(server, packet, size);
-        break;
-    case WH_SHE_VERIFY_MAC:
-        ret = hsmSheVerifyMac(server, packet, size);
-        break;
-    default:
-        ret = WH_ERROR_BADARGS;
-        break;
-    }
-    /* if a handler didn't set a specific error, set general error */
+    ret = _reportInvalidSheState(server, magic, action, req_size, req_packet,
+                                 out_resp_size, resp_packet);
     if (ret != 0) {
-        if (ret != WH_SHE_ERC_SEQUENCE_ERROR &&
-        ret != WH_SHE_ERC_KEY_NOT_AVAILABLE && ret != WH_SHE_ERC_KEY_INVALID &&
-        ret != WH_SHE_ERC_KEY_EMPTY && ret != WH_SHE_ERC_NO_SECURE_BOOT &&
-        ret != WH_SHE_ERC_WRITE_PROTECTED && ret != WH_SHE_ERC_KEY_UPDATE_ERROR
-        && ret != WH_SHE_ERC_RNG_SEED && ret != WH_SHE_ERC_NO_DEBUGGING &&
-        ret != WH_SHE_ERC_BUSY && ret != WH_SHE_ERC_MEMORY_FAILURE) {
-            ret = WH_SHE_ERC_GENERAL_ERROR;
-        }
-        packet->rc = ret;
-        *size = WH_PACKET_STUB_SIZE + sizeof(packet->rc);
+        return ret;
     }
+
+    switch (action) {
+        case WH_SHE_SET_UID:
+            ret = hsmSheSetUid(server, magic, req_size, req_packet,
+                               out_resp_size, resp_packet);
+            break;
+        case WH_SHE_SECURE_BOOT_INIT:
+            ret = hsmSheSecureBootInit(server, magic, req_size, req_packet,
+                                       out_resp_size, resp_packet);
+            break;
+        case WH_SHE_SECURE_BOOT_UPDATE:
+            ret = hsmSheSecureBootUpdate(server, magic, req_size, req_packet,
+                                         out_resp_size, resp_packet);
+            break;
+        case WH_SHE_SECURE_BOOT_FINISH:
+            ret = hsmSheSecureBootFinish(server, magic, req_size, req_packet,
+                                         out_resp_size, resp_packet);
+            break;
+        case WH_SHE_GET_STATUS:
+            ret = hsmSheGetStatus(server, magic, req_size, req_packet,
+                                  out_resp_size, resp_packet);
+            break;
+        case WH_SHE_LOAD_KEY:
+            ret = hsmSheLoadKey(server, magic, req_size, req_packet,
+                                out_resp_size, resp_packet);
+            break;
+        case WH_SHE_LOAD_PLAIN_KEY:
+            ret = hsmSheLoadPlainKey(server, magic, req_size, req_packet,
+                                     out_resp_size, resp_packet);
+            break;
+        case WH_SHE_EXPORT_RAM_KEY:
+            ret = hsmSheExportRamKey(server, magic, req_size, req_packet,
+                                     out_resp_size, resp_packet);
+            break;
+        case WH_SHE_INIT_RND:
+            ret = hsmSheInitRnd(server, magic, req_size, req_packet,
+                                out_resp_size, resp_packet);
+            break;
+        case WH_SHE_RND:
+            ret = hsmSheRnd(server, magic, req_size, req_packet, out_resp_size,
+                            resp_packet);
+            break;
+        case WH_SHE_EXTEND_SEED:
+            ret = hsmSheExtendSeed(server, magic, req_size, req_packet,
+                                   out_resp_size, resp_packet);
+            break;
+        case WH_SHE_ENC_ECB:
+            ret = hsmSheEncEcb(server, magic, req_size, req_packet,
+                               out_resp_size, resp_packet);
+            break;
+        case WH_SHE_ENC_CBC:
+            ret = hsmSheEncCbc(server, magic, req_size, req_packet,
+                               out_resp_size, resp_packet);
+            break;
+        case WH_SHE_DEC_ECB:
+            ret = hsmSheDecEcb(server, magic, req_size, req_packet,
+                               out_resp_size, resp_packet);
+            break;
+        case WH_SHE_DEC_CBC:
+            ret = hsmSheDecCbc(server, magic, req_size, req_packet,
+                               out_resp_size, resp_packet);
+            break;
+        case WH_SHE_GEN_MAC:
+            ret = hsmSheGenerateMac(server, magic, req_size, req_packet,
+                                    out_resp_size, resp_packet);
+            break;
+        case WH_SHE_VERIFY_MAC:
+            ret = hsmSheVerifyMac(server, magic, req_size, req_packet,
+                                  out_resp_size, resp_packet);
+            break;
+        default:
+            ret = WH_ERROR_BADARGS;
+            break;
+    }
+
     /* reset our SHE state */
-    /* TODO is it safe to call wc_InitCmac over and over or do we need to call final first? */
+    /* TODO is it safe to call wc_InitCmac over and over or do we need to call
+     * final first? */
     if ((action == WH_SHE_SECURE_BOOT_INIT ||
-        action == WH_SHE_SECURE_BOOT_UPDATE ||
-        action == WH_SHE_SECURE_BOOT_FINISH) && ret != 0 &&
-        ret != WH_SHE_ERC_NO_SECURE_BOOT) {
-        server->she->sbState = WH_SHE_SB_INIT;
-        server->she->blSize = 0;
+         action == WH_SHE_SECURE_BOOT_UPDATE ||
+         action == WH_SHE_SECURE_BOOT_FINISH) &&
+        ret != 0 && ret != WH_SHE_ERC_NO_SECURE_BOOT) {
+        server->she->sbState        = WH_SHE_SB_INIT;
+        server->she->blSize         = 0;
         server->she->blSizeReceived = 0;
-        server->she->cmacKeyFound = 0;
+        server->she->cmacKeyFound   = 0;
     }
-    packet->rc = ret;
+
+    /* Unconditionaly return success so response message is sent, propagating
+     * the error code to the client */
+    /* TODO: Are there any fatal server errors that should be handled here? */
     return 0;
 }
 
 #else /* WOLFHSM_CFG_NO_CRYPTO */
 int wh_Server_HandleSheRequest(whServerContext* server,
-    uint16_t action, uint8_t* data, uint16_t* size)
+    uint16_t magic, uint16_t action, uint16_t req_size,
+    const void* req_packet, uint16_t* out_resp_size, void* resp_packet)
 {
     /* No crypto build, so always return bad args */
     (void)server;
@@ -1167,3 +1637,4 @@ int wh_Server_HandleSheRequest(whServerContext* server,
 #endif /* !WOLFHSM_CFG_NO_CRYPTO */
 
 #endif /* WOLFHSM_CFG_SHE_EXTENSION*/
+

--- a/src/wh_server_she.c
+++ b/src/wh_server_she.c
@@ -26,8 +26,8 @@
 
 /* System libraries */
 #include <stdint.h>
-#include <stddef.h>  /* For NULL */
-#include <string.h>  /* For memset, memcpy */
+#include <stddef.h> /* For NULL */
+#include <string.h> /* For memset, memcpy */
 
 #include "wolfhsm/wh_message.h"
 #include "wolfhsm/wh_error.h"
@@ -68,66 +68,70 @@ enum WH_SHE_SB_STATE {
 };
 
 /** Local Declarations */
-static int wh_AesMp16(whServerContext* server, uint8_t* in, word32 inSz,
-        uint8_t* out);
-static uint16_t hsmShePopAuthId(uint8_t* messageOne);
-static uint16_t hsmShePopId(uint8_t* messageOne);
-static uint32_t hsmShePopFlags(uint8_t* messageTwo);
-static int hsmSheSetUid(whServerContext* server, uint16_t magic,
-                        uint16_t req_size, const void* req_packet,
-                        uint16_t* out_resp_size, void* resp_packet);
-static int      hsmSheSecureBootInit(whServerContext* server, uint16_t magic,
-                                     uint16_t req_size, const void* req_packet,
-                                     uint16_t* out_resp_size, void* resp_packet);
-static int      hsmSheSecureBootUpdate(whServerContext* server, uint16_t magic,
-                                       uint16_t req_size, const void* req_packet,
-                                       uint16_t* out_resp_size, void* resp_packet);
-static int      hsmSheSecureBootFinish(whServerContext* server, uint16_t magic,
-                                       uint16_t req_size, const void* req_packet,
-                                       uint16_t* out_resp_size, void* resp_packet);
-static int hsmSheGetStatus(whServerContext* server, uint16_t magic,
+static int      _AesMp16(whServerContext* server, uint8_t* in, word32 inSz,
+                         uint8_t* out);
+static uint16_t _PopAuthId(uint8_t* messageOne);
+static uint16_t _PopId(uint8_t* messageOne);
+static uint32_t _PopFlags(uint8_t* messageTwo);
+static int _SetUid(whServerContext* server, uint16_t magic, uint16_t req_size,
+                   const void* req_packet, uint16_t* out_resp_size,
+                   void* resp_packet);
+static int _SecureBootInit(whServerContext* server, uint16_t magic,
                            uint16_t req_size, const void* req_packet,
                            uint16_t* out_resp_size, void* resp_packet);
-static int hsmSheLoadKey(whServerContext* server, uint16_t magic,
+static int _SecureBootUpdate(whServerContext* server, uint16_t magic,
+                             uint16_t req_size, const void* req_packet,
+                             uint16_t* out_resp_size, void* resp_packet);
+static int _SecureBootFinish(whServerContext* server, uint16_t magic,
+                             uint16_t req_size, const void* req_packet,
+                             uint16_t* out_resp_size, void* resp_packet);
+static int _GetStatus(whServerContext* server, uint16_t magic,
+                      uint16_t req_size, const void* req_packet,
+                      uint16_t* out_resp_size, void* resp_packet);
+static int _LoadKey(whServerContext* server, uint16_t magic, uint16_t req_size,
+                    const void* req_packet, uint16_t* out_resp_size,
+                    void* resp_packet);
+static int _LoadPlainKey(whServerContext* server, uint16_t magic,
                          uint16_t req_size, const void* req_packet,
                          uint16_t* out_resp_size, void* resp_packet);
-static int      hsmSheLoadPlainKey(whServerContext* server, uint16_t magic,
-                                   uint16_t req_size, const void* req_packet,
-                                   uint16_t* out_resp_size, void* resp_packet);
-static int      hsmSheExportRamKey(whServerContext* server, uint16_t magic,
-                                   uint16_t req_size, const void* req_packet,
-                                   uint16_t* out_resp_size, void* resp_packet);
-static int      hsmSheInitRnd(whServerContext* server, uint16_t magic,
-                              uint16_t req_size, const void* req_packet,
-                              uint16_t* out_resp_size, void* resp_packet);
-static int hsmSheRnd(whServerContext* server, uint16_t magic, uint16_t req_size,
-                     const void* req_packet, uint16_t* out_resp_size,
-                     void* resp_packet);
-static int      hsmSheExtendSeed(whServerContext* server, uint16_t magic,
-                                 uint16_t req_size, const void* req_packet,
-                                 uint16_t* out_resp_size, void* resp_packet);
-static int      hsmSheEncEcb(whServerContext* server, uint16_t magic,
-                             uint16_t req_size, const void* req_packet,
-                             uint16_t* out_resp_size, void* resp_packet);
-static int      hsmSheEncCbc(whServerContext* server, uint16_t magic,
-                             uint16_t req_size, const void* req_packet,
-                             uint16_t* out_resp_size, void* resp_packet);
-static int      hsmSheDecEcb(whServerContext* server, uint16_t magic,
-                             uint16_t req_size, const void* req_packet,
-                             uint16_t* out_resp_size, void* resp_packet);
-static int      hsmSheDecCbc(whServerContext* server, uint16_t magic,
-                             uint16_t req_size, const void* req_packet,
-                             uint16_t* out_resp_size, void* resp_packet);
-static int      hsmSheGenerateMac(whServerContext* server, uint16_t magic,
-                                  uint16_t req_size, const void* req_packet,
-                                  uint16_t* out_resp_size, void* resp_packet);
-static int      hsmSheVerifyMac(whServerContext* server, uint16_t magic,
-                                uint16_t req_size, const void* req_packet,
-                                uint16_t* out_resp_size, void* resp_packet);
-static int _translateSheReturnCode(int ret);
+static int _ExportRamKey(whServerContext* server, uint16_t magic,
+                         uint16_t req_size, const void* req_packet,
+                         uint16_t* out_resp_size, void* resp_packet);
+static int _InitRnd(whServerContext* server, uint16_t magic, uint16_t req_size,
+                    const void* req_packet, uint16_t* out_resp_size,
+                    void* resp_packet);
+static int _Rnd(whServerContext* server, uint16_t magic, uint16_t req_size,
+                const void* req_packet, uint16_t* out_resp_size,
+                void* resp_packet);
+static int _ExtendSeed(whServerContext* server, uint16_t magic,
+                       uint16_t req_size, const void* req_packet,
+                       uint16_t* out_resp_size, void* resp_packet);
+static int _EncEcb(whServerContext* server, uint16_t magic, uint16_t req_size,
+                   const void* req_packet, uint16_t* out_resp_size,
+                   void* resp_packet);
+static int _EncCbc(whServerContext* server, uint16_t magic, uint16_t req_size,
+                   const void* req_packet, uint16_t* out_resp_size,
+                   void* resp_packet);
+static int _DecEcb(whServerContext* server, uint16_t magic, uint16_t req_size,
+                   const void* req_packet, uint16_t* out_resp_size,
+                   void* resp_packet);
+static int _DecCbc(whServerContext* server, uint16_t magic, uint16_t req_size,
+                   const void* req_packet, uint16_t* out_resp_size,
+                   void* resp_packet);
+static int _GenerateMac(whServerContext* server, uint16_t magic,
+                        uint16_t req_size, const void* req_packet,
+                        uint16_t* out_resp_size, void* resp_packet);
+static int _VerifyMac(whServerContext* server, uint16_t magic,
+                      uint16_t req_size, const void* req_packet,
+                      uint16_t* out_resp_size, void* resp_packet);
+static int      _TranslateSheReturnCode(int ret);
+static int      _ReportInvalidSheState(whServerContext* server, uint16_t magic,
+                                       uint16_t action, uint16_t req_size,
+                                       const void* req_packet,
+                                       uint16_t* out_resp_size, void* resp_packet);
 
 /** Local Implementations */
-static int _translateSheReturnCode(int ret)
+static int _TranslateSheReturnCode(int ret)
 {
     /* if a handler didn't set a specific error, set general error */
     if (ret != WH_SHE_ERC_NO_ERROR) {
@@ -147,40 +151,40 @@ static int _translateSheReturnCode(int ret)
 }
 
 /* kdf function based on the Miyaguchi-Preneel one-way compression function */
-static int wh_AesMp16(whServerContext* server, uint8_t* in, word32 inSz,
-        uint8_t* out)
+static int _AesMp16(whServerContext* server, uint8_t* in, word32 inSz,
+                    uint8_t* out)
 {
     /* check valid inputs */
     if (server == NULL || server->she == NULL)
         return WH_ERROR_BADARGS;
     return wh_She_AesMp16_ex(server->she->sheAes, NULL, server->crypto->devId,
-            in, inSz, out);
+                             in, inSz, out);
 }
 
 /* AuthID is the 4 rightmost bits of messageOne */
-static uint16_t hsmShePopAuthId(uint8_t* messageOne)
+static uint16_t _PopAuthId(uint8_t* messageOne)
 {
     return (*(messageOne + WH_SHE_M1_SZ - 1) & 0x0f);
 }
 
 /* ID is the second to last 4 bits of messageOne */
-static uint16_t hsmShePopId(uint8_t* messageOne)
+static uint16_t _PopId(uint8_t* messageOne)
 {
     return ((*(messageOne + WH_SHE_M1_SZ - 1) & 0xf0) >> 4);
 }
 
 /* flags are the rightmost 4 bits of byte 3 as it's leftmost bits
  * and leftmost bit of byte 4 as it's rightmost bit */
-static uint32_t hsmShePopFlags(uint8_t* messageTwo)
+static uint32_t _PopFlags(uint8_t* messageTwo)
 {
     return (((messageTwo[3] & 0x0f) << 4) | ((messageTwo[4] & 0x80) >> 7));
 }
 
-static int hsmSheSetUid(whServerContext* server, uint16_t magic,
-                        uint16_t req_size, const void* req_packet,
-                        uint16_t* out_resp_size, void* resp_packet)
+static int _SetUid(whServerContext* server, uint16_t magic, uint16_t req_size,
+                   const void* req_packet, uint16_t* out_resp_size,
+                   void* resp_packet)
 {
-    int ret = WH_SHE_ERC_NO_ERROR;
+    int                         ret = WH_SHE_ERC_NO_ERROR;
     whMessageShe_SetUidRequest  req;
     whMessageShe_SetUidResponse resp;
 
@@ -202,14 +206,14 @@ static int hsmSheSetUid(whServerContext* server, uint16_t magic,
     return ret;
 }
 
-static int hsmSheSecureBootInit(whServerContext* server, uint16_t magic,
-                                uint16_t req_size, const void* req_packet,
-                                uint16_t* out_resp_size, void* resp_packet)
+static int _SecureBootInit(whServerContext* server, uint16_t magic,
+                           uint16_t req_size, const void* req_packet,
+                           uint16_t* out_resp_size, void* resp_packet)
 {
-    int ret = 0;
-    uint32_t keySz;
-    uint8_t macKey[WH_SHE_KEY_SZ];
-    whMessageShe_SecureBootInitRequest req;
+    int                                 ret = 0;
+    uint32_t                            keySz;
+    uint8_t                             macKey[WH_SHE_KEY_SZ];
+    whMessageShe_SecureBootInitRequest  req;
     whMessageShe_SecureBootInitResponse resp;
 
     (void)wh_MessageShe_TranslateSecureBootInitRequest(magic, req_packet, &req);
@@ -222,15 +226,16 @@ static int hsmSheSecureBootInit(whServerContext* server, uint16_t magic,
         server->she->blSize = req.sz;
         /* check if the boot mac key is empty */
         keySz = sizeof(macKey);
-        ret = hsmReadKey(server, WH_MAKE_KEYID(WH_KEYTYPE_SHE,
-            server->comm->client_id, WH_SHE_BOOT_MAC_KEY_ID), NULL,
-            macKey, &keySz);
+        ret   = hsmReadKey(server,
+                           WH_MAKE_KEYID(WH_KEYTYPE_SHE, server->comm->client_id,
+                                         WH_SHE_BOOT_MAC_KEY_ID),
+                           NULL, macKey, &keySz);
         /* if the key wasn't found */
         if (ret != 0) {
             /* return ERC_NO_SECURE_BOOT */
             ret = WH_SHE_ERC_NO_SECURE_BOOT;
             /* skip SB process since we have no key */
-            server->she->sbState = WH_SHE_SB_SUCCESS;
+            server->she->sbState      = WH_SHE_SB_SUCCESS;
             server->she->cmacKeyFound = 0;
         }
         else
@@ -240,18 +245,20 @@ static int hsmSheSecureBootInit(whServerContext* server, uint16_t magic,
      * expected digest so meta->len will be too long */
     if (ret == 0) {
         ret = wc_InitCmac_ex(server->she->sheCmac, macKey, WH_SHE_KEY_SZ,
-            WC_CMAC_AES, NULL, NULL, server->crypto->devId);
+                             WC_CMAC_AES, NULL, NULL, server->crypto->devId);
     }
     /* hash 12 zeros */
     if (ret == 0) {
         XMEMSET(macKey, 0, WH_SHE_BOOT_MAC_PREFIX_LEN);
-        ret = wc_CmacUpdate(server->she->sheCmac, macKey, WH_SHE_BOOT_MAC_PREFIX_LEN);
+        ret = wc_CmacUpdate(server->she->sheCmac, macKey,
+                            WH_SHE_BOOT_MAC_PREFIX_LEN);
     }
     /* TODO is size big or little endian? spec says it is 32 bit */
     /* hash size */
     if (ret == 0) {
-        ret = wc_CmacUpdate(server->she->sheCmac, (uint8_t*)&server->she->blSize,
-            sizeof(server->she->blSize));
+        ret =
+            wc_CmacUpdate(server->she->sheCmac, (uint8_t*)&server->she->blSize,
+                          sizeof(server->she->blSize));
     }
     if (ret == 0) {
         /* advance to the next state */
@@ -263,23 +270,25 @@ static int hsmSheSecureBootInit(whServerContext* server, uint16_t magic,
         resp.status = WH_SHE_ERC_GENERAL_ERROR;
     }
 
-    resp.rc = _translateSheReturnCode(ret);
-    (void)wh_MessageShe_TranslateSecureBootInitResponse(magic, &resp, resp_packet);
+    resp.rc = _TranslateSheReturnCode(ret);
+    (void)wh_MessageShe_TranslateSecureBootInitResponse(magic, &resp,
+                                                        resp_packet);
     *out_resp_size = sizeof(resp);
 
     return ret;
 }
 
-static int hsmSheSecureBootUpdate(whServerContext* server, uint16_t magic,
-                                  uint16_t req_size, const void* req_packet,
-                                  uint16_t* out_resp_size, void* resp_packet)
+static int _SecureBootUpdate(whServerContext* server, uint16_t magic,
+                             uint16_t req_size, const void* req_packet,
+                             uint16_t* out_resp_size, void* resp_packet)
 {
-    int ret = 0;
-    uint8_t* in;
-    whMessageShe_SecureBootUpdateRequest req;
+    int                                   ret = 0;
+    uint8_t*                              in;
+    whMessageShe_SecureBootUpdateRequest  req;
     whMessageShe_SecureBootUpdateResponse resp;
 
-    (void)wh_MessageShe_TranslateSecureBootUpdateRequest(magic, req_packet, &req);
+    (void)wh_MessageShe_TranslateSecureBootUpdateRequest(magic, req_packet,
+                                                         &req);
 
     /* if we aren't looking for update return error */
     if (server->she->sbState != WH_SHE_SB_UPDATE)
@@ -307,16 +316,17 @@ static int hsmSheSecureBootUpdate(whServerContext* server, uint16_t magic,
         resp.status = WH_SHE_ERC_GENERAL_ERROR;
     }
 
-    resp.rc = _translateSheReturnCode(ret);
-    (void)wh_MessageShe_TranslateSecureBootUpdateResponse(magic, &resp, resp_packet);
+    resp.rc = _TranslateSheReturnCode(ret);
+    (void)wh_MessageShe_TranslateSecureBootUpdateResponse(magic, &resp,
+                                                          resp_packet);
     *out_resp_size = sizeof(resp);
 
     return ret;
 }
 
-static int hsmSheSecureBootFinish(whServerContext* server, uint16_t magic,
-                                  uint16_t req_size, const void* req_packet,
-                                  uint16_t* out_resp_size, void* resp_packet)
+static int _SecureBootFinish(whServerContext* server, uint16_t magic,
+                             uint16_t req_size, const void* req_packet,
+                             uint16_t* out_resp_size, void* resp_packet)
 {
     int      ret = 0;
     uint32_t keySz;
@@ -360,7 +370,7 @@ static int hsmSheSecureBootFinish(whServerContext* server, uint16_t magic,
         }
     }
 
-    resp.rc = _translateSheReturnCode(ret);
+    resp.rc = _TranslateSheReturnCode(ret);
     (void)wh_MessageShe_TranslateSecureBootFinishResponse(magic, &resp,
                                                           resp_packet);
     *out_resp_size = sizeof(resp);
@@ -368,9 +378,9 @@ static int hsmSheSecureBootFinish(whServerContext* server, uint16_t magic,
     return ret;
 }
 
-static int hsmSheGetStatus(whServerContext* server, uint16_t magic,
-                           uint16_t req_size, const void* req_packet,
-                           uint16_t* out_resp_size, void* resp_packet)
+static int _GetStatus(whServerContext* server, uint16_t magic,
+                      uint16_t req_size, const void* req_packet,
+                      uint16_t* out_resp_size, void* resp_packet)
 {
     whMessageShe_GetStatusResponse resp;
 
@@ -396,32 +406,32 @@ static int hsmSheGetStatus(whServerContext* server, uint16_t magic,
     }
 
     *out_resp_size = sizeof(resp);
-    resp.rc = WH_SHE_ERC_NO_ERROR;
+    resp.rc        = WH_SHE_ERC_NO_ERROR;
     (void)wh_MessageShe_TranslateGetStatusResponse(magic, &resp, resp_packet);
 
     return 0;
 }
 
-static int hsmSheLoadKey(whServerContext* server, uint16_t magic,
-                         uint16_t req_size, const void* req_packet,
-                         uint16_t* out_resp_size, void* resp_packet)
+static int _LoadKey(whServerContext* server, uint16_t magic, uint16_t req_size,
+                    const void* req_packet, uint16_t* out_resp_size,
+                    void* resp_packet)
 {
-    int ret;
-    int keyRet = 0;
-    uint32_t keySz;
-    uint32_t field;
-    uint8_t kdfInput[WH_SHE_KEY_SZ * 2];
-    uint8_t cmacOutput[AES_BLOCK_SIZE];
-    uint8_t tmpKey[WH_SHE_KEY_SZ];
+    int           ret;
+    int           keyRet = 0;
+    uint32_t      keySz;
+    uint32_t      field;
+    uint8_t       kdfInput[WH_SHE_KEY_SZ * 2];
+    uint8_t       cmacOutput[AES_BLOCK_SIZE];
+    uint8_t       tmpKey[WH_SHE_KEY_SZ];
     whNvmMetadata meta[1];
-    uint32_t she_meta_count = 0;
-    uint32_t she_meta_flags = 0;
-    uint32_t* msg_counter_BE;
+    uint32_t      she_meta_count = 0;
+    uint32_t      she_meta_flags = 0;
+    uint32_t*     msg_counter_BE;
 
-    whMessageShe_LoadKeyRequest req = {0};
+    whMessageShe_LoadKeyRequest  req  = {0};
     whMessageShe_LoadKeyResponse resp = {0};
     /* Buffer for counter operations */
-    uint8_t counter_buffer[WH_SHE_KEY_SZ] = {0};  
+    uint8_t counter_buffer[WH_SHE_KEY_SZ] = {0};
 
     /* translate the request */
     (void)wh_MessageShe_TranslateLoadKeyRequest(magic, req_packet, &req);
@@ -429,18 +439,18 @@ static int hsmSheLoadKey(whServerContext* server, uint16_t magic,
 
     /* read the auth key by AuthID */
     keySz = sizeof(kdfInput);
-    ret = hsmReadKey(server, WH_MAKE_KEYID(WH_KEYTYPE_SHE,
-        server->comm->client_id,
-        hsmShePopAuthId(req.messageOne)), NULL, kdfInput,
-        &keySz);
+    ret   = hsmReadKey(server,
+                       WH_MAKE_KEYID(WH_KEYTYPE_SHE, server->comm->client_id,
+                                     _PopAuthId(req.messageOne)),
+                       NULL, kdfInput, &keySz);
     /* make K2 using AES-MP(authKey | WH_SHE_KEY_UPDATE_MAC_C) */
     if (ret == 0) {
         /* add WH_SHE_KEY_UPDATE_MAC_C to the input */
         XMEMCPY(kdfInput + keySz, _SHE_KEY_UPDATE_MAC_C,
-            sizeof(_SHE_KEY_UPDATE_MAC_C));
+                sizeof(_SHE_KEY_UPDATE_MAC_C));
         /* do kdf */
-        ret = wh_AesMp16(server, kdfInput,
-            keySz + sizeof(_SHE_KEY_UPDATE_MAC_C), tmpKey);
+        ret = _AesMp16(server, kdfInput, keySz + sizeof(_SHE_KEY_UPDATE_MAC_C),
+                       tmpKey);
     }
     else
         ret = WH_SHE_ERC_KEY_NOT_AVAILABLE;
@@ -449,87 +459,81 @@ static int hsmSheLoadKey(whServerContext* server, uint16_t magic,
         uint8_t cmacInput[sizeof(req.messageOne) + sizeof(req.messageTwo)];
         /* Concatenate messageOne and messageTwo for CMAC */
         memcpy(cmacInput, req.messageOne, sizeof(req.messageOne));
-        memcpy(cmacInput + sizeof(req.messageOne), req.messageTwo, sizeof(req.messageTwo));
-        
+        memcpy(cmacInput + sizeof(req.messageOne), req.messageTwo,
+               sizeof(req.messageTwo));
+
         field = AES_BLOCK_SIZE;
-        ret = wc_AesCmacGenerate_ex(
-            server->she->sheCmac, cmacOutput, (word32*)&field,
-            cmacInput, sizeof(cmacInput),
-            tmpKey, WH_SHE_KEY_SZ, NULL, server->crypto->devId);
+        ret   = wc_AesCmacGenerate_ex(server->she->sheCmac, cmacOutput,
+                                      (word32*)&field, cmacInput,
+                                      sizeof(cmacInput), tmpKey, WH_SHE_KEY_SZ,
+                                      NULL, server->crypto->devId);
     }
     /* compare digest to M3 */
-    if (ret == 0 && XMEMCMP(req.messageThree,
-        cmacOutput, field) != 0) {
+    if (ret == 0 && XMEMCMP(req.messageThree, cmacOutput, field) != 0) {
         ret = WH_SHE_ERC_KEY_UPDATE_ERROR;
     }
     /* make K1 using AES-MP(authKey | WH_SHE_KEY_UPDATE_ENC_C) */
     if (ret == 0) {
         /* add WH_SHE_KEY_UPDATE_ENC_C to the input */
         XMEMCPY(kdfInput + keySz, _SHE_KEY_UPDATE_ENC_C,
-            sizeof(_SHE_KEY_UPDATE_ENC_C));
+                sizeof(_SHE_KEY_UPDATE_ENC_C));
         /* do kdf */
-        ret = wh_AesMp16(server, kdfInput,
-            keySz + sizeof(_SHE_KEY_UPDATE_ENC_C), tmpKey);
+        ret = _AesMp16(server, kdfInput, keySz + sizeof(_SHE_KEY_UPDATE_ENC_C),
+                       tmpKey);
     }
     /* decrypt messageTwo */
     if (ret == 0)
         ret = wc_AesInit(server->she->sheAes, NULL, server->crypto->devId);
     if (ret == 0) {
-        ret = wc_AesSetKey(server->she->sheAes, tmpKey, WH_SHE_KEY_SZ,
-            NULL, AES_DECRYPTION);
+        ret = wc_AesSetKey(server->she->sheAes, tmpKey, WH_SHE_KEY_SZ, NULL,
+                           AES_DECRYPTION);
     }
     if (ret == 0) {
-        ret = wc_AesCbcDecrypt(server->she->sheAes,
-            req.messageTwo,
-            req.messageTwo,
-            sizeof(req.messageTwo));
+        ret = wc_AesCbcDecrypt(server->she->sheAes, req.messageTwo,
+                               req.messageTwo, sizeof(req.messageTwo));
     }
     /* free aes for protection */
     wc_AesFree(server->she->sheAes);
     /* load the target key */
     if (ret == 0) {
-        ret = hsmReadKey(server, WH_MAKE_KEYID(WH_KEYTYPE_SHE,
-            server->comm->client_id,
-            hsmShePopId(req.messageOne)), meta, kdfInput,
-            &keySz);
+        ret = hsmReadKey(server,
+                         WH_MAKE_KEYID(WH_KEYTYPE_SHE, server->comm->client_id,
+                                       _PopId(req.messageOne)),
+                         meta, kdfInput, &keySz);
         /* Extract count and flags from the label, even if it failed */
         wh_She_Label2Meta(meta->label, &she_meta_count, &she_meta_flags);
         /* if the keyslot is empty or write protection is not on continue */
         if (ret == WH_ERROR_NOTFOUND ||
             (she_meta_flags & WH_SHE_FLAG_WRITE_PROTECT) == 0) {
             keyRet = ret;
-            ret = 0;
+            ret    = 0;
         }
         else
             ret = WH_SHE_ERC_WRITE_PROTECTED;
     }
     /* check UID == 0 */
-    if (ret == 0 && wh_Utils_memeqzero(req.messageOne,
-        WH_SHE_UID_SZ) == 1) {
+    if (ret == 0 && wh_Utils_memeqzero(req.messageOne, WH_SHE_UID_SZ) == 1) {
         /* check wildcard */
         if ((she_meta_flags & WH_SHE_FLAG_WILDCARD) == 0) {
             ret = WH_SHE_ERC_KEY_UPDATE_ERROR;
         }
     }
     /* compare to UID */
-    else if (ret == 0 && XMEMCMP(req.messageOne,
-        server->she->uid, sizeof(server->she->uid)) != 0) {
+    else if (ret == 0 && XMEMCMP(req.messageOne, server->she->uid,
+                                 sizeof(server->she->uid)) != 0) {
         ret = WH_SHE_ERC_KEY_UPDATE_ERROR;
     }
     /* verify msg_counter_BE is greater than stored value */
     msg_counter_BE = (uint32_t*)req.messageTwo;
-    if (ret == 0 &&
-        keyRet != WH_ERROR_NOTFOUND &&
+    if (ret == 0 && keyRet != WH_ERROR_NOTFOUND &&
         wh_Utils_ntohl(*msg_counter_BE) >> 4 <= she_meta_count) {
         ret = WH_SHE_ERC_KEY_UPDATE_ERROR;
     }
     /* write key with msg_counter_BE */
     if (ret == 0) {
-        meta->id = WH_MAKE_KEYID(WH_KEYTYPE_SHE,
-            server->comm->client_id,
-            hsmShePopId(req.messageOne));
-        she_meta_flags =
-            hsmShePopFlags(req.messageTwo);
+        meta->id       = WH_MAKE_KEYID(WH_KEYTYPE_SHE, server->comm->client_id,
+                                       _PopId(req.messageOne));
+        she_meta_flags = _PopFlags(req.messageTwo);
         she_meta_count = wh_Utils_ntohl(*msg_counter_BE) >> 4;
         /* Update the meta label with new values */
         wh_She_Meta2Label(she_meta_count, she_meta_flags, meta->label);
@@ -540,15 +544,15 @@ static int hsmSheLoadKey(whServerContext* server, uint16_t magic,
         }
         else {
             ret = wh_Nvm_AddObject(server->nvm, meta, meta->len,
-                req.messageTwo + WH_SHE_KEY_SZ);
+                                   req.messageTwo + WH_SHE_KEY_SZ);
             /* read the evicted back from nvm */
             if (ret == 0) {
                 keySz = WH_SHE_KEY_SZ;
-                ret = hsmReadKey(server, meta->id, meta,
-                    req.messageTwo + WH_SHE_KEY_SZ,
-                    &keySz);
+                ret   = hsmReadKey(server, meta->id, meta,
+                                   req.messageTwo + WH_SHE_KEY_SZ, &keySz);
                 /* Extract count and flags from the label, even if it failed */
-                wh_She_Label2Meta(meta->label, &she_meta_count, &she_meta_flags);
+                wh_She_Label2Meta(meta->label, &she_meta_count,
+                                  &she_meta_flags);
             }
         }
         if (ret != 0)
@@ -557,37 +561,36 @@ static int hsmSheLoadKey(whServerContext* server, uint16_t magic,
     /* generate K3 using the updated key */
     if (ret == 0) {
         /* copy new key to kdfInput */
-        XMEMCPY(kdfInput, req.messageTwo +
-            WH_SHE_KEY_SZ, WH_SHE_KEY_SZ);
+        XMEMCPY(kdfInput, req.messageTwo + WH_SHE_KEY_SZ, WH_SHE_KEY_SZ);
         /* add WH_SHE_KEY_UPDATE_ENC_C to the input */
         XMEMCPY(kdfInput + meta->len, _SHE_KEY_UPDATE_ENC_C,
-            sizeof(_SHE_KEY_UPDATE_ENC_C));
+                sizeof(_SHE_KEY_UPDATE_ENC_C));
         /* do kdf */
-        ret = wh_AesMp16(server, kdfInput,
-            meta->len + sizeof(_SHE_KEY_UPDATE_ENC_C), tmpKey);
+        ret = _AesMp16(server, kdfInput,
+                       meta->len + sizeof(_SHE_KEY_UPDATE_ENC_C), tmpKey);
     }
     if (ret == 0)
         ret = wc_AesInit(server->she->sheAes, NULL, server->crypto->devId);
     if (ret == 0) {
-        ret = wc_AesSetKey(server->she->sheAes, tmpKey, WH_SHE_KEY_SZ,
-            NULL, AES_ENCRYPTION);
+        ret = wc_AesSetKey(server->she->sheAes, tmpKey, WH_SHE_KEY_SZ, NULL,
+                           AES_ENCRYPTION);
     }
     if (ret == 0) {
         /* Prepare counter in separate buffer */
-        msg_counter_BE = (uint32_t*)counter_buffer;
+        msg_counter_BE  = (uint32_t*)counter_buffer;
         *msg_counter_BE = wh_Utils_htonl(she_meta_count << 4);
         counter_buffer[3] |= 0x08;
 
         /* First copy UID into messageFour */
         XMEMCPY(resp.messageFour, server->she->uid, sizeof(server->she->uid));
         /* Set ID and AuthID in last byte */
-        resp.messageFour[15] = ((hsmShePopId(req.messageOne) << 4) | 
-                               hsmShePopAuthId(req.messageOne));
+        resp.messageFour[15] =
+            ((_PopId(req.messageOne) << 4) | _PopAuthId(req.messageOne));
 
         /* Then encrypt counter into second half of messageFour */
         ret = wc_AesEncryptDirect(server->she->sheAes,
-            resp.messageFour + WH_SHE_KEY_SZ,
-            counter_buffer);
+                                  resp.messageFour + WH_SHE_KEY_SZ,
+                                  counter_buffer);
     }
     /* free aes for protection */
     wc_AesFree(server->she->sheAes);
@@ -595,18 +598,18 @@ static int hsmSheLoadKey(whServerContext* server, uint16_t magic,
     if (ret == 0) {
         /* add WH_SHE_KEY_UPDATE_MAC_C to the input */
         XMEMCPY(kdfInput + meta->len, _SHE_KEY_UPDATE_MAC_C,
-            sizeof(_SHE_KEY_UPDATE_MAC_C));
+                sizeof(_SHE_KEY_UPDATE_MAC_C));
         /* do kdf */
-        ret = wh_AesMp16(server, kdfInput,
-            meta->len + sizeof(_SHE_KEY_UPDATE_MAC_C), tmpKey);
+        ret = _AesMp16(server, kdfInput,
+                       meta->len + sizeof(_SHE_KEY_UPDATE_MAC_C), tmpKey);
     }
     /* cmac messageFour using K4 as the cmac key */
     if (ret == 0) {
         field = AES_BLOCK_SIZE;
-        ret = wc_AesCmacGenerate_ex(server->she->sheCmac, resp.messageFive,
-            (word32*)&field, resp.messageFour,
-            sizeof(resp.messageFour), tmpKey,
-            WH_SHE_KEY_SZ, NULL, server->crypto->devId);
+        ret   = wc_AesCmacGenerate_ex(server->she->sheCmac, resp.messageFive,
+                                      (word32*)&field, resp.messageFour,
+                                      sizeof(resp.messageFour), tmpKey,
+                                      WH_SHE_KEY_SZ, NULL, server->crypto->devId);
     }
     if (ret == 0) {
         /* mark if the ram key was loaded */
@@ -615,15 +618,15 @@ static int hsmSheLoadKey(whServerContext* server, uint16_t magic,
     }
 
     *out_resp_size = sizeof(resp);
-    resp.rc = _translateSheReturnCode(ret);
+    resp.rc        = _TranslateSheReturnCode(ret);
     (void)wh_MessageShe_TranslateLoadKeyResponse(magic, &resp, resp_packet);
 
     return ret;
 }
 
-static int hsmSheLoadPlainKey(whServerContext* server, uint16_t magic,
-                              uint16_t req_size, const void* req_packet,
-                              uint16_t* out_resp_size, void* resp_packet)
+static int _LoadPlainKey(whServerContext* server, uint16_t magic,
+                         uint16_t req_size, const void* req_packet,
+                         uint16_t* out_resp_size, void* resp_packet)
 {
     int           ret     = 0;
     whNvmMetadata meta[1] = {{0}};
@@ -643,7 +646,7 @@ static int hsmSheLoadPlainKey(whServerContext* server, uint16_t magic,
         server->she->ramKeyPlain = 1;
     }
 
-    resp.rc = _translateSheReturnCode(ret);
+    resp.rc = _TranslateSheReturnCode(ret);
     (void)wh_MessageShe_TranslateLoadPlainKeyResponse(magic, &resp,
                                                       resp_packet);
     *out_resp_size = sizeof(resp);
@@ -652,9 +655,9 @@ static int hsmSheLoadPlainKey(whServerContext* server, uint16_t magic,
 }
 
 
-static int hsmSheExportRamKey(whServerContext* server, uint16_t magic,
-                              uint16_t req_size, const void* req_packet,
-                              uint16_t* out_resp_size, void* resp_packet)
+static int _ExportRamKey(whServerContext* server, uint16_t magic,
+                         uint16_t req_size, const void* req_packet,
+                         uint16_t* out_resp_size, void* resp_packet)
 {
     int                               ret = 0;
     uint32_t                          keySz;
@@ -690,8 +693,8 @@ static int hsmSheExportRamKey(whServerContext* server, uint16_t magic,
         XMEMCPY(kdfInput + meta->len, _SHE_KEY_UPDATE_ENC_C,
                 sizeof(_SHE_KEY_UPDATE_ENC_C));
         /* generate K1 */
-        ret = wh_AesMp16(server, kdfInput,
-                         meta->len + sizeof(_SHE_KEY_UPDATE_ENC_C), tmpKey);
+        ret = _AesMp16(server, kdfInput,
+                       meta->len + sizeof(_SHE_KEY_UPDATE_ENC_C), tmpKey);
     }
     /* build cleartext M2 */
     if (ret == 0) {
@@ -730,8 +733,8 @@ static int hsmSheExportRamKey(whServerContext* server, uint16_t magic,
         XMEMCPY(kdfInput + meta->len, _SHE_KEY_UPDATE_MAC_C,
                 sizeof(_SHE_KEY_UPDATE_MAC_C));
         /* generate K2 */
-        ret = wh_AesMp16(server, kdfInput,
-                         meta->len + sizeof(_SHE_KEY_UPDATE_MAC_C), tmpKey);
+        ret = _AesMp16(server, kdfInput,
+                       meta->len + sizeof(_SHE_KEY_UPDATE_MAC_C), tmpKey);
     }
     /* cmac messageOne and messageTwo using K2 as the cmac key */
     if (ret == 0) {
@@ -754,8 +757,8 @@ static int hsmSheExportRamKey(whServerContext* server, uint16_t magic,
         XMEMCPY(kdfInput + WH_SHE_KEY_SZ, _SHE_KEY_UPDATE_ENC_C,
                 sizeof(_SHE_KEY_UPDATE_ENC_C));
         /* generate K3 */
-        ret = wh_AesMp16(server, kdfInput,
-                         WH_SHE_KEY_SZ + sizeof(_SHE_KEY_UPDATE_ENC_C), tmpKey);
+        ret = _AesMp16(server, kdfInput,
+                       WH_SHE_KEY_SZ + sizeof(_SHE_KEY_UPDATE_ENC_C), tmpKey);
     }
     /* set K3 as encryption key */
     if (ret == 0) {
@@ -787,8 +790,8 @@ static int hsmSheExportRamKey(whServerContext* server, uint16_t magic,
         XMEMCPY(kdfInput + WH_SHE_KEY_SZ, _SHE_KEY_UPDATE_MAC_C,
                 sizeof(_SHE_KEY_UPDATE_MAC_C));
         /* generate K4 */
-        ret = wh_AesMp16(server, kdfInput,
-                         WH_SHE_KEY_SZ + sizeof(_SHE_KEY_UPDATE_MAC_C), tmpKey);
+        ret = _AesMp16(server, kdfInput,
+                       WH_SHE_KEY_SZ + sizeof(_SHE_KEY_UPDATE_MAC_C), tmpKey);
     }
     /* cmac messageFour using K4 as the cmac key */
     if (ret == 0) {
@@ -799,7 +802,7 @@ static int hsmSheExportRamKey(whServerContext* server, uint16_t magic,
                                       WH_SHE_KEY_SZ, NULL, server->crypto->devId);
     }
 
-    resp.rc = _translateSheReturnCode(ret);
+    resp.rc = _TranslateSheReturnCode(ret);
     (void)wh_MessageShe_TranslateExportRamKeyResponse(magic, &resp,
                                                       resp_packet);
     *out_resp_size = sizeof(resp);
@@ -807,9 +810,9 @@ static int hsmSheExportRamKey(whServerContext* server, uint16_t magic,
     return ret;
 }
 
-static int hsmSheInitRnd(whServerContext* server, uint16_t magic,
-                        uint16_t req_size, const void* req_packet,
-                        uint16_t* out_resp_size, void* resp_packet)
+static int _InitRnd(whServerContext* server, uint16_t magic, uint16_t req_size,
+                    const void* req_packet, uint16_t* out_resp_size,
+                    void* resp_packet)
 {
     int                          ret = 0;
     uint32_t                     keySz;
@@ -839,8 +842,8 @@ static int hsmSheInitRnd(whServerContext* server, uint16_t magic,
         XMEMCPY(kdfInput + WH_SHE_KEY_SZ, _SHE_PRNG_SEED_KEY_C,
                 sizeof(_SHE_PRNG_SEED_KEY_C));
         /* generate PRNG_SEED_KEY */
-        ret = wh_AesMp16(server, kdfInput,
-                         WH_SHE_KEY_SZ + sizeof(_SHE_PRNG_SEED_KEY_C), tmpKey);
+        ret = _AesMp16(server, kdfInput,
+                       WH_SHE_KEY_SZ + sizeof(_SHE_PRNG_SEED_KEY_C), tmpKey);
     }
     /* read the current PRNG_SEED, i - 1, to cmacOutput */
     if (ret == 0) {
@@ -885,9 +888,9 @@ static int hsmSheInitRnd(whServerContext* server, uint16_t magic,
         XMEMCPY(kdfInput + WH_SHE_KEY_SZ, _SHE_PRNG_KEY_C,
                 sizeof(_SHE_PRNG_KEY_C));
         /* generate PRNG_KEY */
-        ret = wh_AesMp16(server, kdfInput,
-                         WH_SHE_KEY_SZ + sizeof(_SHE_PRNG_KEY_C),
-                         server->she->prngKey);
+        ret =
+            _AesMp16(server, kdfInput, WH_SHE_KEY_SZ + sizeof(_SHE_PRNG_KEY_C),
+                     server->she->prngKey);
     }
     if (ret == 0) {
         /* set init rng to 1 */
@@ -898,7 +901,7 @@ static int hsmSheInitRnd(whServerContext* server, uint16_t magic,
      * the liberty to set it and doesn't appear to have any negative side
      * effects. */
     resp.status = (ret == 0) ? WH_SHE_ERC_NO_ERROR : WH_SHE_ERC_GENERAL_ERROR;
-    resp.rc = _translateSheReturnCode(ret);
+    resp.rc     = _TranslateSheReturnCode(ret);
     (void)wh_MessageShe_TranslateInitRngResponse(magic, &resp, resp_packet);
     *out_resp_size = sizeof(resp);
 
@@ -906,9 +909,9 @@ static int hsmSheInitRnd(whServerContext* server, uint16_t magic,
 }
 
 
-static int hsmSheRnd(whServerContext* server, uint16_t magic, uint16_t req_size,
-                     const void* req_packet, uint16_t* out_resp_size,
-                     void* resp_packet)
+static int _Rnd(whServerContext* server, uint16_t magic, uint16_t req_size,
+                const void* req_packet, uint16_t* out_resp_size,
+                void* resp_packet)
 {
     int                      ret = 0;
     whMessageShe_RndResponse resp;
@@ -943,16 +946,16 @@ static int hsmSheRnd(whServerContext* server, uint16_t magic, uint16_t req_size,
         XMEMCPY(resp.rnd, server->she->prngState, WH_SHE_KEY_SZ);
     }
 
-    resp.rc = _translateSheReturnCode(ret);
+    resp.rc = _TranslateSheReturnCode(ret);
     (void)wh_MessageShe_TranslateRndResponse(magic, &resp, resp_packet);
     *out_resp_size = sizeof(resp);
 
     return ret;
 }
 
-static int hsmSheExtendSeed(whServerContext* server, uint16_t magic,
-                            uint16_t req_size, const void* req_packet,
-                            uint16_t* out_resp_size, void* resp_packet)
+static int _ExtendSeed(whServerContext* server, uint16_t magic,
+                       uint16_t req_size, const void* req_packet,
+                       uint16_t* out_resp_size, void* resp_packet)
 {
     int                             ret = 0;
     uint32_t                        keySz;
@@ -973,8 +976,8 @@ static int hsmSheExtendSeed(whServerContext* server, uint16_t magic,
         /* add the user supplied entropy to kdfInput */
         XMEMCPY(kdfInput + WH_SHE_KEY_SZ, req.entropy, sizeof(req.entropy));
         /* extend PRNG_STATE */
-        ret = wh_AesMp16(server, kdfInput, WH_SHE_KEY_SZ + sizeof(req.entropy),
-                         server->she->prngState);
+        ret = _AesMp16(server, kdfInput, WH_SHE_KEY_SZ + sizeof(req.entropy),
+                       server->she->prngState);
     }
     /* read the PRNG_SEED into kdfInput */
     if (ret == 0) {
@@ -989,8 +992,8 @@ static int hsmSheExtendSeed(whServerContext* server, uint16_t magic,
     }
     if (ret == 0) {
         /* extend PRNG_STATE */
-        ret = wh_AesMp16(server, kdfInput, WH_SHE_KEY_SZ + sizeof(req.entropy),
-                         kdfInput);
+        ret = _AesMp16(server, kdfInput, WH_SHE_KEY_SZ + sizeof(req.entropy),
+                       kdfInput);
     }
     /* save PRNG_SEED */
     if (ret == 0) {
@@ -1007,16 +1010,16 @@ static int hsmSheExtendSeed(whServerContext* server, uint16_t magic,
      * the liberty to set it and doesn't appear to have any negative side
      * effects. */
     resp.status = (ret == 0) ? WH_SHE_ERC_NO_ERROR : WH_SHE_ERC_RNG_SEED;
-    resp.rc     = _translateSheReturnCode(ret);
+    resp.rc     = _TranslateSheReturnCode(ret);
     (void)wh_MessageShe_TranslateExtendSeedResponse(magic, &resp, resp_packet);
     *out_resp_size = sizeof(resp);
 
     return ret;
 }
 
-static int hsmSheEncEcb(whServerContext* server, uint16_t magic,
-                        uint16_t req_size, const void* req_packet,
-                        uint16_t* out_resp_size, void* resp_packet)
+static int _EncEcb(whServerContext* server, uint16_t magic, uint16_t req_size,
+                   const void* req_packet, uint16_t* out_resp_size,
+                   void* resp_packet)
 {
     int      ret;
     uint32_t field;
@@ -1066,14 +1069,14 @@ static int hsmSheEncEcb(whServerContext* server, uint16_t magic,
         resp.sz        = 0;
         *out_resp_size = sizeof(resp);
     }
-    resp.rc = _translateSheReturnCode(ret);
+    resp.rc = _TranslateSheReturnCode(ret);
     (void)wh_MessageShe_TranslateEncEcbResponse(magic, &resp, resp_packet);
     return ret;
 }
 
-static int hsmSheEncCbc(whServerContext* server, uint16_t magic,
-                        uint16_t req_size, const void* req_packet,
-                        uint16_t* out_resp_size, void* resp_packet)
+static int _EncCbc(whServerContext* server, uint16_t magic, uint16_t req_size,
+                   const void* req_packet, uint16_t* out_resp_size,
+                   void* resp_packet)
 {
     int                         ret;
     uint32_t                    field;
@@ -1128,15 +1131,15 @@ static int hsmSheEncCbc(whServerContext* server, uint16_t magic,
         *out_resp_size = sizeof(resp);
     }
 
-    resp.rc = _translateSheReturnCode(ret);
+    resp.rc = _TranslateSheReturnCode(ret);
     (void)wh_MessageShe_TranslateEncCbcResponse(magic, &resp, resp_packet);
 
     return ret;
 }
 
-static int hsmSheDecEcb(whServerContext* server, uint16_t magic,
-                        uint16_t req_size, const void* req_packet,
-                        uint16_t* out_resp_size, void* resp_packet)
+static int _DecEcb(whServerContext* server, uint16_t magic, uint16_t req_size,
+                   const void* req_packet, uint16_t* out_resp_size,
+                   void* resp_packet)
 {
     int      ret;
     uint32_t field;
@@ -1190,15 +1193,15 @@ static int hsmSheDecEcb(whServerContext* server, uint16_t magic,
         *out_resp_size = sizeof(resp);
     }
 
-    resp.rc = _translateSheReturnCode(ret);
+    resp.rc = _TranslateSheReturnCode(ret);
     (void)wh_MessageShe_TranslateDecEcbResponse(magic, &resp, resp_packet);
 
     return ret;
 }
 
-static int hsmSheDecCbc(whServerContext* server, uint16_t magic,
-                        uint16_t req_size, const void* req_packet,
-                        uint16_t* out_resp_size, void* resp_packet)
+static int _DecCbc(whServerContext* server, uint16_t magic, uint16_t req_size,
+                   const void* req_packet, uint16_t* out_resp_size,
+                   void* resp_packet)
 {
     int                         ret;
     uint32_t                    field;
@@ -1253,15 +1256,15 @@ static int hsmSheDecCbc(whServerContext* server, uint16_t magic,
         *out_resp_size = sizeof(resp);
     }
 
-    resp.rc = _translateSheReturnCode(ret);
+    resp.rc = _TranslateSheReturnCode(ret);
     (void)wh_MessageShe_TranslateDecCbcResponse(magic, &resp, resp_packet);
 
     return ret;
 }
 
-static int hsmSheGenerateMac(whServerContext* server, uint16_t magic,
-                             uint16_t req_size, const void* req_packet,
-                             uint16_t* out_resp_size, void* resp_packet)
+static int _GenerateMac(whServerContext* server, uint16_t magic,
+                        uint16_t req_size, const void* req_packet,
+                        uint16_t* out_resp_size, void* resp_packet)
 {
     int                         ret;
     uint32_t                    field = AES_BLOCK_SIZE;
@@ -1292,16 +1295,16 @@ static int hsmSheGenerateMac(whServerContext* server, uint16_t magic,
         ret = WH_SHE_ERC_KEY_NOT_AVAILABLE;
     }
 
-    resp.rc = _translateSheReturnCode(ret);
+    resp.rc = _TranslateSheReturnCode(ret);
     (void)wh_MessageShe_TranslateGenMacResponse(magic, &resp, resp_packet);
     *out_resp_size = sizeof(resp);
 
     return ret;
 }
 
-static int hsmSheVerifyMac(whServerContext* server, uint16_t magic,
-                           uint16_t req_size, const void* req_packet,
-                           uint16_t* out_resp_size, void* resp_packet)
+static int _VerifyMac(whServerContext* server, uint16_t magic,
+                      uint16_t req_size, const void* req_packet,
+                      uint16_t* out_resp_size, void* resp_packet)
 {
     int                            ret;
     uint32_t                       keySz;
@@ -1341,7 +1344,7 @@ static int hsmSheVerifyMac(whServerContext* server, uint16_t magic,
         ret = WH_SHE_ERC_KEY_NOT_AVAILABLE;
     }
 
-    resp.rc = _translateSheReturnCode(ret);
+    resp.rc = _TranslateSheReturnCode(ret);
     (void)wh_MessageShe_TranslateVerifyMacResponse(magic, &resp, resp_packet);
     *out_resp_size = sizeof(resp);
 
@@ -1352,7 +1355,7 @@ static int hsmSheVerifyMac(whServerContext* server, uint16_t magic,
 /* TODO: This is terrible, but without implementing a SHE sub-protocol like we
  * do for crypto layer, there is no way to return non-request specific error
  * codes */
-int _reportInvalidSheState(whServerContext* server, uint16_t magic,
+static int _ReportInvalidSheState(whServerContext* server, uint16_t magic,
                            uint16_t action, uint16_t req_size,
                            const void* req_packet, uint16_t* out_resp_size,
                            void* resp_packet)
@@ -1522,7 +1525,7 @@ int wh_Server_HandleSheRequest(whServerContext* server, uint16_t magic,
         return WH_ERROR_BADARGS;
     }
 
-    ret = _reportInvalidSheState(server, magic, action, req_size, req_packet,
+    ret = _ReportInvalidSheState(server, magic, action, req_size, req_packet,
                                  out_resp_size, resp_packet);
     if (ret != 0) {
         return ret;
@@ -1530,72 +1533,72 @@ int wh_Server_HandleSheRequest(whServerContext* server, uint16_t magic,
 
     switch (action) {
         case WH_SHE_SET_UID:
-            ret = hsmSheSetUid(server, magic, req_size, req_packet,
-                               out_resp_size, resp_packet);
+            ret = _SetUid(server, magic, req_size, req_packet, out_resp_size,
+                          resp_packet);
             break;
         case WH_SHE_SECURE_BOOT_INIT:
-            ret = hsmSheSecureBootInit(server, magic, req_size, req_packet,
-                                       out_resp_size, resp_packet);
+            ret = _SecureBootInit(server, magic, req_size, req_packet,
+                                  out_resp_size, resp_packet);
             break;
         case WH_SHE_SECURE_BOOT_UPDATE:
-            ret = hsmSheSecureBootUpdate(server, magic, req_size, req_packet,
-                                         out_resp_size, resp_packet);
-            break;
-        case WH_SHE_SECURE_BOOT_FINISH:
-            ret = hsmSheSecureBootFinish(server, magic, req_size, req_packet,
-                                         out_resp_size, resp_packet);
-            break;
-        case WH_SHE_GET_STATUS:
-            ret = hsmSheGetStatus(server, magic, req_size, req_packet,
-                                  out_resp_size, resp_packet);
-            break;
-        case WH_SHE_LOAD_KEY:
-            ret = hsmSheLoadKey(server, magic, req_size, req_packet,
-                                out_resp_size, resp_packet);
-            break;
-        case WH_SHE_LOAD_PLAIN_KEY:
-            ret = hsmSheLoadPlainKey(server, magic, req_size, req_packet,
-                                     out_resp_size, resp_packet);
-            break;
-        case WH_SHE_EXPORT_RAM_KEY:
-            ret = hsmSheExportRamKey(server, magic, req_size, req_packet,
-                                     out_resp_size, resp_packet);
-            break;
-        case WH_SHE_INIT_RND:
-            ret = hsmSheInitRnd(server, magic, req_size, req_packet,
-                                out_resp_size, resp_packet);
-            break;
-        case WH_SHE_RND:
-            ret = hsmSheRnd(server, magic, req_size, req_packet, out_resp_size,
-                            resp_packet);
-            break;
-        case WH_SHE_EXTEND_SEED:
-            ret = hsmSheExtendSeed(server, magic, req_size, req_packet,
-                                   out_resp_size, resp_packet);
-            break;
-        case WH_SHE_ENC_ECB:
-            ret = hsmSheEncEcb(server, magic, req_size, req_packet,
-                               out_resp_size, resp_packet);
-            break;
-        case WH_SHE_ENC_CBC:
-            ret = hsmSheEncCbc(server, magic, req_size, req_packet,
-                               out_resp_size, resp_packet);
-            break;
-        case WH_SHE_DEC_ECB:
-            ret = hsmSheDecEcb(server, magic, req_size, req_packet,
-                               out_resp_size, resp_packet);
-            break;
-        case WH_SHE_DEC_CBC:
-            ret = hsmSheDecCbc(server, magic, req_size, req_packet,
-                               out_resp_size, resp_packet);
-            break;
-        case WH_SHE_GEN_MAC:
-            ret = hsmSheGenerateMac(server, magic, req_size, req_packet,
+            ret = _SecureBootUpdate(server, magic, req_size, req_packet,
                                     out_resp_size, resp_packet);
             break;
+        case WH_SHE_SECURE_BOOT_FINISH:
+            ret = _SecureBootFinish(server, magic, req_size, req_packet,
+                                    out_resp_size, resp_packet);
+            break;
+        case WH_SHE_GET_STATUS:
+            ret = _GetStatus(server, magic, req_size, req_packet, out_resp_size,
+                             resp_packet);
+            break;
+        case WH_SHE_LOAD_KEY:
+            ret = _LoadKey(server, magic, req_size, req_packet, out_resp_size,
+                           resp_packet);
+            break;
+        case WH_SHE_LOAD_PLAIN_KEY:
+            ret = _LoadPlainKey(server, magic, req_size, req_packet,
+                                out_resp_size, resp_packet);
+            break;
+        case WH_SHE_EXPORT_RAM_KEY:
+            ret = _ExportRamKey(server, magic, req_size, req_packet,
+                                out_resp_size, resp_packet);
+            break;
+        case WH_SHE_INIT_RND:
+            ret = _InitRnd(server, magic, req_size, req_packet, out_resp_size,
+                           resp_packet);
+            break;
+        case WH_SHE_RND:
+            ret = _Rnd(server, magic, req_size, req_packet, out_resp_size,
+                       resp_packet);
+            break;
+        case WH_SHE_EXTEND_SEED:
+            ret = _ExtendSeed(server, magic, req_size, req_packet,
+                              out_resp_size, resp_packet);
+            break;
+        case WH_SHE_ENC_ECB:
+            ret = _EncEcb(server, magic, req_size, req_packet, out_resp_size,
+                          resp_packet);
+            break;
+        case WH_SHE_ENC_CBC:
+            ret = _EncCbc(server, magic, req_size, req_packet, out_resp_size,
+                          resp_packet);
+            break;
+        case WH_SHE_DEC_ECB:
+            ret = _DecEcb(server, magic, req_size, req_packet, out_resp_size,
+                          resp_packet);
+            break;
+        case WH_SHE_DEC_CBC:
+            ret = _DecCbc(server, magic, req_size, req_packet, out_resp_size,
+                          resp_packet);
+            break;
+        case WH_SHE_GEN_MAC:
+            ret = _GenerateMac(server, magic, req_size, req_packet,
+                               out_resp_size, resp_packet);
+            break;
         case WH_SHE_VERIFY_MAC:
-            ret = hsmSheVerifyMac(server, magic, req_size, req_packet,
-                                  out_resp_size, resp_packet);
+            ret = _VerifyMac(server, magic, req_size, req_packet, out_resp_size,
+                             resp_packet);
             break;
         default:
             ret = WH_ERROR_BADARGS;
@@ -1622,9 +1625,10 @@ int wh_Server_HandleSheRequest(whServerContext* server, uint16_t magic,
 }
 
 #else /* WOLFHSM_CFG_NO_CRYPTO */
-int wh_Server_HandleSheRequest(whServerContext* server,
-    uint16_t magic, uint16_t action, uint16_t req_size,
-    const void* req_packet, uint16_t* out_resp_size, void* resp_packet)
+int wh_Server_HandleSheRequest(whServerContext* server, uint16_t magic,
+                               uint16_t action, uint16_t req_size,
+                               const void* req_packet, uint16_t* out_resp_size,
+                               void* resp_packet)
 {
     /* No crypto build, so always return bad args */
     (void)server;
@@ -1637,4 +1641,3 @@ int wh_Server_HandleSheRequest(whServerContext* server,
 #endif /* !WOLFHSM_CFG_NO_CRYPTO */
 
 #endif /* WOLFHSM_CFG_SHE_EXTENSION*/
-

--- a/src/wh_utils.c
+++ b/src/wh_utils.c
@@ -137,12 +137,12 @@ void* wh_Utils_memcpy_flush(void* dst, const void* src , size_t n)
 
 
 #ifdef DEBUG_CRYPTOCB_VERBOSE
-void wh_Utils_Hexdump(const char* initial, uint8_t* ptr, size_t size)
+void wh_Utils_Hexdump(const char* initial, const uint8_t* ptr, size_t size)
 {
 #define HEXDUMP_BYTES_PER_LINE 16
     int count = 0;
     if(initial != NULL)
-        printf("%s",initial);
+        printf("%s ",initial);
     while(size > 0) {
         printf ("%02X ", *ptr);
         ptr++;

--- a/test/Makefile
+++ b/test/Makefile
@@ -176,6 +176,7 @@ SRC_C += \
             $(WOLFHSM_DIR)/src/wh_message_crypto.c \
             $(WOLFHSM_DIR)/src/wh_message_keystore.c \
             $(WOLFHSM_DIR)/src/wh_message_counter.c \
+            $(WOLFHSM_DIR)/src/wh_message_she.c \
             $(WOLFHSM_DIR)/src/wh_transport_mem.c \
             $(WOLFHSM_DIR)/src/wh_flash_ramsim.c
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -173,6 +173,9 @@ SRC_C += \
             $(WOLFHSM_DIR)/src/wh_message_customcb.c \
             $(WOLFHSM_DIR)/src/wh_message_nvm.c \
             $(WOLFHSM_DIR)/src/wh_message_cert.c \
+            $(WOLFHSM_DIR)/src/wh_message_crypto.c \
+            $(WOLFHSM_DIR)/src/wh_message_keystore.c \
+            $(WOLFHSM_DIR)/src/wh_message_counter.c \
             $(WOLFHSM_DIR)/src/wh_transport_mem.c \
             $(WOLFHSM_DIR)/src/wh_flash_ramsim.c
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -9,6 +9,9 @@ WOLFSSL_DIR ?= $(CURDIR)/../../wolfssl
 # Project name
 BIN = wh_test
 
+# C standard to use (default to c90 if not specified)
+CSTD ?= c90
+
 # Includes
 USER_SETTINGS_DIR ?= ./
 INC = -I$(WOLFHSM_DIR) \
@@ -32,7 +35,7 @@ ARCHFLAGS ?=
 # Compiler and linker flags
 ASFLAGS ?= $(ARCHFLAGS)
 CFLAGS_EXTRA ?= -Wmissing-field-initializers -Wmissing-braces
-CFLAGS ?= $(ARCHFLAGS) -std=c90 -D_GNU_SOURCE -Wall -Werror -Wno-cpp $(CFLAGS_EXTRA)
+CFLAGS ?= $(ARCHFLAGS) -std=$(CSTD) -D_GNU_SOURCE -Wall -Werror -Wno-cpp $(CFLAGS_EXTRA)
 LDFLAGS ?= $(ARCHFLAGS)
 
 # LD: generate map

--- a/test/user_settings.h
+++ b/test/user_settings.h
@@ -42,7 +42,6 @@ extern "C" {
 /** wolfHSM required settings for wolfCrypt */
 /* #define WOLFCRYPT_ONLY */
 #define WOLF_CRYPTO_CB
-#define HAVE_HASHDRBG
 #define WOLFSSL_KEY_GEN
 #define WOLFSSL_ASN_TEMPLATE
 #define WOLFSSL_BASE64_ENCODE

--- a/test/wh_test_check_struct_padding.c
+++ b/test/wh_test_check_struct_padding.c
@@ -59,76 +59,81 @@ whMessageNvm_ReadDmaRequest      whMessageNvm_ReadDmaRequest_test;
 whPacket whPacket_test;
 /* Test every variant of the nested union */
 wh_Packet_version_exchange      versionExchange;
-wh_Packet_key_cache_req         keyCacheReq;
-wh_Packet_key_evict_req         keyEvictReq;
-wh_Packet_key_commit_req        keyCommitReq;
-wh_Packet_key_export_req        keyExportReq;
-wh_Packet_key_erase_req         keyEraseReq;
-wh_Packet_counter_init_req      counterInitReq;
-wh_Packet_counter_increment_req counterIncrementReq;
-wh_Packet_counter_read_req      counterReadReq;
-wh_Packet_counter_destroy_req   counterDestroyReq;
-wh_Packet_key_cache_res         keyCacheRes;
-wh_Packet_key_evict_res         keyEvictRes;
-wh_Packet_key_commit_res        keyCommitRes;
-wh_Packet_key_export_res        keyExportRes;
-wh_Packet_key_erase_res         keyEraseRes;
-wh_Packet_counter_init_res      counterInitRes;
-wh_Packet_counter_increment_res counterIncrementRes;
-wh_Packet_counter_read_res      counterReadRes;
 
-wh_Packet_key_cache_Dma_req      keyCacheDmaReq;
-wh_Packet_key_cache_Dma_res      keyCacheDmaRes;
-wh_Packet_key_export_Dma_req     keyExportDmaReq;
-wh_Packet_key_export_Dma_res     keyExportDmaRes;
+/* Include keystore message header for new keystore message structures */
+#include "wolfhsm/wh_message_keystore.h"
+whMessageKeystore_CacheRequest     keyCacheReq;
+whMessageKeystore_EvictRequest     keyEvictReq;
+whMessageKeystore_CommitRequest    keyCommitReq;
+whMessageKeystore_ExportRequest    keyExportReq;
+whMessageKeystore_EraseRequest     keyEraseReq;
+whMessageKeystore_CacheResponse    keyCacheRes;
+whMessageKeystore_EvictResponse    keyEvictRes;
+whMessageKeystore_CommitResponse   keyCommitRes;
+whMessageKeystore_ExportResponse   keyExportRes;
+whMessageKeystore_EraseResponse    keyEraseRes;
+
+/* Include counter message header for new counter message structures */
+#include "wolfhsm/wh_message_counter.h"
+whMessageCounter_InitRequest       counterInitReq;
+whMessageCounter_IncrementRequest  counterIncrementReq;
+whMessageCounter_ReadRequest       counterReadReq;
+whMessageCounter_DestroyRequest    counterDestroyReq;
+whMessageCounter_InitResponse      counterInitRes;
+whMessageCounter_IncrementResponse counterIncrementRes;
+whMessageCounter_ReadResponse      counterReadRes;
+whMessageCounter_DestroyResponse   counterDestroyRes;
+
+/* DMA keystore messages */
+whMessageKeystore_CacheDmaRequest   keyCacheDmaReq;
+whMessageKeystore_CacheDmaResponse  keyCacheDmaRes;
+whMessageKeystore_ExportDmaRequest  keyExportDmaReq;
+whMessageKeystore_ExportDmaResponse keyExportDmaRes;
 
 #ifndef WOLFHSM_CFG_NO_CRYPTO
-wh_Packet_cipher_any_req      cipherAnyReq;
-wh_Packet_cipher_aescbc_req   cipherAesCbcReq;
-wh_Packet_cipher_aesgcm_req   cipherAesGcmReq;
-wh_Packet_pk_any_req          pkAnyReq;
-wh_Packet_pk_rsakg_req        pkRsakgReq;
-wh_Packet_pk_rsa_req          pkRsaReq;
-wh_Packet_pk_rsa_get_size_req pkRsaGetSizeReq;
-wh_Packet_pk_eckg_req         pkEckgReq;
-wh_Packet_pk_ecdh_req         pkEcdhReq;
-wh_Packet_pk_ecc_sign_req     pkEccSignReq;
-wh_Packet_pk_ecc_verify_req   pkEccVerifyReq;
-wh_Packet_pk_ecc_check_req    pkEccCheckReq;
-wh_Packet_pk_curve25519kg_req pkCurve25519kgReq;
-wh_Packet_pk_curve25519kg_res pkCurve25519kgRes;
-wh_Packet_pk_curve25519_req   pkCurve25519Req;
-wh_Packet_pk_curve25519_res   pkCurve25519Res;
-wh_Packet_rng_req             rngReq;
-wh_Packet_cmac_req            cmacReq;
-wh_Packet_cipher_aescbc_res   cipherAesCbcRes;
-wh_Packet_cipher_aesgcm_res   cipherAesGcmRes;
-wh_Packet_pk_rsakg_res        pkRsakgRes;
-wh_Packet_pk_rsa_res          pkRsaRes;
-wh_Packet_pk_rsa_get_size_res pkRsaGetSizeRes;
-wh_Packet_pk_eckg_res         pkEckgRes;
-wh_Packet_pk_ecdh_res         pkEcdhRes;
-wh_Packet_pk_ecc_sign_res     pkEccSignRes;
-wh_Packet_pk_ecc_verify_res   pkEccVerifyRes;
-wh_Packet_pk_ecc_check_res    pkEccCheckRes;
-wh_Packet_rng_res             rngRes;
-wh_Packet_cmac_res            cmacRes;
-wh_Packet_hash_any_req        hashAnyReq;
-wh_Packet_hash_sha256_req     hashSha256Req;
-wh_Packet_hash_sha256_res     hashSha256Res;
+/* Include crypto message header for new crypto message structures */
+#include "wolfhsm/wh_message_crypto.h"
+whMessageCrypto_GenericRequestHeader  cryptoGenericReqHeader;
+whMessageCrypto_GenericResponseHeader cryptoGenericResHeader;
+whMessageCrypto_AesCbcRequest        cipherAesCbcReq;
+whMessageCrypto_AesGcmRequest        cipherAesGcmReq;
+whMessageCrypto_RsaKeyGenRequest     pkRsakgReq;
+whMessageCrypto_RsaRequest           pkRsaReq;
+whMessageCrypto_RsaGetSizeRequest    pkRsaGetSizeReq;
+whMessageCrypto_EccKeyGenRequest     pkEckgReq;
+whMessageCrypto_EcdhRequest          pkEcdhReq;
+whMessageCrypto_EccSignRequest       pkEccSignReq;
+whMessageCrypto_EccVerifyRequest     pkEccVerifyReq;
+whMessageCrypto_EccCheckRequest      pkEccCheckReq;
+whMessageCrypto_RngRequest           rngReq;
+whMessageCrypto_CmacRequest          cmacReq;
+whMessageCrypto_AesCbcResponse       cipherAesCbcRes;
+whMessageCrypto_AesGcmResponse       cipherAesGcmRes;
+whMessageCrypto_RsaKeyGenResponse    pkRsakgRes;
+whMessageCrypto_RsaResponse          pkRsaRes;
+whMessageCrypto_RsaGetSizeResponse   pkRsaGetSizeRes;
+whMessageCrypto_EccKeyGenResponse    pkEckgRes;
+whMessageCrypto_EcdhResponse         pkEcdhRes;
+whMessageCrypto_EccSignResponse      pkEccSignRes;
+whMessageCrypto_EccVerifyResponse    pkEccVerifyRes;
+whMessageCrypto_EccCheckResponse     pkEccCheckRes;
+whMessageCrypto_RngResponse          rngRes;
+whMessageCrypto_CmacResponse         cmacRes;
+whMessageCrypto_Sha256Request        hashSha256Req;
+whMessageCrypto_Sha256Response       hashSha256Res;
 
-/* DMA structs */
+/* DMA crypto messages */
 #if defined(WOLFHSM_CFG_DMA)
-wh_Packet_hash_sha256_Dma_req     hashSha256DmaReq;
-wh_Packet_hash_sha256_Dma_res     hashSha256DmaRes;
-wh_Packet_pq_mldsa_keygen_Dma_req pqMldsaKeygenDmaReq;
-wh_Packet_pq_mldsa_Dma_res        pqMldsaDmaRes;
-wh_Packet_pq_mldsa_sign_Dma_req   pqMldsaSignDmaReq;
-wh_Packet_pq_mldsa_sign_Dma_res   pqMldsaSignDmaRes;
-wh_Packet_pq_mldsa_verify_Dma_req pqMldsaVerifyDmaReq;
-wh_Packet_pq_mldsa_verify_Dma_res pqMldsaVerifyDmaRes;
-wh_Packet_cmac_Dma_req            cmacDmaReq;
-wh_Packet_cmac_Dma_res            cmacDmaRes;
+whMessageCrypto_Sha256DmaRequest        hashSha256DmaReq;
+whMessageCrypto_Sha256DmaResponse       hashSha256DmaRes;
+whMessageCrypto_MlDsaKeyGenDmaRequest   pqMldsaKeygenDmaReq;
+whMessageCrypto_MlDsaKeyGenDmaResponse  pqMldsaKeygenDmaRes;
+whMessageCrypto_MlDsaSignDmaRequest     pqMldsaSignDmaReq;
+whMessageCrypto_MlDsaSignDmaResponse    pqMldsaSignDmaRes;
+whMessageCrypto_MlDsaVerifyDmaRequest   pqMldsaVerifyDmaReq;
+whMessageCrypto_MlDsaVerifyDmaResponse  pqMldsaVerifyDmaRes;
+whMessageCrypto_CmacDmaRequest          cmacDmaReq;
+whMessageCrypto_CmacDmaResponse         cmacDmaRes;
 #endif /* WOLFHSM_CFG_DMA */
 
 #endif /* !WOLFHSM_CFG_NO_CRYPTO */

--- a/test/wh_test_check_struct_padding.c
+++ b/test/wh_test_check_struct_padding.c
@@ -139,33 +139,37 @@ whMessageCrypto_CmacDmaResponse         cmacDmaRes;
 #endif /* !WOLFHSM_CFG_NO_CRYPTO */
 
 #ifdef WOLFHSM_CFG_SHE_EXTENSION
-wh_Packet_she_set_uid_req            sheSetUidReq;
-wh_Packet_she_secure_boot_init_req   sheSecureBootInitReq;
-wh_Packet_she_secure_boot_init_res   sheSecureBootInitRes;
-wh_Packet_she_secure_boot_update_req sheSecureBootUpdateReq;
-wh_Packet_she_secure_boot_update_res sheSecureBootUpdateRes;
-wh_Packet_she_secure_boot_finish_res sheSecureBootFinishRes;
-wh_Packet_she_get_status_res         sheGetStatusRes;
-wh_Packet_she_load_key_req           sheLoadKeyReq;
-wh_Packet_she_load_key_res           sheLoadKeyRes;
-wh_Packet_she_load_plain_key_req     sheLoadPlainKeyReq;
-wh_Packet_she_export_ram_key_res     sheExportRamKeyRes;
-wh_Packet_she_init_rng_res           sheInitRngRes;
-wh_Packet_she_rnd_res                sheRndRes;
-wh_Packet_she_extend_seed_req        sheExtendSeedReq;
-wh_Packet_she_extend_seed_res        sheExtendSeedRes;
-wh_Packet_she_enc_ecb_req            sheEncEcbReq;
-wh_Packet_she_enc_ecb_res            sheEncEcbRes;
-wh_Packet_she_enc_cbc_req            sheEncCbcReq;
-wh_Packet_she_enc_cbc_res            sheEncCbcRes;
-wh_Packet_she_enc_ecb_req            sheDecEcbReq;
-wh_Packet_she_enc_ecb_res            sheDecEcbRes;
-wh_Packet_she_enc_cbc_req            sheDecCbcReq;
-wh_Packet_she_enc_cbc_res            sheDecCbcRes;
-wh_Packet_she_gen_mac_req            sheGenMacReq;
-wh_Packet_she_gen_mac_res            sheGenMacRes;
-wh_Packet_she_verify_mac_req         sheVerifyMacReq;
-wh_Packet_she_verify_mac_res         sheVerifyMacRes;
+/* Include SHE message header for SHE message structures */
+#include "wolfhsm/wh_message_she.h"
+whMessageShe_SetUidRequest            sheSetUidReq;
+whMessageShe_SetUidResponse           sheSetUidRes;
+whMessageShe_SecureBootInitRequest    sheSecureBootInitReq;
+whMessageShe_SecureBootInitResponse   sheSecureBootInitRes;
+whMessageShe_SecureBootUpdateRequest  sheSecureBootUpdateReq;
+whMessageShe_SecureBootUpdateResponse sheSecureBootUpdateRes;
+whMessageShe_SecureBootFinishResponse sheSecureBootFinishRes;
+whMessageShe_GetStatusResponse        sheGetStatusRes;
+whMessageShe_LoadKeyRequest           sheLoadKeyReq;
+whMessageShe_LoadKeyResponse          sheLoadKeyRes;
+whMessageShe_LoadPlainKeyRequest      sheLoadPlainKeyReq;
+whMessageShe_LoadPlainKeyResponse     sheLoadPlainKeyRes;
+whMessageShe_ExportRamKeyResponse     sheExportRamKeyRes;
+whMessageShe_InitRngResponse          sheInitRngRes;
+whMessageShe_RndResponse              sheRndRes;
+whMessageShe_ExtendSeedRequest        sheExtendSeedReq;
+whMessageShe_ExtendSeedResponse       sheExtendSeedRes;
+whMessageShe_EncEcbRequest            sheEncEcbReq;
+whMessageShe_EncEcbResponse           sheEncEcbRes;
+whMessageShe_EncCbcRequest            sheEncCbcReq;
+whMessageShe_EncCbcResponse           sheEncCbcRes;
+whMessageShe_DecEcbRequest            sheDecEcbReq;
+whMessageShe_DecEcbResponse           sheDecEcbRes;
+whMessageShe_DecCbcRequest            sheDecCbcReq;
+whMessageShe_DecCbcResponse           sheDecCbcRes;
+whMessageShe_GenMacRequest            sheGenMacReq;
+whMessageShe_GenMacResponse           sheGenMacRes;
+whMessageShe_VerifyMacRequest         sheVerifyMacReq;
+whMessageShe_VerifyMacResponse        sheVerifyMacRes;
 #endif /* WOLFHSM_CFG_SHE_EXTENSION */
 
 

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -220,8 +220,8 @@ static int whTest_CryptoRsa(whClientContext* ctx, int devId, WC_RNG* rng)
                         WH_ERROR_PRINT("Failed to decrypt %d\n", ret);
                     } else {
                         ret = 0;
-                        if (memcmp(plainText, finalText,
-                                sizeof(plainText)) != 0) {
+                        if (memcmp(plainText, finalText, sizeof(plainText)) !=
+                            0) {
                             WH_ERROR_PRINT("Failed to match\n");
                             ret = -1;
                         }
@@ -268,7 +268,7 @@ static int whTest_CryptoRsa(whClientContext* ctx, int devId, WC_RNG* rng)
                             } else {
                                 ret = 0;
                                 if (memcmp(plainText, finalText,
-                                        sizeof(plainText)) != 0) {
+                                           sizeof(plainText)) != 0) {
                                     WH_ERROR_PRINT("Failed to match\n");
                                     ret = -1;
                                 }
@@ -338,7 +338,8 @@ static int whTest_CryptoEcc(whClientContext* ctx, int devId, WC_RNG* rng)
                         } else {
                             if (memcmp(shared_ab, shared_ba, secLen) == 0) {
                                 printf("ECDH SUCCESS\n");
-                            } else {
+                            }
+                            else {
                                 WH_ERROR_PRINT("ECDH FAILED TO MATCH\n");
                                 ret = -1;
                             }
@@ -435,7 +436,7 @@ static int whTest_CryptoCurve25519(whClientContext* ctx, int devId, WC_RNG* rng)
                     }
                 }
                 if (ret == 0) {
-                    if (XMEMCMP(shared_ab, shared_ba, len) != 0) {
+                    if (memcmp(shared_ab, shared_ba, len) != 0) {
                         WH_ERROR_PRINT("CURVE25519 secrets don't match\n");
                         ret = -1;
                     }
@@ -486,7 +487,7 @@ static int whTest_CryptoCurve25519(whClientContext* ctx, int devId, WC_RNG* rng)
                     }
                 }
                 if (ret == 0) {
-                    if (XMEMCMP(shared_ab, shared_ba, len) != 0) {
+                    if (memcmp(shared_ab, shared_ba, len) != 0) {
                         WH_ERROR_PRINT("CURVE25519 secrets don't match\n");
                         ret = -1;
                     }
@@ -539,7 +540,7 @@ static int whTest_CryptoCurve25519(whClientContext* ctx, int devId, WC_RNG* rng)
                     }
                 }
                 if (ret == 0) {
-                    if (XMEMCMP(shared_ab, shared_ba, len) != 0) {
+                    if (memcmp(shared_ab, shared_ba, len) != 0) {
                         WH_ERROR_PRINT("CURVE25519 secrets don't match\n");
                         ret = -1;
                     }
@@ -599,8 +600,7 @@ static int whTest_CryptoSha256(whClientContext* ctx, int devId, WC_RNG* rng)
                 WH_ERROR_PRINT("Failed to wc_Sha256Final %d\n", ret);
             } else {
                 /* Compare the computed hash with the expected output */
-                if (memcmp(out, expectedOutOne,
-                           WC_SHA256_DIGEST_SIZE) != 0) {
+                if (memcmp(out, expectedOutOne, WC_SHA256_DIGEST_SIZE) != 0) {
                     WH_ERROR_PRINT("SHA256 hash does not match expected.\n");
                     ret = -1;
                 }
@@ -691,7 +691,7 @@ static int whTest_CacheExportKey(whClientContext* ctx, whKeyId* inout_key_id,
         } else {
             if ((key_len_out != key_len) ||
                 (memcmp(key_in, key_out, key_len_out) != 0) ||
-                (memcmp(label_in, label_out, label_len) != 0) ) {
+                (memcmp(label_in, label_out, label_len) != 0)) {
                 ret = -1;
             }
         }
@@ -817,13 +817,13 @@ static int whTest_KeyCache(whClientContext* ctx, int devId, WC_RNG* rng)
                         WH_ERROR_PRINT("Failed to wh_Client_KeyExport %d\n",
                                 ret);
                     } else {
-                        if ( (outLen != sizeof(key)) ||
-                                (memcmp(key, keyOut, outLen) != 0) ||
-                                (memcmp(labelIn, labelOut,
-                                        sizeof(labelIn)) != 0) ) {
+                        if ((outLen != sizeof(key)) ||
+                            (memcmp(key, keyOut, outLen) != 0) ||
+                            (memcmp(labelIn, labelOut, sizeof(labelIn)) != 0)) {
                             WH_ERROR_PRINT("Failed to match\n");
                             ret = -1;
-                        } else {
+                        }
+                        else {
                             printf("KEY CACHE USER EXCLUSION SUCCESS\n");
                         }
                     }
@@ -874,12 +874,13 @@ static int whTest_KeyCache(whClientContext* ctx, int devId, WC_RNG* rng)
                                 ret);
                     } else {
                         if ((outLen != sizeof(key) ||
-                                (memcmp(key, keyOut, outLen) != 0) ||
-                                (memcmp(labelIn, labelOut,
-                                        sizeof(labelIn))) != 0) ) {
+                             (memcmp(key, keyOut, outLen) != 0) ||
+                             (memcmp(labelIn, labelOut, sizeof(labelIn))) !=
+                                 0)) {
                             WH_ERROR_PRINT("Failed to match committed key\n");
                             ret = -1;
-                        } else {
+                        }
+                        else {
                             /* verify commit isn't using new nvm objects */
                             for (i = 0; i < WOLFHSM_CFG_NVM_OBJECT_COUNT; i++) {
                                 ret = wh_Client_KeyCommit(ctx, keyId);
@@ -957,7 +958,7 @@ static int whTestCrypto_Aes(whClientContext* ctx, int devId, WC_RNG* rng)
     whKeyId keyId = WH_KEYID_ERASED;
     uint8_t labelIn[WH_NVM_LABEL_LEN] = "AES Key Label";
 
-    XMEMCPY(plainIn, PLAINTEXT, sizeof(plainIn));
+    memcpy(plainIn, PLAINTEXT, sizeof(plainIn));
 
     /* Randomize inputs */
     ret = wc_RNG_GenerateBlock(rng, key, sizeof(key));
@@ -997,8 +998,8 @@ static int whTestCrypto_Aes(whClientContext* ctx, int devId, WC_RNG* rng)
                             WH_ERROR_PRINT("Failed to wc_AesCbcDecrypt %d\n",
                                     ret);
                         } else {
-                            if (memcmp(plainIn, plainOut,
-                                    sizeof(plainIn)) != 0) {
+                            if (memcmp(plainIn, plainOut, sizeof(plainIn)) !=
+                                0) {
                                 WH_ERROR_PRINT("Failed to match AES-CBC\n");
                                 ret = -1;
                             }
@@ -1050,7 +1051,7 @@ static int whTestCrypto_Aes(whClientContext* ctx, int devId, WC_RNG* rng)
                                             ret);
                                 } else {
                                     if (memcmp(plainIn, plainOut,
-                                            sizeof(plainIn)) != 0) {
+                                               sizeof(plainIn)) != 0) {
                                         WH_ERROR_PRINT("Failed to match\n");
                                         ret = -1;
                                     }
@@ -1144,7 +1145,8 @@ static int whTestCrypto_Aes(whClientContext* ctx, int devId, WC_RNG* rng)
                         if (ret != 0) {
                             WH_ERROR_PRINT("Failed to wc_AesGcmDecrypt %d\n", ret);
                         } else {
-                            if (memcmp(plainIn, plainOut, sizeof(plainIn)) != 0) {
+                            if (memcmp(plainIn, plainOut, sizeof(plainIn)) !=
+                                0) {
                                 WH_ERROR_PRINT("AES GCM FAILED TO MATCH\n");
                                 ret = -1;
                             }
@@ -1654,7 +1656,7 @@ static int whTestCrypto_MlDsaDmaClient(whClientContext* ctx, int devId,
     /* Compare the keys */
     if (ret == 0) {
         if (key_der1_len != key_der2_len ||
-            XMEMCMP(key_der1, key_der2, key_der1_len) != 0) {
+            memcmp(key_der1, key_der2, key_der1_len) != 0) {
             WH_ERROR_PRINT("Exported key does not match generated key\n");
             ret = -1;
         }

--- a/test/wh_test_she.c
+++ b/test/wh_test_she.c
@@ -320,11 +320,11 @@ int whTest_SheClientConfig(whClientConfig* config)
     }
     printf("SHE ECB SUCCESS\n");
     if ((ret = wh_Client_SheEncCbc(client, WH_SHE_RAM_KEY_ID, iv, sizeof(iv), plainText, cipherText, sizeof(plainText))) != 0) {
-        WH_ERROR_PRINT("Failed to wh_Client_SheEncEcb %d\n", ret);
+        WH_ERROR_PRINT("Failed to wh_Client_SheEncCbc %d\n", ret);
         goto exit;
     }
     if ((ret = wh_Client_SheDecCbc(client, WH_SHE_RAM_KEY_ID, iv, sizeof(iv), cipherText, finalText, sizeof(cipherText))) != 0) {
-        WH_ERROR_PRINT("Failed to wh_Client_SheEncEcb %d\n", ret);
+        WH_ERROR_PRINT("Failed to wh_Client_SheDecCbc %d\n", ret);
         goto exit;
     }
     if (memcmp(finalText, plainText, sizeof(plainText)) != 0) {

--- a/wolfhsm/wh_client_crypto.h
+++ b/wolfhsm/wh_client_crypto.h
@@ -394,6 +394,32 @@ int wh_Client_AesGcm(whClientContext* ctx,
 
 
 #ifdef WOLFSSL_CMAC
+
+/**
+ * @brief Performs a CMAC operation on the input data.
+ *
+ * This function performs a CMAC operation with the specified parameters.
+ * It can be used for initialization, update, or finalization of CMAC
+ * operations, depending on the input arguments.
+ *
+ * @param[in] ctx Pointer to the wolfHSM client context.
+ * @param[in,out] cmac Pointer to the CMAC structure.
+ * @param[in] type The type of CMAC operation.
+ * @param[in] key Pointer to the key buffer, or NULL if using a key stored in
+ * HSM.
+ * @param[in] keyLen Length of the key in bytes.
+ * @param[in] in Pointer to the input data buffer, or NULL for finalization.
+ * @param[in] inLen Length of the input data in bytes.
+ * @param[out] outMac Pointer to the output buffer for the CMAC tag.
+ * @param[in,out] outMacLen Pointer to the size of the output buffer, updated
+ * with actual size.
+ * @return int Returns WH_ERROR_OK (0) on success, or a negative error code on
+ * failure.
+ */
+int wh_Client_Cmac(whClientContext* ctx, Cmac* cmac, CmacType type,
+                   const uint8_t* key, uint32_t keyLen, const uint8_t* in,
+                   uint32_t inLen, uint8_t* outMac, uint32_t* outMacLen);
+
 /**
  * @brief Runs the CMAC-AES operation in a single call with a wolfHSM keyId.
  *
@@ -480,7 +506,69 @@ int wh_Client_CmacSetKeyId(Cmac* key, whNvmId keyId);
  * @return int Returns 0 on success or a negative error code on failure.
  */
 int wh_Client_CmacGetKeyId(Cmac* key, whNvmId* outId);
+
+#ifdef WOLFHSM_CFG_DMA
+/**
+ * @brief Performs CMAC operations using DMA for data transfer.
+ *
+ * This function performs CMAC operations (initialize, update, finalize) using
+ * DMA for efficient data transfer between client and server. The operation
+ * performed depends on which parameters are non-NULL.
+ *
+ * @param[in] ctx Pointer to the client context structure.
+ * @param[in,out] cmac Pointer to the CMAC structure to be used.
+ * @param[in] type The type of CMAC operation (e.g., WC_CMAC_AES).
+ * @param[in] key Pointer to the key data. NULL if using a stored key.
+ * @param[in] keyLen Length of the key in bytes.
+ * @param[in] in Pointer to the input data. NULL if not performing an update.
+ * @param[in] inLen Length of the input data in bytes.
+ * @param[out] outMac Pointer to store the CMAC result. NULL if not finalizing.
+ * @param[in,out] outMacLen Pointer to the size of the outMac buffer. Updated
+ * with actual size on return.
+ * @return int Returns 0 on success or a negative error code on failure.
+ */
+int wh_Client_CmacDma(whClientContext* ctx, Cmac* cmac, CmacType type,
+                      const uint8_t* key, uint32_t keyLen, const uint8_t* in,
+                      uint32_t inLen, uint8_t* outMac, uint32_t* outMacLen);
+#endif /* WOLFHSM_CFG_DMA */
+
 #endif /* WOLFSSL_CMAC */
+
+#ifndef NO_SHA256
+
+/**
+ * @brief Performs a SHA-256 hash operation on the input data.
+         *
+ * This function performs a SHA-256 hash operation on the input data and stores
+ * the result in the output buffer.
+ *
+ * @param[in] ctx Pointer to the client context structure.
+ * @param[in] sha Pointer to the SHA-256 context structure.
+ * @param[in] in Pointer to the input data.
+ * @param[in] inLen Length of the input data in bytes.
+ * @param[out] out Pointer to the output buffer.
+ * @return int Returns 0 on success or a negative error code on failure.
+ */
+int wh_Client_Sha256(whClientContext* ctx, wc_Sha256* sha, const uint8_t* in,
+                     uint32_t inLen, uint8_t* out);
+
+/**
+ * @brief Performs a SHA-256 hash operation on the input data using DMA.
+ *
+ * This function performs a SHA-256 hash operation on the input data and stores
+ * the result in the output buffer using DMA.
+ *
+ * @param[in] ctx Pointer to the client context structure.
+ * @param[in] sha Pointer to the SHA-256 context structure.
+ * @param[in] in Pointer to the input data.
+ * @param[in] inLen Length of the input data in bytes.
+ * @param[out] out Pointer to the output buffer.
+ * @return int Returns 0 on success or a negative error code on failure.
+ */
+int wh_Client_Sha256Dma(whClientContext* ctx, wc_Sha256* sha, const uint8_t* in,
+                        uint32_t inLen, uint8_t* out);
+
+#endif /* !NO_SHA256 */
 
 #ifdef HAVE_DILITHIUM
 

--- a/wolfhsm/wh_message_counter.h
+++ b/wolfhsm/wh_message_counter.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2024 wolfSSL Inc.
+ *
+ * This file is part of wolfHSM.
+ *
+ * wolfHSM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfHSM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wolfHSM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * wolfhsm/wh_message_counter.h
+ *
+ * Message structures and translation functions for counter operations.
+ */
+
+#ifndef WOLFHSM_WH_MESSAGE_COUNTER_H_
+#define WOLFHSM_WH_MESSAGE_COUNTER_H_
+
+/* Pick up compile-time configuration */
+#include "wolfhsm/wh_settings.h"
+
+#include <stdint.h>
+
+#include "wolfhsm/wh_common.h"
+
+/* Counter Init Request */
+typedef struct {
+    uint32_t counter;
+    uint16_t counterId;
+    uint8_t  WH_PAD[2];
+} whMessageCounter_InitRequest;
+
+/* Counter Init Response */
+typedef struct {
+    uint32_t rc;
+    uint32_t counter;
+} whMessageCounter_InitResponse;
+
+/* Counter Init translation functions */
+int wh_MessageCounter_TranslateInitRequest(
+    uint16_t magic, const whMessageCounter_InitRequest* src,
+    whMessageCounter_InitRequest* dest);
+
+int wh_MessageCounter_TranslateInitResponse(
+    uint16_t magic, const whMessageCounter_InitResponse* src,
+    whMessageCounter_InitResponse* dest);
+
+/* Counter Increment Request */
+typedef struct {
+    uint16_t counterId;
+    uint8_t  WH_PAD[6];
+} whMessageCounter_IncrementRequest;
+
+/* Counter Increment Response */
+typedef struct {
+    uint32_t rc;
+    uint32_t counter;
+} whMessageCounter_IncrementResponse;
+
+/* Counter Increment translation functions */
+int wh_MessageCounter_TranslateIncrementRequest(
+    uint16_t magic, const whMessageCounter_IncrementRequest* src,
+    whMessageCounter_IncrementRequest* dest);
+
+int wh_MessageCounter_TranslateIncrementResponse(
+    uint16_t magic, const whMessageCounter_IncrementResponse* src,
+    whMessageCounter_IncrementResponse* dest);
+
+/* Counter Read Request */
+typedef struct {
+    uint16_t counterId;
+    uint8_t  WH_PAD[6];
+} whMessageCounter_ReadRequest;
+
+/* Counter Read Response */
+typedef struct {
+    uint32_t rc;
+    uint32_t counter;
+} whMessageCounter_ReadResponse;
+
+/* Counter Read translation functions */
+int wh_MessageCounter_TranslateReadRequest(
+    uint16_t magic, const whMessageCounter_ReadRequest* src,
+    whMessageCounter_ReadRequest* dest);
+
+int wh_MessageCounter_TranslateReadResponse(
+    uint16_t magic, const whMessageCounter_ReadResponse* src,
+    whMessageCounter_ReadResponse* dest);
+
+/* Counter Destroy Request */
+typedef struct {
+    uint16_t counterId;
+    uint8_t  WH_PAD[6];
+} whMessageCounter_DestroyRequest;
+
+/* Counter Destroy Response */
+typedef struct {
+    uint32_t rc;
+    uint8_t  WH_PAD[4];
+} whMessageCounter_DestroyResponse;
+
+/* Counter Destroy translation functions */
+int wh_MessageCounter_TranslateDestroyRequest(
+    uint16_t magic, const whMessageCounter_DestroyRequest* src,
+    whMessageCounter_DestroyRequest* dest);
+
+int wh_MessageCounter_TranslateDestroyResponse(
+    uint16_t magic, const whMessageCounter_DestroyResponse* src,
+    whMessageCounter_DestroyResponse* dest);
+
+#endif /* !WOLFHSM_WH_MESSAGE_COUNTER_H_ */

--- a/wolfhsm/wh_message_crypto.h
+++ b/wolfhsm/wh_message_crypto.h
@@ -1,0 +1,808 @@
+/*
+ * Copyright (C) 2024 wolfSSL Inc.
+ *
+ * This file is part of wolfHSM.
+ *
+ * wolfHSM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfHSM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wolfHSM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * wolfhsm/wh_message_crypto.h
+ *
+ * Message structures and translation functions for crypto operations.
+ */
+
+#ifndef WOLFHSM_WH_MESSAGE_CRYPTO_H_
+#define WOLFHSM_WH_MESSAGE_CRYPTO_H_
+
+/* Pick up compile-time configuration */
+#include "wolfhsm/wh_settings.h"
+
+#include <stdint.h>
+
+#include "wolfhsm/wh_common.h"
+#include "wolfhsm/wh_message.h"
+
+
+/*
+ * Crypto Message Protocol Packet Structure
+ *
+ * +---------------------------+
+ * |                           |
+ * |      Comm Buffer Data     |
+ * |                           |
+ * | +-------------------------+
+ * | |                         |
+ * | | Generic Crypto Header   | <- Size of whMessageCrypto_GenericHeader
+ * | | (Request or Response)   |    Could be either:
+ * | |                         |    - whMessageCrypto_GenericRequestHeader
+ * | |                         |       (client -> server)
+ * | |                         |    - whMessageCrypto_GenericResponseHeader
+ * | |                         |       (server -> client)
+ * | +-------------------------+
+ * | |                         |
+ * | | Crypto-Specific Header  | <- Algorithm-specific request/response
+ * | |                         |    (e.g., AesGcm, Rsa, Ecc, etc.)
+ * | +-------------------------+
+ * | |                         |
+ * | |                         |
+ * | |     Arbitrary Data      | <- Input/output data, keys, IVs, etc.
+ * | |                         |    (layout defined by specific algorithm)
+ * | |                         |
+ * | +-------------------------+
+ * |                           |
+ * +---------------------------+
+ */
+
+
+/* Indicates the algorithm type for the requested crypto operation. Corresponds
+ * to the wolfCrypt crypto callback subtype (e.g. cypher type, pk type, etc.) */
+typedef uint32_t whMessageCrypto_AlgoType;
+
+/* Generic crypto header message. This will always be the first element in any
+ * crypto message and indicates how to interpret the rest of the message. */
+typedef struct {
+    whMessageCrypto_AlgoType algoType;    /* Type of crypto operation */
+    whMessageCrypto_AlgoType algoSubType; /* Subtype, specific to algoType.
+                                             Right now only used for PQ algos */
+#define WH_MESSAGE_CRYPTO_ALGO_SUBTYPE_NONE 0
+} whMessageCrypto_GenericRequestHeader;
+
+/* Generic crypto response header message. This must always be the first element
+ * in the response message. */
+typedef struct {
+    whMessageCrypto_AlgoType algoType; /* Type of crypto operation */
+    int32_t                  rc;       /* Return code */
+} whMessageCrypto_GenericResponseHeader;
+
+/* TODO fix, make this a generic static assert*/
+_Static_assert(
+    sizeof(whMessageCrypto_GenericRequestHeader) ==
+        sizeof(whMessageCrypto_GenericResponseHeader),
+    "GenericRequestHeader and GenericResponseHeader must be the same size");
+
+/* Size allocated in the comm buffer data for the crypto request and response
+ * headers. Because crypto operations process data in-place in the comm buffer,
+ * the header sizes for the request and response protocol messages must be the
+ * same. If they are not, then crypto input and output buffers will not overlap,
+ * and crypto operations will fail in mysterious ways. */
+typedef union {
+    whMessageCrypto_GenericRequestHeader  request;
+    whMessageCrypto_GenericResponseHeader response;
+} whMessageCrypto_GenericHeader;
+
+int wh_MessageCrypto_TranslateGenericRequestHeader(
+    uint16_t magic, const whMessageCrypto_GenericRequestHeader* src,
+    whMessageCrypto_GenericRequestHeader* dest);
+
+int wh_MessageCrypto_TranslateGenericResponseHeader(
+    uint16_t magic, const whMessageCrypto_GenericResponseHeader* src,
+    whMessageCrypto_GenericResponseHeader* dest);
+
+
+/*
+ * RNG
+ */
+
+/* RNG Request */
+typedef struct {
+    uint32_t sz; /* Size of output data */
+} whMessageCrypto_RngRequest;
+
+/* RNG Response */
+typedef struct {
+    uint32_t sz; /* Size of output data */
+    /* Data follows:
+     * uint8_t out[sz]
+     */
+} whMessageCrypto_RngResponse;
+
+int wh_MessageCrypto_TranslateRngRequest(uint16_t magic,
+                                         const whMessageCrypto_RngRequest* src,
+                                         whMessageCrypto_RngRequest* dest);
+
+int wh_MessageCrypto_TranslateRngResponse(
+    uint16_t magic, const whMessageCrypto_RngResponse* src,
+    whMessageCrypto_RngResponse* dest);
+
+
+/*
+ * AES
+ */
+
+/* AES CBC Request */
+typedef struct {
+    uint32_t enc;       /* 1 for encrypt, 0 for decrypt */
+    uint32_t keyLen;    /* Length of key in bytes */
+    uint32_t sz;        /* Size of input data */
+    uint16_t keyId;     /* Key ID if using stored key */
+    uint8_t  WH_PAD[2]; /* Padding for alignment */
+    /* Data follows:
+     * uint8_t in[sz]
+     * uint8_t key[keyLen]
+     * uint8_t iv[AES_IV_SIZE]
+     */
+} whMessageCrypto_AesCbcRequest;
+
+/* AES CBC Response */
+typedef struct {
+    uint32_t sz; /* Size of output data */
+    /* Pad to ensure overlap for input and output buffers */
+    uint8_t WH_PAD[sizeof(whMessageCrypto_AesCbcRequest) - sizeof(uint32_t)];
+    /* Data follows:
+     * uint8_t out[sz]
+     */
+} whMessageCrypto_AesCbcResponse;
+
+/* TODO fix, make this a generic static assert*/
+_Static_assert(sizeof(whMessageCrypto_AesCbcRequest) ==
+                   sizeof(whMessageCrypto_AesCbcResponse),
+               "AesCbcRequest and AesCbcResponse must be the same size");
+
+int wh_MessageCrypto_TranslateAesCbcRequest(
+    uint16_t magic, const whMessageCrypto_AesCbcRequest* src,
+    whMessageCrypto_AesCbcRequest* dest);
+
+int wh_MessageCrypto_TranslateAesCbcResponse(
+    uint16_t magic, const whMessageCrypto_AesCbcResponse* src,
+    whMessageCrypto_AesCbcResponse* dest);
+
+/* AES GCM Request */
+typedef struct {
+    uint32_t enc;       /* 1 for encrypt, 0 for decrypt */
+    uint32_t keyLen;    /* Length of key in bytes */
+    uint32_t sz;        /* Size of input data */
+    uint32_t ivSz;      /* Size of IV */
+    uint32_t authInSz;  /* Size of auth data */
+    uint32_t authTagSz; /* Size of auth tag */
+    uint16_t keyId;     /* Key ID if using stored key */
+    uint8_t  WH_PAD[2]; /* Padding for alignment */
+    /* Data follows:
+     * uint8_t in[sz]
+     * uint8_t key[keyLen]
+     * uint8_t iv[ivSz]
+     * uint8_t authIn[authInSz]
+     * uint8_t authTag[authTagSz]
+     */
+} whMessageCrypto_AesGcmRequest;
+
+/* AES GCM Response */
+typedef struct {
+    uint32_t sz;        /* Size of output data */
+    uint32_t authTagSz; /* Size of auth tag */
+    /* Pad to ensure overlap for input and output buffers */
+    uint8_t
+        WH_PAD[sizeof(whMessageCrypto_AesGcmRequest) - (sizeof(uint32_t) * 2)];
+    /* Data follows:
+     * uint8_t out[sz]
+     * uint8_t authTag[authTagSz]
+     */
+} whMessageCrypto_AesGcmResponse;
+
+/* TODO fix, make this a generic static assert*/
+_Static_assert(sizeof(whMessageCrypto_AesGcmRequest) ==
+                   sizeof(whMessageCrypto_AesGcmResponse),
+               "AesGcmRequest and AesGcmResponse must be the same size");
+
+int wh_MessageCrypto_TranslateAesGcmRequest(
+    uint16_t magic, const whMessageCrypto_AesGcmRequest* src,
+    whMessageCrypto_AesGcmRequest* dest);
+
+int wh_MessageCrypto_TranslateAesGcmResponse(
+    uint16_t magic, const whMessageCrypto_AesGcmResponse* src,
+    whMessageCrypto_AesGcmResponse* dest);
+
+/*
+ * RSA
+ */
+
+/* RSA Key Generation Request */
+typedef struct {
+    uint32_t flags;
+    uint32_t keyId;
+    uint32_t size;
+    uint32_t e;
+    uint8_t  label[WH_NVM_LABEL_LEN];
+} whMessageCrypto_RsaKeyGenRequest;
+
+/* RSA Key Generation Response */
+typedef struct {
+    uint32_t keyId;
+    uint32_t len;
+    /* Data follows:
+     * uint8_t out[len];
+     */
+} whMessageCrypto_RsaKeyGenResponse;
+
+int wh_MessageCrypto_TranslateRsaKeyGenRequest(
+    uint16_t magic, const whMessageCrypto_RsaKeyGenRequest* src,
+    whMessageCrypto_RsaKeyGenRequest* dest);
+
+int wh_MessageCrypto_TranslateRsaKeyGenResponse(
+    uint16_t magic, const whMessageCrypto_RsaKeyGenResponse* src,
+    whMessageCrypto_RsaKeyGenResponse* dest);
+
+
+/* RSA Operation Request */
+typedef struct {
+    uint32_t opType;
+    uint32_t options;
+#define WH_MESSAGE_CRYPTO_RSA_OPTIONS_EVICT (1 << 0)
+    uint32_t keyId;
+    uint32_t inLen;
+    uint32_t outLen;
+    /* Data follows:
+     * uint8_t in[inLen];
+     */
+} whMessageCrypto_RsaRequest;
+
+/* RSA Operation Response */
+typedef struct {
+    uint32_t outLen;
+    /* Data follows:
+     * uint8_t out[outLen];
+     */
+} whMessageCrypto_RsaResponse;
+
+int wh_MessageCrypto_TranslateRsaRequest(uint16_t magic,
+                                         const whMessageCrypto_RsaRequest* src,
+                                         whMessageCrypto_RsaRequest* dest);
+
+int wh_MessageCrypto_TranslateRsaResponse(
+    uint16_t magic, const whMessageCrypto_RsaResponse* src,
+    whMessageCrypto_RsaResponse* dest);
+
+/* RSA Get Size Request */
+typedef struct {
+    uint32_t options;
+#define WH_MESSAGE_CRYPTO_RSA_GET_SIZE_OPTIONS_EVICT (1 << 0)
+    uint32_t keyId;
+} whMessageCrypto_RsaGetSizeRequest;
+
+/* RSA Get Size Response */
+typedef struct {
+    uint32_t keySize;
+} whMessageCrypto_RsaGetSizeResponse;
+
+int wh_MessageCrypto_TranslateRsaGetSizeRequest(
+    uint16_t magic, const whMessageCrypto_RsaGetSizeRequest* src,
+    whMessageCrypto_RsaGetSizeRequest* dest);
+
+int wh_MessageCrypto_TranslateRsaGetSizeResponse(
+    uint16_t magic, const whMessageCrypto_RsaGetSizeResponse* src,
+    whMessageCrypto_RsaGetSizeResponse* dest);
+
+/*
+ * ECC
+ */
+
+/* ECC Key Generation Request */
+typedef struct {
+    uint32_t sz;
+    uint32_t curveId;
+    uint32_t keyId;
+    uint32_t flags;
+    uint32_t access;
+    uint8_t  label[WH_NVM_LABEL_LEN];
+} whMessageCrypto_EccKeyGenRequest;
+
+/* ECC Key Generation Response */
+typedef struct {
+    uint32_t keyId;
+    uint32_t len;
+    /* Data follows:
+     * uint8_t out[len];
+     */
+} whMessageCrypto_EccKeyGenResponse;
+
+int wh_MessageCrypto_TranslateEccKeyGenRequest(
+    uint16_t magic, const whMessageCrypto_EccKeyGenRequest* src,
+    whMessageCrypto_EccKeyGenRequest* dest);
+
+int wh_MessageCrypto_TranslateEccKeyGenResponse(
+    uint16_t magic, const whMessageCrypto_EccKeyGenResponse* src,
+    whMessageCrypto_EccKeyGenResponse* dest);
+
+/* ECDH Request */
+typedef struct {
+    uint32_t options;
+#define WH_MESSAGE_CRYPTO_ECDH_OPTIONS_EVICTPUB (1 << 0)
+#define WH_MESSAGE_CRYPTO_ECDH_OPTIONS_EVICTPRV (1 << 1)
+    uint32_t privateKeyId;
+    uint32_t publicKeyId;
+} whMessageCrypto_EcdhRequest;
+
+/* ECDH Response */
+typedef struct {
+    uint32_t sz;
+    /* Data follows:
+     * uint8_t out[sz];
+     */
+} whMessageCrypto_EcdhResponse;
+
+int wh_MessageCrypto_TranslateEcdhRequest(
+    uint16_t magic, const whMessageCrypto_EcdhRequest* src,
+    whMessageCrypto_EcdhRequest* dest);
+
+int wh_MessageCrypto_TranslateEcdhResponse(
+    uint16_t magic, const whMessageCrypto_EcdhResponse* src,
+    whMessageCrypto_EcdhResponse* dest);
+
+/* ECC Sign Request */
+typedef struct {
+    uint32_t options;
+#define WH_MESSAGE_CRYPTO_ECCSIGN_OPTIONS_EVICT (1 << 0)
+    uint32_t keyId;
+    uint32_t sz;
+    /* Data follows:
+     * uint8_t in[sz];
+     */
+} whMessageCrypto_EccSignRequest;
+
+/* ECC Sign Response */
+typedef struct {
+    uint32_t sz;
+    /* Data follows:
+     * uint8_t out[sz];
+     */
+} whMessageCrypto_EccSignResponse;
+
+int wh_MessageCrypto_TranslateEccSignRequest(
+    uint16_t magic, const whMessageCrypto_EccSignRequest* src,
+    whMessageCrypto_EccSignRequest* dest);
+
+int wh_MessageCrypto_TranslateEccSignResponse(
+    uint16_t magic, const whMessageCrypto_EccSignResponse* src,
+    whMessageCrypto_EccSignResponse* dest);
+
+/* ECC Verify Request */
+typedef struct {
+    uint32_t options;
+#define WH_MESSAGE_CRYPTO_ECCVERIFY_OPTIONS_EVICT (1 << 0)
+#define WH_MESSAGE_CRYPTO_ECCVERIFY_OPTIONS_EXPORTPUB (1 << 1)
+    uint32_t keyId;
+    uint32_t sigSz;
+    uint32_t hashSz;
+    /* Data follows:
+     * uint8_t sig[sigSz];
+     * uint8_t hash[hashSz];
+     */
+} whMessageCrypto_EccVerifyRequest;
+
+/* ECC Verify Response */
+typedef struct {
+    uint32_t res;
+    uint32_t pubSz;
+    /* Data follows:
+     * uint8_t pub[pubSz];
+     */
+} whMessageCrypto_EccVerifyResponse;
+
+int wh_MessageCrypto_TranslateEccVerifyRequest(
+    uint16_t magic, const whMessageCrypto_EccVerifyRequest* src,
+    whMessageCrypto_EccVerifyRequest* dest);
+
+int wh_MessageCrypto_TranslateEccVerifyResponse(
+    uint16_t magic, const whMessageCrypto_EccVerifyResponse* src,
+    whMessageCrypto_EccVerifyResponse* dest);
+
+/* ECC Check Request */
+typedef struct {
+    uint32_t keyId;
+    uint32_t curveId;
+} whMessageCrypto_EccCheckRequest;
+
+/* ECC Check Response */
+typedef struct {
+    uint32_t ok;
+} whMessageCrypto_EccCheckResponse;
+
+int wh_MessageCrypto_TranslateEccCheckRequest(
+    uint16_t magic, const whMessageCrypto_EccCheckRequest* src,
+    whMessageCrypto_EccCheckRequest* dest);
+
+int wh_MessageCrypto_TranslateEccCheckResponse(
+    uint16_t magic, const whMessageCrypto_EccCheckResponse* src,
+    whMessageCrypto_EccCheckResponse* dest);
+
+
+/*
+ * Curve25519
+ */
+
+/* Curve25519 Key Generation Request */
+typedef struct {
+    uint32_t sz;
+    uint32_t flags;
+    uint32_t keyId;
+    uint8_t  label[WH_NVM_LABEL_LEN];
+} whMessageCrypto_Curve25519KeyGenRequest;
+
+/* Curve25519 Key Generation Response */
+typedef struct {
+    uint32_t keyId;
+    uint32_t len;
+    /* Data follows:
+     * uint8_t out[len];
+     */
+} whMessageCrypto_Curve25519KeyGenResponse;
+
+int wh_MessageCrypto_TranslateCurve25519KeyGenRequest(
+    uint16_t magic, const whMessageCrypto_Curve25519KeyGenRequest* src,
+    whMessageCrypto_Curve25519KeyGenRequest* dest);
+
+int wh_MessageCrypto_TranslateCurve25519KeyGenResponse(
+    uint16_t magic, const whMessageCrypto_Curve25519KeyGenResponse* src,
+    whMessageCrypto_Curve25519KeyGenResponse* dest);
+
+/* Curve25519 Request */
+typedef struct {
+    uint32_t options;
+#define WH_MESSAGE_CRYPTO_CURVE25519_OPTIONS_EVICTPUB (1 << 0)
+#define WH_MESSAGE_CRYPTO_CURVE25519_OPTIONS_EVICTPRV (1 << 1)
+    uint32_t privateKeyId;
+    uint32_t publicKeyId;
+    uint32_t endian;
+} whMessageCrypto_Curve25519Request;
+
+/* Curve25519 Response */
+typedef struct {
+    uint32_t sz;
+    uint8_t  WH_PAD[4];
+    /* Data follows:
+     * uint8_t out[sz];
+     */
+} whMessageCrypto_Curve25519Response;
+
+int wh_MessageCrypto_TranslateCurve25519Request(
+    uint16_t magic, const whMessageCrypto_Curve25519Request* src,
+    whMessageCrypto_Curve25519Request* dest);
+
+int wh_MessageCrypto_TranslateCurve25519Response(
+    uint16_t magic, const whMessageCrypto_Curve25519Response* src,
+    whMessageCrypto_Curve25519Response* dest);
+
+/*
+ * SHA
+ */
+
+/* SHA256 Request */
+typedef struct {
+    struct {
+        uint32_t hiLen;
+        uint32_t loLen;
+        /* intermediate hash value */
+        uint8_t hash[32]; /* TODO (BRN) WC_SHA256_DIGEST_SIZE */
+    } resumeState;
+    /* Flag indicating to the server that this is the last block and it should
+     * finalize the hash. If set, inBlock may be only partially full*/
+    uint32_t isLastBlock;
+    /* Length of the last input block of data. Only valid if isLastBlock=1 */
+    uint32_t lastBlockLen;
+    /* Full sha256 input block to hash */
+    uint8_t inBlock[64]; /* TODO (BRN) WC_SHA256_BLOCK_SIZE */
+    uint8_t WH_PAD[4];
+} whMessageCrypto_Sha256Request;
+
+/* SHA256 Response */
+typedef struct {
+    /* Resulting hash value */
+    uint32_t hiLen;
+    uint32_t loLen;
+    uint8_t  hash[32]; /* TODO WC_SHA256_DIGEST_SIZE */
+} whMessageCrypto_Sha256Response;
+
+int wh_MessageCrypto_TranslateSha256Request(
+    uint16_t magic, const whMessageCrypto_Sha256Request* src,
+    whMessageCrypto_Sha256Request* dest);
+
+int wh_MessageCrypto_TranslateSha256Response(
+    uint16_t magic, const whMessageCrypto_Sha256Response* src,
+    whMessageCrypto_Sha256Response* dest);
+
+/*
+ * CMAC
+ */
+
+/* CMAC Request */
+typedef struct {
+    uint32_t type; /* wolfCrypt CmacType enum */
+    uint32_t outSz;
+    uint32_t inSz;
+    uint32_t keySz;
+    uint16_t keyId;
+    uint8_t  WH_PAD[6];
+    /* Data follows:
+     * uint8_t in[inSz]
+     * uint8_t key[keySz]
+     */
+} whMessageCrypto_CmacRequest;
+
+/* CMAC Response */
+typedef struct {
+    uint32_t outSz;
+    uint16_t keyId;
+    uint8_t  WH_PAD[2];
+    /* Data follows:
+     * uint8_t out[outSz];
+     */
+} whMessageCrypto_CmacResponse;
+
+int wh_MessageCrypto_TranslateCmacRequest(
+    uint16_t magic, const whMessageCrypto_CmacRequest* src,
+    whMessageCrypto_CmacRequest* dest);
+
+int wh_MessageCrypto_TranslateCmacResponse(
+    uint16_t magic, const whMessageCrypto_CmacResponse* src,
+    whMessageCrypto_CmacResponse* dest);
+
+
+/*
+ * ML-DSA
+ */
+
+/* ML-DSA Key Generation Request */
+typedef struct {
+    uint32_t sz;
+    uint32_t level;
+    uint32_t keyId;
+    uint32_t flags;
+    uint32_t access;
+    uint8_t  label[WH_NVM_LABEL_LEN];
+} whMessageCrypto_MlDsaKeyGenRequest;
+
+/* ML-DSA Key Generation Response */
+typedef struct {
+    uint32_t keyId;
+    uint32_t len;
+    /* Data follows:
+     * uint8_t out[len];
+     */
+} whMessageCrypto_MlDsaKeyGenResponse;
+
+int wh_MessageCrypto_TranslateMlDsaKeyGenRequest(
+    uint16_t magic, const whMessageCrypto_MlDsaKeyGenRequest* src,
+    whMessageCrypto_MlDsaKeyGenRequest* dest);
+
+int wh_MessageCrypto_TranslateMlDsaKeyGenResponse(
+    uint16_t magic, const whMessageCrypto_MlDsaKeyGenResponse* src,
+    whMessageCrypto_MlDsaKeyGenResponse* dest);
+
+/* ML-DSA Sign Request */
+typedef struct {
+    uint32_t options;
+#define WH_MESSAGE_CRYPTO_MLDSA_SIGN_OPTIONS_EVICT (1 << 0)
+    uint32_t level;
+    uint32_t keyId;
+    uint32_t sz;
+    uint8_t  WH_PAD[4];
+    /* Data follows:
+     * uint8_t in[sz];
+     */
+} whMessageCrypto_MlDsaSignRequest;
+
+/* ML-DSA Sign Response */
+typedef struct {
+    uint32_t sz;
+    uint8_t  WH_PAD[4];
+    /* Data follows:
+     * uint8_t out[sz];
+     */
+} whMessageCrypto_MlDsaSignResponse;
+
+int wh_MessageCrypto_TranslateMlDsaSignRequest(
+    uint16_t magic, const whMessageCrypto_MlDsaSignRequest* src,
+    whMessageCrypto_MlDsaSignRequest* dest);
+
+int wh_MessageCrypto_TranslateMlDsaSignResponse(
+    uint16_t magic, const whMessageCrypto_MlDsaSignResponse* src,
+    whMessageCrypto_MlDsaSignResponse* dest);
+
+/* ML-DSA Verify Request */
+typedef struct {
+    uint32_t options;
+#define WH_MESSAGE_CRYPTO_MLDSA_VERIFY_OPTIONS_EVICT (1 << 0)
+#define WH_MESSAGE_CRYPTO_MLDSA_VERIFY_OPTIONS_EXPORTPUB (1 << 1)
+    uint32_t level;
+    uint32_t keyId;
+    uint32_t sigSz;
+    uint32_t hashSz;
+    uint8_t  WH_PAD[4];
+    /* Data follows:
+     * uint8_t sig[sigSz];
+     * uint8_t hash[hashSz];
+     */
+} whMessageCrypto_MlDsaVerifyRequest;
+
+/* ML-DSA Verify Response */
+typedef struct {
+    uint32_t res;
+    uint8_t  WH_PAD[4];
+} whMessageCrypto_MlDsaVerifyResponse;
+
+int wh_MessageCrypto_TranslateMlDsaVerifyRequest(
+    uint16_t magic, const whMessageCrypto_MlDsaVerifyRequest* src,
+    whMessageCrypto_MlDsaVerifyRequest* dest);
+
+int wh_MessageCrypto_TranslateMlDsaVerifyResponse(
+    uint16_t magic, const whMessageCrypto_MlDsaVerifyResponse* src,
+    whMessageCrypto_MlDsaVerifyResponse* dest);
+
+
+/*
+ * DMA-based crypto messages
+ */
+
+/* DMA buffer structure */
+typedef struct {
+    uint64_t addr;
+    uint64_t sz;
+} whMessageCrypto_DmaBuffer;
+
+/* DMA address status structure */
+typedef struct {
+    /* If packet->rc == WH_ERROR_ACCESS, this field will contain the offending
+     * address/size pair. Invalid otherwise. */
+    whMessageCrypto_DmaBuffer badAddr;
+} whMessageCrypto_DmaAddrStatus;
+
+/* SHA256 DMA Request */
+typedef struct {
+    /* Since client addresses are subject to DMA checking, we can't use them to
+     * determine the requested operation (update/final). Therefore we need to
+     * indicate to the server which SHA256 operation to perform */
+    uint64_t                  finalize;
+    whMessageCrypto_DmaBuffer input;
+    whMessageCrypto_DmaBuffer state;
+    whMessageCrypto_DmaBuffer output;
+} whMessageCrypto_Sha256DmaRequest;
+
+/* SHA256 DMA Response */
+typedef struct {
+    whMessageCrypto_DmaAddrStatus dmaAddrStatus;
+} whMessageCrypto_Sha256DmaResponse;
+
+/* SHA256 DMA translation functions */
+int wh_MessageCrypto_TranslateSha256DmaRequest(
+    uint16_t magic, const whMessageCrypto_Sha256DmaRequest* src,
+    whMessageCrypto_Sha256DmaRequest* dest);
+
+int wh_MessageCrypto_TranslateSha256DmaResponse(
+    uint16_t magic, const whMessageCrypto_Sha256DmaResponse* src,
+    whMessageCrypto_Sha256DmaResponse* dest);
+
+/* CMAC DMA Request */
+typedef struct {
+    uint32_t                  type;     /* enum wc_CmacType */
+    uint32_t                  finalize; /* 1 if final, 0 if update */
+    whMessageCrypto_DmaBuffer state;    /* CMAC state buffer */
+    whMessageCrypto_DmaBuffer key;      /* Key buffer */
+    whMessageCrypto_DmaBuffer input;    /* Input buffer */
+    whMessageCrypto_DmaBuffer output;   /* Output buffer */
+} whMessageCrypto_CmacDmaRequest;
+
+/* CMAC DMA Response */
+typedef struct {
+    whMessageCrypto_DmaAddrStatus dmaAddrStatus;
+    uint32_t                      outSz;
+    uint8_t                       WH_PAD[4]; /* Pad to 8-byte alignment */
+} whMessageCrypto_CmacDmaResponse;
+
+/* CMAC DMA translation functions */
+int wh_MessageCrypto_TranslateCmacDmaRequest(
+    uint16_t magic, const whMessageCrypto_CmacDmaRequest* src,
+    whMessageCrypto_CmacDmaRequest* dest);
+
+int wh_MessageCrypto_TranslateCmacDmaResponse(
+    uint16_t magic, const whMessageCrypto_CmacDmaResponse* src,
+    whMessageCrypto_CmacDmaResponse* dest);
+
+/* ML-DSA DMA Key Generation Request */
+typedef struct {
+    whMessageCrypto_DmaBuffer key;
+    uint32_t                  level;
+    uint32_t                  flags;
+    uint32_t                  keyId;
+    uint32_t                  access; /* Key access permissions */
+    uint32_t                  labelSize;
+    uint8_t                   label[WH_NVM_LABEL_LEN];
+    uint8_t WH_PAD2[4]; /* Final padding for 8-byte alignment */
+} whMessageCrypto_MlDsaKeyGenDmaRequest;
+
+/* ML-DSA DMA Response */
+typedef struct {
+    whMessageCrypto_DmaAddrStatus dmaAddrStatus;
+    uint32_t                      keyId;   /* Assigned key ID */
+    uint32_t                      keySize; /* Actual size of generated key */
+} whMessageCrypto_MlDsaKeyGenDmaResponse;
+
+/* ML-DSA DMA Sign Request */
+typedef struct {
+    whMessageCrypto_DmaBuffer msg;       /* Message buffer */
+    whMessageCrypto_DmaBuffer sig;       /* Signature buffer */
+    uint32_t                  options;   /* Same options as non-DMA version */
+    uint32_t                  level;     /* ML-DSA security level */
+    uint32_t                  keyId;     /* Key ID to use for signing */
+    uint8_t                   WH_PAD[4]; /* Pad to 8-byte alignment */
+} whMessageCrypto_MlDsaSignDmaRequest;
+
+/* ML-DSA DMA Sign Response */
+typedef struct {
+    whMessageCrypto_DmaAddrStatus dmaAddrStatus;
+    uint32_t                      sigLen;    /* Actual signature length */
+    uint8_t                       WH_PAD[4]; /* Pad to 8-byte alignment */
+} whMessageCrypto_MlDsaSignDmaResponse;
+
+/* ML-DSA DMA Verify Request */
+typedef struct {
+    whMessageCrypto_DmaBuffer sig;       /* Signature buffer */
+    whMessageCrypto_DmaBuffer msg;       /* Message buffer */
+    uint32_t                  options;   /* Same options as non-DMA version */
+    uint32_t                  level;     /* ML-DSA security level */
+    uint32_t                  keyId;     /* Key ID to use for verification */
+    uint8_t                   WH_PAD[4]; /* Pad to 8-byte alignment */
+} whMessageCrypto_MlDsaVerifyDmaRequest;
+
+/* ML-DSA DMA Verify Response */
+typedef struct {
+    whMessageCrypto_DmaAddrStatus dmaAddrStatus;
+    int32_t                       verifyResult; /* Result of verification */
+    uint8_t                       WH_PAD[4];    /* Pad to 8-byte alignment */
+} whMessageCrypto_MlDsaVerifyDmaResponse;
+
+/* ML-DSA DMA translation functions */
+int wh_MessageCrypto_TranslateMlDsaKeyGenDmaRequest(
+    uint16_t magic, const whMessageCrypto_MlDsaKeyGenDmaRequest* src,
+    whMessageCrypto_MlDsaKeyGenDmaRequest* dest);
+
+int wh_MessageCrypto_TranslateMlDsaKeyGenDmaResponse(
+    uint16_t magic, const whMessageCrypto_MlDsaKeyGenDmaResponse* src,
+    whMessageCrypto_MlDsaKeyGenDmaResponse* dest);
+
+int wh_MessageCrypto_TranslateMlDsaSignDmaRequest(
+    uint16_t magic, const whMessageCrypto_MlDsaSignDmaRequest* src,
+    whMessageCrypto_MlDsaSignDmaRequest* dest);
+
+int wh_MessageCrypto_TranslateMlDsaSignDmaResponse(
+    uint16_t magic, const whMessageCrypto_MlDsaSignDmaResponse* src,
+    whMessageCrypto_MlDsaSignDmaResponse* dest);
+
+int wh_MessageCrypto_TranslateMlDsaVerifyDmaRequest(
+    uint16_t magic, const whMessageCrypto_MlDsaVerifyDmaRequest* src,
+    whMessageCrypto_MlDsaVerifyDmaRequest* dest);
+
+int wh_MessageCrypto_TranslateMlDsaVerifyDmaResponse(
+    uint16_t magic, const whMessageCrypto_MlDsaVerifyDmaResponse* src,
+    whMessageCrypto_MlDsaVerifyDmaResponse* dest);
+
+#endif /* !WOLFHSM_WH_MESSAGE_CRYPTO_H_ */

--- a/wolfhsm/wh_message_crypto.h
+++ b/wolfhsm/wh_message_crypto.h
@@ -32,7 +32,7 @@
 
 #include "wolfhsm/wh_common.h"
 #include "wolfhsm/wh_message.h"
-
+#include "wolfhsm/wh_utils.h"
 
 /*
  * Crypto Message Protocol Packet Structure
@@ -86,7 +86,7 @@ typedef struct {
 } whMessageCrypto_GenericResponseHeader;
 
 /* TODO fix, make this a generic static assert*/
-_Static_assert(
+WH_UTILS_STATIC_ASSERT(
     sizeof(whMessageCrypto_GenericRequestHeader) ==
         sizeof(whMessageCrypto_GenericResponseHeader),
     "GenericRequestHeader and GenericResponseHeader must be the same size");
@@ -165,7 +165,7 @@ typedef struct {
 } whMessageCrypto_AesCbcResponse;
 
 /* TODO fix, make this a generic static assert*/
-_Static_assert(sizeof(whMessageCrypto_AesCbcRequest) ==
+WH_UTILS_STATIC_ASSERT(sizeof(whMessageCrypto_AesCbcRequest) ==
                    sizeof(whMessageCrypto_AesCbcResponse),
                "AesCbcRequest and AesCbcResponse must be the same size");
 
@@ -210,7 +210,7 @@ typedef struct {
 } whMessageCrypto_AesGcmResponse;
 
 /* TODO fix, make this a generic static assert*/
-_Static_assert(sizeof(whMessageCrypto_AesGcmRequest) ==
+WH_UTILS_STATIC_ASSERT(sizeof(whMessageCrypto_AesGcmRequest) ==
                    sizeof(whMessageCrypto_AesGcmResponse),
                "AesGcmRequest and AesGcmResponse must be the same size");
 

--- a/wolfhsm/wh_message_keystore.h
+++ b/wolfhsm/wh_message_keystore.h
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2024 wolfSSL Inc.
+ *
+ * This file is part of wolfHSM.
+ *
+ * wolfHSM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfHSM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wolfHSM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * wolfhsm/wh_message_keystore.h
+ *
+ * Message structures and translation functions for keystore operations.
+ */
+
+#ifndef WOLFHSM_WH_MESSAGE_KEYSTORE_H_
+#define WOLFHSM_WH_MESSAGE_KEYSTORE_H_
+
+/* Pick up compile-time configuration */
+#include "wolfhsm/wh_settings.h"
+
+#include <stdint.h>
+
+#include "wolfhsm/wh_common.h"
+
+/* Key Cache Request */
+typedef struct {
+    uint32_t flags;
+    uint32_t sz;
+    uint32_t labelSz;
+    uint16_t id;
+    uint8_t  WH_PAD[2];
+    uint8_t  label[WH_NVM_LABEL_LEN];
+    /* Data follows:
+     * uint8_t in[sz]
+     */
+} whMessageKeystore_CacheRequest;
+
+/* Key Cache Response */
+typedef struct {
+    uint32_t rc;
+    uint16_t id;
+    uint8_t  WH_PAD[6];
+} whMessageKeystore_CacheResponse;
+
+/* Key Cache translation functions */
+int wh_MessageKeystore_TranslateCacheRequest(
+    uint16_t magic, const whMessageKeystore_CacheRequest* src,
+    whMessageKeystore_CacheRequest* dest);
+
+int wh_MessageKeystore_TranslateCacheResponse(
+    uint16_t magic, const whMessageKeystore_CacheResponse* src,
+    whMessageKeystore_CacheResponse* dest);
+
+/* Key Evict Request */
+typedef struct {
+    uint32_t id;
+    uint8_t  WH_PAD[4];
+} whMessageKeystore_EvictRequest;
+
+/* Key Evict Response */
+typedef struct {
+    uint32_t rc;
+    uint32_t ok;
+    uint8_t  WH_PAD[4];
+} whMessageKeystore_EvictResponse;
+
+/* Key Evict translation functions */
+int wh_MessageKeystore_TranslateEvictRequest(
+    uint16_t magic, const whMessageKeystore_EvictRequest* src,
+    whMessageKeystore_EvictRequest* dest);
+
+int wh_MessageKeystore_TranslateEvictResponse(
+    uint16_t magic, const whMessageKeystore_EvictResponse* src,
+    whMessageKeystore_EvictResponse* dest);
+
+/* Key Commit Request */
+typedef struct {
+    uint32_t id;
+    uint8_t  WH_PAD[4];
+} whMessageKeystore_CommitRequest;
+
+/* Key Commit Response */
+typedef struct {
+    uint32_t rc;
+    uint32_t ok;
+    uint8_t  WH_PAD[4];
+} whMessageKeystore_CommitResponse;
+
+/* Key Commit translation functions */
+int wh_MessageKeystore_TranslateCommitRequest(
+    uint16_t magic, const whMessageKeystore_CommitRequest* src,
+    whMessageKeystore_CommitRequest* dest);
+
+int wh_MessageKeystore_TranslateCommitResponse(
+    uint16_t magic, const whMessageKeystore_CommitResponse* src,
+    whMessageKeystore_CommitResponse* dest);
+
+/* Key Export Request */
+typedef struct {
+    uint32_t id;
+    uint8_t  WH_PAD[4];
+} whMessageKeystore_ExportRequest;
+
+/* Key Export Response */
+typedef struct {
+    uint32_t rc;
+    uint32_t len;
+    uint8_t  label[WH_NVM_LABEL_LEN];
+    uint8_t  WH_PAD[4];
+    /* Data follows:
+     * uint8_t out[len]
+     */
+} whMessageKeystore_ExportResponse;
+
+/* Key Export translation functions */
+int wh_MessageKeystore_TranslateExportRequest(
+    uint16_t magic, const whMessageKeystore_ExportRequest* src,
+    whMessageKeystore_ExportRequest* dest);
+
+int wh_MessageKeystore_TranslateExportResponse(
+    uint16_t magic, const whMessageKeystore_ExportResponse* src,
+    whMessageKeystore_ExportResponse* dest);
+
+/* Key Erase Request */
+typedef struct {
+    uint32_t id;
+    uint8_t  WH_PAD[4];
+} whMessageKeystore_EraseRequest;
+
+/* Key Erase Response */
+typedef struct {
+    uint32_t rc;
+    uint32_t ok;
+    uint8_t  WH_PAD[4];
+} whMessageKeystore_EraseResponse;
+
+/* Key Erase translation functions */
+int wh_MessageKeystore_TranslateEraseRequest(
+    uint16_t magic, const whMessageKeystore_EraseRequest* src,
+    whMessageKeystore_EraseRequest* dest);
+
+int wh_MessageKeystore_TranslateEraseResponse(
+    uint16_t magic, const whMessageKeystore_EraseResponse* src,
+    whMessageKeystore_EraseResponse* dest);
+
+/*
+ * DMA-based keystore operations
+ */
+
+/* DMA buffer structure */
+typedef struct {
+    uint64_t addr;
+    uint64_t sz;
+} whMessageKeystore_DmaBuffer;
+
+/* DMA address status structure */
+typedef struct {
+    /* If packet->rc == WH_ERROR_ACCESS, this field will contain the offending
+     * address/size pair. Invalid otherwise. */
+    whMessageKeystore_DmaBuffer badAddr;
+} whMessageKeystore_DmaAddrStatus;
+
+/* Key Cache DMA Request */
+typedef struct {
+    whMessageKeystore_DmaBuffer
+             key; /* Client memory buffer containing key data */
+    uint32_t flags;
+    uint32_t labelSz;
+    uint16_t id;
+    uint8_t  label[WH_NVM_LABEL_LEN];
+    uint8_t  WH_PAD[6]; /* Pad to 8-byte alignment */
+} whMessageKeystore_CacheDmaRequest;
+
+/* Key Cache DMA Response */
+typedef struct {
+    whMessageKeystore_DmaAddrStatus dmaAddrStatus;
+    uint32_t                        rc;
+    uint16_t                        id;
+    uint8_t                         WH_PAD[2]; /* Pad to 8-byte alignment */
+} whMessageKeystore_CacheDmaResponse;
+
+/* Key Cache DMA translation functions */
+int wh_MessageKeystore_TranslateCacheDmaRequest(
+    uint16_t magic, const whMessageKeystore_CacheDmaRequest* src,
+    whMessageKeystore_CacheDmaRequest* dest);
+
+int wh_MessageKeystore_TranslateCacheDmaResponse(
+    uint16_t magic, const whMessageKeystore_CacheDmaResponse* src,
+    whMessageKeystore_CacheDmaResponse* dest);
+
+/* Key Export DMA Request */
+typedef struct {
+    whMessageKeystore_DmaBuffer
+             key; /* Client memory buffer to receive key data */
+    uint32_t id;
+    uint8_t  WH_PAD[4]; /* Pad to 8-byte alignment */
+} whMessageKeystore_ExportDmaRequest;
+
+/* Key Export DMA Response */
+typedef struct {
+    whMessageKeystore_DmaAddrStatus dmaAddrStatus;
+    uint32_t                        rc;
+    uint32_t                        len;
+    uint8_t                         label[WH_NVM_LABEL_LEN];
+} whMessageKeystore_ExportDmaResponse;
+
+/* Key Export DMA translation functions */
+int wh_MessageKeystore_TranslateExportDmaRequest(
+    uint16_t magic, const whMessageKeystore_ExportDmaRequest* src,
+    whMessageKeystore_ExportDmaRequest* dest);
+
+int wh_MessageKeystore_TranslateExportDmaResponse(
+    uint16_t magic, const whMessageKeystore_ExportDmaResponse* src,
+    whMessageKeystore_ExportDmaResponse* dest);
+
+#endif /* !WOLFHSM_WH_MESSAGE_KEYSTORE_H_ */

--- a/wolfhsm/wh_message_keystore.h
+++ b/wolfhsm/wh_message_keystore.h
@@ -63,8 +63,8 @@ int wh_MessageKeystore_TranslateCacheResponse(
 
 /* Key Evict Request */
 typedef struct {
-    uint32_t id;
-    uint8_t  WH_PAD[4];
+    uint16_t id;
+    uint8_t  WH_PAD[6];
 } whMessageKeystore_EvictRequest;
 
 /* Key Evict Response */
@@ -85,8 +85,8 @@ int wh_MessageKeystore_TranslateEvictResponse(
 
 /* Key Commit Request */
 typedef struct {
-    uint32_t id;
-    uint8_t  WH_PAD[4];
+    uint16_t id;
+    uint8_t  WH_PAD[6];
 } whMessageKeystore_CommitRequest;
 
 /* Key Commit Response */
@@ -107,8 +107,8 @@ int wh_MessageKeystore_TranslateCommitResponse(
 
 /* Key Export Request */
 typedef struct {
-    uint32_t id;
-    uint8_t  WH_PAD[4];
+    uint16_t id;
+    uint8_t  WH_PAD[6];
 } whMessageKeystore_ExportRequest;
 
 /* Key Export Response */
@@ -133,8 +133,8 @@ int wh_MessageKeystore_TranslateExportResponse(
 
 /* Key Erase Request */
 typedef struct {
-    uint32_t id;
-    uint8_t  WH_PAD[4];
+    uint16_t id;
+    uint8_t  WH_PAD[6];
 } whMessageKeystore_EraseRequest;
 
 /* Key Erase Response */
@@ -202,8 +202,8 @@ int wh_MessageKeystore_TranslateCacheDmaResponse(
 typedef struct {
     whMessageKeystore_DmaBuffer
              key; /* Client memory buffer to receive key data */
-    uint32_t id;
-    uint8_t  WH_PAD[4]; /* Pad to 8-byte alignment */
+    uint16_t id;
+    uint8_t  WH_PAD[6]; /* Pad to 8-byte alignment */
 } whMessageKeystore_ExportDmaRequest;
 
 /* Key Export DMA Response */

--- a/wolfhsm/wh_message_she.h
+++ b/wolfhsm/wh_message_she.h
@@ -1,0 +1,394 @@
+/*
+ * Copyright (C) 2024 wolfSSL Inc.
+ *
+ * This file is part of wolfHSM.
+ *
+ * wolfHSM is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfHSM is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with wolfHSM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * wolfhsm/wh_message_she.h
+ *
+ * Message structures and translation functions for SHE operations.
+ */
+
+#ifndef WOLFHSM_WH_MESSAGE_SHE_H_
+#define WOLFHSM_WH_MESSAGE_SHE_H_
+
+/* Pick up compile-time configuration */
+#include "wolfhsm/wh_settings.h"
+
+#ifdef WOLFHSM_CFG_SHE_EXTENSION
+
+#include <stdint.h>
+
+#include "wolfhsm/wh_common.h"
+#include "wolfhsm/wh_she_common.h"
+
+/* Set UID Request */
+typedef struct {
+    uint8_t uid[WH_SHE_UID_SZ];
+    uint8_t WH_PAD[1];
+} whMessageShe_SetUidRequest;
+
+/* Set UID Response */
+typedef struct {
+    uint32_t rc;
+    uint8_t  WH_PAD[4];
+} whMessageShe_SetUidResponse;
+
+/* Set UID translation function */
+int wh_MessageShe_TranslateSetUidRequest(uint16_t magic,
+                                         const whMessageShe_SetUidRequest* src,
+                                         whMessageShe_SetUidRequest* dest);
+
+int wh_MessageShe_TranslateSetUidResponse(
+    uint16_t magic, const whMessageShe_SetUidResponse* src,
+    whMessageShe_SetUidResponse* dest);
+
+/* Secure Boot Init Request */
+typedef struct {
+    uint32_t sz;
+    uint8_t  WH_PAD[4];
+} whMessageShe_SecureBootInitRequest;
+
+/* Secure Boot Init Response */
+typedef struct {
+    uint32_t rc;
+    uint32_t status;
+} whMessageShe_SecureBootInitResponse;
+
+/* Secure Boot Init translation functions */
+int wh_MessageShe_TranslateSecureBootInitRequest(
+    uint16_t magic, const whMessageShe_SecureBootInitRequest* src,
+    whMessageShe_SecureBootInitRequest* dest);
+
+int wh_MessageShe_TranslateSecureBootInitResponse(
+    uint16_t magic, const whMessageShe_SecureBootInitResponse* src,
+    whMessageShe_SecureBootInitResponse* dest);
+
+/* Secure Boot Update Request */
+typedef struct {
+    uint32_t sz;
+    uint8_t  WH_PAD[4];
+    /* Data follows:
+     * uint8_t in[sz]
+     */
+} whMessageShe_SecureBootUpdateRequest;
+
+/* Secure Boot Update Response */
+typedef struct {
+    uint32_t rc;
+    uint32_t status;
+} whMessageShe_SecureBootUpdateResponse;
+
+/* Secure Boot Update translation functions */
+int wh_MessageShe_TranslateSecureBootUpdateRequest(
+    uint16_t magic, const whMessageShe_SecureBootUpdateRequest* src,
+    whMessageShe_SecureBootUpdateRequest* dest);
+
+int wh_MessageShe_TranslateSecureBootUpdateResponse(
+    uint16_t magic, const whMessageShe_SecureBootUpdateResponse* src,
+    whMessageShe_SecureBootUpdateResponse* dest);
+
+/* Secure Boot Finish Response */
+typedef struct {
+    uint32_t rc;
+    uint32_t status;
+} whMessageShe_SecureBootFinishResponse;
+
+/* Secure Boot Finish translation function */
+int wh_MessageShe_TranslateSecureBootFinishResponse(
+    uint16_t magic, const whMessageShe_SecureBootFinishResponse* src,
+    whMessageShe_SecureBootFinishResponse* dest);
+
+/* Get Status Response */
+typedef struct {
+    uint32_t rc;
+    uint8_t  sreg;
+    uint8_t  WH_PAD[7];
+} whMessageShe_GetStatusResponse;
+
+/* Get Status translation function */
+int wh_MessageShe_TranslateGetStatusResponse(
+    uint16_t magic, const whMessageShe_GetStatusResponse* src,
+    whMessageShe_GetStatusResponse* dest);
+
+/* Load Key Request */
+typedef struct {
+    uint8_t messageOne[WH_SHE_M1_SZ];
+    uint8_t messageTwo[WH_SHE_M2_SZ];
+    uint8_t messageThree[WH_SHE_M3_SZ];
+} whMessageShe_LoadKeyRequest;
+
+/* Load Key Response */
+typedef struct {
+    uint32_t rc;
+    uint8_t  messageFour[WH_SHE_M4_SZ];
+    uint8_t  messageFive[WH_SHE_M5_SZ];
+} whMessageShe_LoadKeyResponse;
+
+/* Load Key translation functions */
+int wh_MessageShe_TranslateLoadKeyRequest(
+    uint16_t magic, const whMessageShe_LoadKeyRequest* src,
+    whMessageShe_LoadKeyRequest* dest);
+
+int wh_MessageShe_TranslateLoadKeyResponse(
+    uint16_t magic, const whMessageShe_LoadKeyResponse* src,
+    whMessageShe_LoadKeyResponse* dest);
+
+/* Load Plain Key Request */
+typedef struct {
+    uint8_t key[WH_SHE_KEY_SZ];
+} whMessageShe_LoadPlainKeyRequest;
+
+/* Load Plain Key Response */
+typedef struct {
+    uint32_t rc;
+} whMessageShe_LoadPlainKeyResponse;
+
+/* Load Plain Key translation function */
+int wh_MessageShe_TranslateLoadPlainKeyRequest(
+    uint16_t magic, const whMessageShe_LoadPlainKeyRequest* src,
+    whMessageShe_LoadPlainKeyRequest* dest);
+
+int wh_MessageShe_TranslateLoadPlainKeyResponse(
+    uint16_t magic, const whMessageShe_LoadPlainKeyResponse* src,
+    whMessageShe_LoadPlainKeyResponse* dest);
+
+/* Export RAM Key Response */
+typedef struct {
+    uint32_t rc;
+    uint8_t  messageOne[WH_SHE_M1_SZ];
+    uint8_t  messageTwo[WH_SHE_M2_SZ];
+    uint8_t  messageThree[WH_SHE_M3_SZ];
+    uint8_t  messageFour[WH_SHE_M4_SZ];
+    uint8_t  messageFive[WH_SHE_M5_SZ];
+} whMessageShe_ExportRamKeyResponse;
+
+/* Export RAM Key translation function */
+int wh_MessageShe_TranslateExportRamKeyResponse(
+    uint16_t magic, const whMessageShe_ExportRamKeyResponse* src,
+    whMessageShe_ExportRamKeyResponse* dest);
+
+/* Init RNG Response */
+typedef struct {
+    uint32_t rc;
+    uint32_t status;
+} whMessageShe_InitRngResponse;
+
+/* Init RNG translation function */
+int wh_MessageShe_TranslateInitRngResponse(
+    uint16_t magic, const whMessageShe_InitRngResponse* src,
+    whMessageShe_InitRngResponse* dest);
+
+/* RND Response */
+typedef struct {
+    uint32_t rc;
+    uint8_t  rnd[WH_SHE_KEY_SZ];
+} whMessageShe_RndResponse;
+
+/* RND translation function */
+int wh_MessageShe_TranslateRndResponse(uint16_t                        magic,
+                                       const whMessageShe_RndResponse* src,
+                                       whMessageShe_RndResponse*       dest);
+
+/* Extend Seed Request */
+typedef struct {
+    uint8_t entropy[WH_SHE_KEY_SZ];
+} whMessageShe_ExtendSeedRequest;
+
+/* Extend Seed Response */
+typedef struct {
+    uint32_t rc;
+    uint32_t status;
+} whMessageShe_ExtendSeedResponse;
+
+/* Extend Seed translation functions */
+int wh_MessageShe_TranslateExtendSeedRequest(
+    uint16_t magic, const whMessageShe_ExtendSeedRequest* src,
+    whMessageShe_ExtendSeedRequest* dest);
+
+int wh_MessageShe_TranslateExtendSeedResponse(
+    uint16_t magic, const whMessageShe_ExtendSeedResponse* src,
+    whMessageShe_ExtendSeedResponse* dest);
+
+/* Encrypt ECB Request */
+typedef struct {
+    uint32_t sz;
+    uint8_t  keyId;
+    uint8_t  WH_PAD[3];
+    /* Data follows:
+     * uint8_t in[sz]
+     */
+} whMessageShe_EncEcbRequest;
+
+/* Encrypt ECB Response */
+typedef struct {
+    uint32_t rc;
+    uint32_t sz;
+    /* Data follows:
+     * uint8_t out[sz]
+     */
+} whMessageShe_EncEcbResponse;
+
+/* Encrypt ECB translation functions */
+int wh_MessageShe_TranslateEncEcbRequest(uint16_t magic,
+                                         const whMessageShe_EncEcbRequest* src,
+                                         whMessageShe_EncEcbRequest* dest);
+
+int wh_MessageShe_TranslateEncEcbResponse(
+    uint16_t magic, const whMessageShe_EncEcbResponse* src,
+    whMessageShe_EncEcbResponse* dest);
+
+/* Encrypt CBC Request */
+typedef struct {
+    uint32_t sz;
+    uint8_t  keyId;
+    uint8_t  WH_PAD[3];
+    uint8_t  iv[WH_SHE_KEY_SZ];
+    /* Data follows:
+     * uint8_t in[sz]
+     */
+} whMessageShe_EncCbcRequest;
+
+/* Encrypt CBC Response */
+typedef struct {
+    uint32_t rc;
+    uint32_t sz;
+    /* Data follows:
+     * uint8_t out[sz]
+     */
+} whMessageShe_EncCbcResponse;
+
+/* Encrypt CBC translation functions */
+int wh_MessageShe_TranslateEncCbcRequest(uint16_t magic,
+                                         const whMessageShe_EncCbcRequest* src,
+                                         whMessageShe_EncCbcRequest* dest);
+
+int wh_MessageShe_TranslateEncCbcResponse(
+    uint16_t magic, const whMessageShe_EncCbcResponse* src,
+    whMessageShe_EncCbcResponse* dest);
+
+/* Decrypt ECB Request */
+typedef struct {
+    uint32_t sz;
+    uint8_t  keyId;
+    uint8_t  WH_PAD[3];
+    /* Data follows:
+     * uint8_t in[sz]
+     */
+} whMessageShe_DecEcbRequest;
+
+/* Decrypt ECB Response */
+typedef struct {
+    uint32_t rc;
+    uint32_t sz;
+    /* Data follows:
+     * uint8_t out[sz]
+     */
+} whMessageShe_DecEcbResponse;
+
+/* Decrypt ECB translation functions */
+int wh_MessageShe_TranslateDecEcbRequest(uint16_t magic,
+                                         const whMessageShe_DecEcbRequest* src,
+                                         whMessageShe_DecEcbRequest* dest);
+
+int wh_MessageShe_TranslateDecEcbResponse(
+    uint16_t magic, const whMessageShe_DecEcbResponse* src,
+    whMessageShe_DecEcbResponse* dest);
+
+/* Decrypt CBC Request */
+typedef struct {
+    uint32_t sz;
+    uint8_t  keyId;
+    uint8_t  WH_PAD[3];
+    uint8_t  iv[WH_SHE_KEY_SZ];
+    /* Data follows:
+     * uint8_t in[sz]
+     */
+} whMessageShe_DecCbcRequest;
+
+/* Decrypt CBC Response */
+typedef struct {
+    uint32_t rc;
+    uint32_t sz;
+    /* Data follows:
+     * uint8_t out[sz]
+     */
+} whMessageShe_DecCbcResponse;
+
+/* Decrypt CBC translation functions */
+int wh_MessageShe_TranslateDecCbcRequest(uint16_t magic,
+                                         const whMessageShe_DecCbcRequest* src,
+                                         whMessageShe_DecCbcRequest* dest);
+
+int wh_MessageShe_TranslateDecCbcResponse(
+    uint16_t magic, const whMessageShe_DecCbcResponse* src,
+    whMessageShe_DecCbcResponse* dest);
+
+/* Generate MAC Request */
+typedef struct {
+    uint32_t keyId;
+    uint32_t sz;
+    /* Data follows:
+     * uint8_t in[sz]
+     */
+} whMessageShe_GenMacRequest;
+
+/* Generate MAC Response */
+typedef struct {
+    uint32_t rc;
+    uint8_t  mac[WH_SHE_KEY_SZ];
+} whMessageShe_GenMacResponse;
+
+/* Generate MAC translation functions */
+int wh_MessageShe_TranslateGenMacRequest(uint16_t magic,
+                                         const whMessageShe_GenMacRequest* src,
+                                         whMessageShe_GenMacRequest* dest);
+
+int wh_MessageShe_TranslateGenMacResponse(
+    uint16_t magic, const whMessageShe_GenMacResponse* src,
+    whMessageShe_GenMacResponse* dest);
+
+/* Verify MAC Request */
+typedef struct {
+    uint32_t keyId;
+    uint32_t messageLen;
+    uint32_t macLen;
+    uint8_t  WH_PAD[4];
+    /* Data follows:
+     * uint8_t message[messageLen]
+     * uint8_t mac[macLen]
+     */
+} whMessageShe_VerifyMacRequest;
+
+/* Verify MAC Response */
+typedef struct {
+    uint32_t rc;
+    uint8_t  status;
+    uint8_t  WH_PAD[7];
+} whMessageShe_VerifyMacResponse;
+
+/* Verify MAC translation functions */
+int wh_MessageShe_TranslateVerifyMacRequest(
+    uint16_t magic, const whMessageShe_VerifyMacRequest* src,
+    whMessageShe_VerifyMacRequest* dest);
+
+int wh_MessageShe_TranslateVerifyMacResponse(
+    uint16_t magic, const whMessageShe_VerifyMacResponse* src,
+    whMessageShe_VerifyMacResponse* dest);
+
+#endif /* WOLFHSM_CFG_SHE_EXTENSION */
+
+#endif /* !WOLFHSM_WH_MESSAGE_SHE_H_ */

--- a/wolfhsm/wh_server_counter.h
+++ b/wolfhsm/wh_server_counter.h
@@ -31,7 +31,9 @@
 
 #include "wolfhsm/wh_server.h"
 
-int wh_Server_HandleCounter(whServerContext* server, uint16_t action,
-    uint8_t* data, uint16_t* size);
+int wh_Server_HandleCounter(whServerContext* server, uint16_t magic,
+                            uint16_t action, uint16_t req_size,
+                            const void* req_packet, uint16_t* out_resp_size,
+                            void* resp_packet);
 
 #endif /* !WOLFHSM_WH_SERVER_COUNTER_H_ */

--- a/wolfhsm/wh_server_crypto.h
+++ b/wolfhsm/wh_server_crypto.h
@@ -42,11 +42,16 @@
 
 #include "wolfhsm/wh_server.h"
 
-int wh_Server_HandleCryptoRequest(whServerContext* server,
-    uint16_t action, uint8_t* data, uint16_t* size, uint16_t seq);
+int wh_Server_HandleCryptoRequest(whServerContext* ctx, uint16_t magic,
+                                  uint16_t action, uint16_t seq,
+                                  uint16_t req_size, const void* req_packet,
+                                  uint16_t* out_resp_size, void* resp_packet);
 
-int wh_Server_HandleCryptoDmaRequest(whServerContext* server,
-    uint16_t action, uint8_t* data, uint16_t* size, uint16_t seq);
+int wh_Server_HandleCryptoDmaRequest(whServerContext* ctx, uint16_t magic,
+                                     uint16_t action, uint16_t seq,
+                                     uint16_t req_size, const void* req_packet,
+                                     uint16_t* out_resp_size,
+                                     void*     resp_packet);
 
 #ifndef NO_RSA
 

--- a/wolfhsm/wh_server_keystore.h
+++ b/wolfhsm/wh_server_keystore.h
@@ -31,21 +31,159 @@
 #include "wolfhsm/wh_common.h"
 #include "wolfhsm/wh_server.h"
 
-/* Find a new unique id using the top bits of inout_id for user and type */
-int hsmGetUniqueId(whServerContext* server, whNvmId* inout_id);
-int hsmCacheFindSlotAndZero(whServerContext* server, uint16_t keySz,
-    uint8_t** outBuf, whNvmMetadata** outMeta);
-int hsmCacheKey(whServerContext* server, whNvmMetadata* meta, uint8_t* in);
-int hsmFreshenKey(whServerContext* server, whKeyId keyId, uint8_t** outBuf,
-    whNvmMetadata** outMeta);
-int hsmReadKey(whServerContext* server, whKeyId keyId, whNvmMetadata* outMeta,
-    uint8_t* out, uint32_t* outSz);
-int hsmEvictKey(whServerContext* server, uint16_t keyId);
-int hsmCommitKey(whServerContext* server, uint16_t keyId);
-int hsmEraseKey(whServerContext* server, whNvmId keyId);
+/**
+ * @brief Find a new unique key ID using the top bits of inout_id for user and
+ * type
+ *
+ * Searches for an available key ID by checking against cache keys and NVM
+ * storage. The client_id and type should be set by caller on inout_id.
+ *
+ * @param[in]     server    Server context
+ * @param[in,out] inout_id  Input: key ID with type and user set; Output: unique
+ * key ID
+ * @return 0 on success, error code on failure
+ */
+int wh_Server_KeystoreGetUniqueId(whServerContext* server, whNvmId* inout_id);
+
+/**
+ * @brief Find an available cache slot for the specified key size
+ *
+ * Searches for an empty slot or a slot with a committed key that can be
+ * evicted. Returns the slot's buffer (zeroed) and metadata.
+ *
+ * @param[in]  server   Server context
+ * @param[in]  keySz    Size of the key in bytes
+ * @param[out] outBuf   Pointer to the cache buffer
+ * @param[out] outMeta  Pointer to the metadata structure
+ * @return 0 on success, error code on failure
+ */
+int wh_Server_KeystoreGetCacheSlot(whServerContext* server, uint16_t keySz,
+                                   uint8_t** outBuf, whNvmMetadata** outMeta);
+
+/**
+ * @brief Cache a key in server memory
+ *
+ * Stores a key in the appropriate cache (regular or big) based on its size.
+ * Checks if the key is already committed to NVM.
+ *
+ * @param[in] server  Server context
+ * @param[in] meta    Key metadata
+ * @param[in] in      Key data buffer
+ * @return 0 on success, error code on failure
+ */
+int wh_Server_KeystoreCacheKey(whServerContext* server, whNvmMetadata* meta,
+                               uint8_t* in);
+
+/**
+ * @brief Ensure a key is in cache, loading it from NVM if necessary
+ *
+ * Tries to put the specified key into cache if it isn't already there.
+ * Returns pointers to the metadata and cached data.
+ *
+ * @param[in]  server   Server context
+ * @param[in]  keyId    Key ID to freshen
+ * @param[out] outBuf   Pointer to the cached key buffer
+ * @param[out] outMeta  Pointer to the key metadata
+ * @return 0 on success, error code on failure
+ */
+int wh_Server_KeystoreFreshenKey(whServerContext* server, whKeyId keyId,
+                                 uint8_t** outBuf, whNvmMetadata** outMeta);
+
+/**
+ * @brief Read a key from cache or NVM
+ *
+ * Retrieves a key from cache or NVM storage and returns its metadata and data.
+ *
+ * @param[in]     server   Server context
+ * @param[in]     keyId    Key ID to read
+ * @param[out]    outMeta  Key metadata (can be NULL)
+ * @param[out]    out      Buffer to store key data (can be NULL)
+ * @param[in,out] outSz    Input: size of out buffer; Output: actual key size
+ * @return 0 on success, error code on failure
+ */
+int wh_Server_KeystoreReadKey(whServerContext* server, whKeyId keyId,
+                              whNvmMetadata* outMeta, uint8_t* out,
+                              uint32_t* outSz);
+
+/**
+ * @brief Remove a key from cache
+ *
+ * Marks the key as erased in the cache if present.
+ *
+ * @param[in] server  Server context
+ * @param[in] keyId   Key ID to evict
+ * @return 0 on success, error code on failure
+ */
+int wh_Server_KeystoreEvictKey(whServerContext* server, whNvmId keyId);
+
+/**
+ * @brief Commit a cached key to NVM storage
+ *
+ * Writes a key from cache to non-volatile memory and marks it as committed.
+ *
+ * @param[in] server  Server context
+ * @param[in] keyId   Key ID to commit
+ * @return 0 on success, error code on failure
+ */
+int wh_Server_KeystoreCommitKey(whServerContext* server, whNvmId keyId);
+
+/**
+ * @brief Erase a key from both cache and NVM
+ *
+ * Removes the key from cache if present and destroys it in NVM.
+ *
+ * @param[in] server  Server context
+ * @param[in] keyId   Key ID to erase
+ * @return 0 on success, error code on failure
+ */
+int wh_Server_KeystoreEraseKey(whServerContext* server, whNvmId keyId);
+
+/**
+ * @brief Handle key management requests from clients
+ *
+ * Processes various key operations including cache, export, evict, commit, and
+ * erase. Supports DMA operations if configured.
+ *
+ * @param[in]     server         Server context
+ * @param[in]     magic          Message magic number
+ * @param[in]     action         Key operation to perform
+ * @param[in]     req_size       Size of request packet
+ * @param[in]     req_packet     Request packet data
+ * @param[out]    out_resp_size  Size of response packet
+ * @param[out]    resp_packet    Response packet data
+ * @return 0 on success, error code on failure
+ */
 int wh_Server_HandleKeyRequest(whServerContext* server, uint16_t magic,
                                uint16_t action, uint16_t req_size,
                                const void* req_packet, uint16_t* out_resp_size,
                                void* resp_packet);
 
+/**
+ * @brief Cache a key using DMA transfer
+ *
+ * Allocates a cache slot and copies key data from client memory using DMA.
+ *
+ * @param[in] server   Server context
+ * @param[in] meta     Key metadata
+ * @param[in] keyAddr  Client memory address containing key data
+ * @return 0 on success, error code on failure
+ */
+int wh_Server_KeystoreCacheKeyDma(whServerContext* server, whNvmMetadata* meta,
+                                  uint64_t keyAddr);
+
+/**
+ * @brief Export a key using DMA transfer
+ *
+ * Copies key data from server cache to client memory using DMA.
+ *
+ * @param[in]  server   Server context
+ * @param[in]  keyId    Key ID to export
+ * @param[in]  keyAddr  Client memory address to receive key data
+ * @param[in]  keySz    Size of client memory buffer
+ * @param[out] outMeta  Buffer to receive key metadata
+ * @return 0 on success, error code on failure
+ */
+int wh_Server_KeystoreExportKeyDma(whServerContext* server, whKeyId keyId,
+                                   uint64_t keyAddr, uint64_t keySz,
+                                   whNvmMetadata* outMeta);
 #endif /* !WOLFHSM_WH_SERVER_KEYSTORE_H_ */

--- a/wolfhsm/wh_server_keystore.h
+++ b/wolfhsm/wh_server_keystore.h
@@ -44,6 +44,8 @@ int hsmEvictKey(whServerContext* server, uint16_t keyId);
 int hsmCommitKey(whServerContext* server, uint16_t keyId);
 int hsmEraseKey(whServerContext* server, whNvmId keyId);
 int wh_Server_HandleKeyRequest(whServerContext* server, uint16_t magic,
-    uint16_t action, uint16_t seq, uint8_t* data, uint16_t* size);
+                               uint16_t action, uint16_t req_size,
+                               const void* req_packet, uint16_t* out_resp_size,
+                               void* resp_packet);
 
 #endif /* !WOLFHSM_WH_SERVER_KEYSTORE_H_ */

--- a/wolfhsm/wh_server_she.h
+++ b/wolfhsm/wh_server_she.h
@@ -63,9 +63,10 @@ typedef struct {
     uint8_t  uid[WH_SHE_UID_SZ];
 } whServerSheContext;
 
-int wh_Server_HandleSheRequest(whServerContext* server,
-    uint16_t action, uint8_t* data, uint16_t* size);
-
+int wh_Server_HandleSheRequest(whServerContext* server, uint16_t magic,
+                               uint16_t action, uint16_t req_size,
+                               const void* req_packet, uint16_t* out_resp_size,
+                               void* resp_packet);
 #endif /* WOLFHSM_CFG_SHE_EXTENSION */
 
 #endif /* !WOLFHSM_WH_SERVER_SHE_H */

--- a/wolfhsm/wh_utils.h
+++ b/wolfhsm/wh_utils.h
@@ -58,7 +58,7 @@ void* wh_Utils_memcpy_flush(void* dst, const void* src , size_t n);
 
 
 #if defined(DEBUG_CRYPTOCB) || defined(DEBUG_CRYPTOCB_VERBOSE)
-void wh_Utils_Hexdump(const char* initial, uint8_t* ptr, size_t size);
+void wh_Utils_Hexdump(const char* initial, const uint8_t* ptr, size_t size);
 #endif
 
 #endif /* !WOLFHSM_WH_UTILS_H_ */

--- a/wolfhsm/wh_utils.h
+++ b/wolfhsm/wh_utils.h
@@ -59,7 +59,6 @@
     typedef char WH_UTILS_JOIN(staticAssertAtLine, __LINE__)[(expr) ? 1 : -1]
 #endif
 
-
 /** Byteswap functions */
 uint16_t wh_Utils_Swap16(uint16_t val);
 uint32_t wh_Utils_Swap32(uint32_t val);

--- a/wolfhsm/wh_utils.h
+++ b/wolfhsm/wh_utils.h
@@ -30,6 +30,36 @@
 #include <stdint.h>
 #include <stddef.h> /* For size_t */
 
+
+/* Macro magic: join two tokens together */
+#define WH_UTILS_JOIN(a, b) WH_UTILS_DO_JOIN(a, b)
+#define WH_UTILS_DO_JOIN(a, b) a##b
+
+/* Portable compile-time assertion macro across different compilers and
+ * language standards. When no static assert support is detected, it compiles
+ * to nothing rather than attempting error-prone workarounds.
+ *
+ * Usage:
+ *   WH_UTILS_STATIC_ASSERT(expression, message)
+ * Where:
+ *   expression - Compile-time constant expression to check (must be true)
+ *   message - String literal or identifier describing the assertion
+ */
+#if defined(__cplusplus) && (__cplusplus >= 201103L)
+/* C++11 or later */
+#define WH_UTILS_STATIC_ASSERT(expr, msg) static_assert(expr, msg)
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
+/* C11 or later */
+#define WH_UTILS_STATIC_ASSERT(expr, msg) _Static_assert(expr, msg)
+#else
+/* C90/C99 fallback: create a typedef with a negative array size on failure.
+ * Works at file scope or inside functions, but cannot be used in control flow
+ * blocks. 'msg' is ignored in this fallback. */
+#define WH_UTILS_STATIC_ASSERT(expr, msg) \
+    typedef char WH_UTILS_JOIN(staticAssertAtLine, __LINE__)[(expr) ? 1 : -1]
+#endif
+
+
 /** Byteswap functions */
 uint16_t wh_Utils_Swap16(uint16_t val);
 uint32_t wh_Utils_Swap32(uint32_t val);


### PR DESCRIPTION
Removes use of whPacket union for messaging in the crypto, keystore, counter, and SHE protocol layers, and replaces with standardized messaging structures with endianness translation functions.

Future work:
In creating this PR, I'm realizing we need to build in a generic "server return code" field into the comm layer that is propagated to the client, irrespective of the nature of the message structs. Similar to how "group" and "action" are built into the comm layer, we should do the same for a server return code. This would allow the server to generically inform the client of an error in the response without needing to know exactly which response structure it needs to serialize into. Right now there has to be a return code field baked into EVERY message struct, and it is not possible to inform the client of a server failure without picking the appropriate response structure and serializing it, which could be one of MANY structs depending on the specific protocol ("group/action"). This would also mean the client can always length-check responses for safety once it knows there is no server error and the received data is of the expected type (vs just "error"). 

For inspiration as to why this is necessary, see the two gross hacks I had to implement: 1) [the "subprotocol" headers added to the crypto layer messaging](https://github.com/bigbrett/wolfHSM/blob/2c5f19460cbc20fe9a0a38a26073fa137211a1d6/wolfhsm/wh_message_crypto.h#L37-L65), and 2) [this absolutely CURSED function](https://github.com/bigbrett/wolfHSM/blob/2fb9f8dfaef09f1328aaf106b1bc4a4a81c6bdc3/src/wh_server_she.c#L1358) in the SHE layer). For the keystore and counter layers we were able to get away with a simple return code in every message struct, as there weren't any needs for "early" returns. 

I'm sure there might be more clever or at least more unified ways to have implemented this given the way we currently do it, but it would be better to bake this into the comm layer itself.