### PR TITLE
Fix flashunit program

### DIFF
--- a/port/posix/posix_flash_file.c
+++ b/port/posix/posix_flash_file.c
@@ -78,7 +78,8 @@ int posixFlashFile_Init(   void* c,
     }
 
     /* Open the storage backend */
-    rc = open(config->filename, O_RDWR|O_CREAT|O_SYNC, S_IRUSR | S_IWUSR);
+    /* III Recommend to add O_SYNC if realtime data consistency is a concern */
+    rc = open(config->filename, O_RDWR|O_CREAT, S_IRUSR | S_IWUSR);
     if (rc >= 0) {
         /* File is open, setup context */
         memset(context, 0, sizeof(*context));

--- a/src/wh_flash_unit.c
+++ b/src/wh_flash_unit.c
@@ -217,8 +217,10 @@ int wh_FlashUnit_ProgramBytes(const whFlashCb* cb, void* context,
     }
 
     /* Aligned programming */
-    ret = wh_FlashUnit_Program(cb, context,
+    if(count) {
+        ret = wh_FlashUnit_Program(cb, context,
             offset, count, (whFlashUnit*)data);
+    }
 
     /* Final partial unit */
     if ((ret == 0) && (rem != 0)) {

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -453,8 +453,8 @@ int wh_Server_CacheImportCurve25519Key(whServerContext* server,
     whNvmMetadata* cacheMeta;
     int            ret;
 
-    uint8_t der_buf[MAX_DER_SIZE];
     /* CURVE25519_MAX_KEY_TO_DER_SZ should be 82 */
+    uint8_t der_buf[CURVE25519_MAX_KEY_TO_DER_SZ];
     uint16_t       keySz = sizeof(der_buf);
 
 

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -453,6 +453,7 @@ int wh_Server_CacheImportCurve25519Key(whServerContext* server,
     whNvmMetadata* cacheMeta;
     int            ret;
 
+    uint8_t der_buf[MAX_DER_SIZE];
     /* CURVE25519_MAX_KEY_TO_DER_SZ should be 82 */
     uint16_t       keySz = sizeof(der_buf);
 

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -452,12 +452,10 @@ int wh_Server_CacheImportCurve25519Key(whServerContext* server,
     uint8_t*       cacheBuf;
     whNvmMetadata* cacheMeta;
     int            ret;
-    /* Max size of a DER encoded curve25519 keypair with SubjectPublicKeyInfo
-     * included. Determined by experiment */
-    const uint16_t MAX_DER_SIZE = 128;
-    uint16_t       keySz        = keySz;
 
-    uint8_t der_buf[MAX_DER_SIZE];
+    /* CURVE2219_MAX_KEY_TO_DER_SZ should be 82 */
+    uint8_t        der_buf[CURVE25519_MAX_KEY_TO_DER_SZ];
+    uint16_t       keySz = sizeof(der_buf);
 
 
     if ((server == NULL) || (key == NULL) || (WH_KEYID_ISERASED(keyId)) ||

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -453,8 +453,7 @@ int wh_Server_CacheImportCurve25519Key(whServerContext* server,
     whNvmMetadata* cacheMeta;
     int            ret;
 
-    /* CURVE2219_MAX_KEY_TO_DER_SZ should be 82 */
-    uint8_t        der_buf[CURVE25519_MAX_KEY_TO_DER_SZ];
+    /* CURVE25519_MAX_KEY_TO_DER_SZ should be 82 */
     uint16_t       keySz = sizeof(der_buf);
 
 

--- a/test/user_settings.h
+++ b/test/user_settings.h
@@ -88,6 +88,7 @@ extern "C" {
 
 /** RSA Options */
 /*#define NO_RSA */
+#define RSA_MIN_SIZE 1024
 #define WC_RSA_PSS
 #define WOLFSSL_PSS_LONG_SALT
 #define FP_MAX_BITS 8192

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -2285,6 +2285,7 @@ int whTest_CryptoClientConfig(whClientConfig* config)
             i++;
         }
     }
+
 #ifdef WOLFHSM_CFG_DMA
     if (ret == 0) {
         ret = whTestCrypto_MlDsaDmaClient(client, WH_DEV_ID_DMA, rng);

--- a/test/wh_test_nvm_flash.h
+++ b/test/wh_test_nvm_flash.h
@@ -33,6 +33,13 @@
 int whTest_NvmFlash(void);
 
 /*
+ * Runs low-level flash tests on a custom NVM flash configuration. Useful to
+ * test your FLASH HAL implementation. This will erase the first partition.
+ * Returns 0 on success, and a non-zero error code on failure
+ */
+int whTest_FlashCfg(const whFlashCb* fcb, void* fctx, const void* cfg);
+
+/*
  * Runs NVM flash tests on a custom NVM flash configuration. Useful to test your
  * NVM HAL implementation
  * Returns 0 on success, and a non-zero error code on failure

--- a/wolfhsm/wh_error.h
+++ b/wolfhsm/wh_error.h
@@ -32,39 +32,37 @@ enum WH_ERROR_ENUM {
     WH_ERROR_OK             = 0,    /* Success, no error. */
 
     /* General errors */
-    WH_ERROR_BADARGS        = -400, /* No side effects. Fix args. */
-    WH_ERROR_NOTREADY       = -401, /* Retry function. */
-    WH_ERROR_ABORTED        = -402, /* Function has fatally failed. Cleanup. */
-    WH_ERROR_CANCEL         = -403, /* Operation was canceled */
-    WH_ERROR_CANCEL_LATE    = -404, /* Cancel was processed too late */
-    WH_ERROR_CERT_VERIFY    = -405, /* Certificate verification failed */
-    WH_ERROR_BUFFER_SIZE    = -406, /* Generic buffer size mismatch. Buffer
+    WH_ERROR_BADARGS        = -2000, /* No side effects. Fix args. */
+    WH_ERROR_NOTREADY       = -2001, /* Retry function. */
+    WH_ERROR_ABORTED        = -2002, /* Function has fatally failed. Cleanup. */
+    WH_ERROR_CANCEL         = -2003, /* Operation was canceled */
+    WH_ERROR_CANCEL_LATE    = -2004, /* Cancel was processed too late */
+    WH_ERROR_CERT_VERIFY    = -2005, /* Certificate verification failed */
+    WH_ERROR_BUFFER_SIZE    = -2006, /* Generic buffer size mismatch. Buffer
                                       * length is not what was expected */
+    WH_ERROR_NOHANDLER      = -2007, /* No customcb handler registered */
 
     /* NVM-specific status returns */
-    WH_ERROR_LOCKED         = -410, /* Unlock and retry if necessary */
-    WH_ERROR_ACCESS         = -411, /* Update access and retry */
-    WH_ERROR_NOTVERIFIED    = -412, /* Backing store does not match */
-    WH_ERROR_NOTBLANK       = -413, /* Area is no blank */
-    WH_ERROR_NOTFOUND       = -414, /* Matching object not found */
-    WH_ERROR_NOSPACE        = -415, /* No available space */
-
-    /* Custom-callback status returns */
-    WH_ERROR_NOHANDLER     = -420, /* No handler registered for action */
+    WH_ERROR_LOCKED         = -2100, /* Unlock and retry if necessary */
+    WH_ERROR_ACCESS         = -2101, /* Update access and retry */
+    WH_ERROR_NOTVERIFIED    = -2102, /* Backing store does not match */
+    WH_ERROR_NOTBLANK       = -2103, /* Area is no blank */
+    WH_ERROR_NOTFOUND       = -2104, /* Matching object not found */
+    WH_ERROR_NOSPACE        = -2105, /* No available space */
 
     /* SHE-specific error codes */
-    WH_SHE_ERC_SEQUENCE_ERROR = -500,
-    WH_SHE_ERC_KEY_NOT_AVAILABLE = -501,
-    WH_SHE_ERC_KEY_INVALID = -502,
-    WH_SHE_ERC_KEY_EMPTY = -503,
-    WH_SHE_ERC_NO_SECURE_BOOT = -504,
-    WH_SHE_ERC_WRITE_PROTECTED = -505,
-    WH_SHE_ERC_KEY_UPDATE_ERROR = -506,
-    WH_SHE_ERC_RNG_SEED = -507,
-    WH_SHE_ERC_NO_DEBUGGING = -508,
-    WH_SHE_ERC_BUSY = -509,
-    WH_SHE_ERC_MEMORY_FAILURE = -510,
-    WH_SHE_ERC_GENERAL_ERROR = -511,
+    WH_SHE_ERC_SEQUENCE_ERROR       = -2200,
+    WH_SHE_ERC_KEY_NOT_AVAILABLE    = -2201,
+    WH_SHE_ERC_KEY_INVALID          = -2202,
+    WH_SHE_ERC_KEY_EMPTY            = -2203,
+    WH_SHE_ERC_NO_SECURE_BOOT       = -2204,
+    WH_SHE_ERC_WRITE_PROTECTED      = -2205,
+    WH_SHE_ERC_KEY_UPDATE_ERROR     = -2206,
+    WH_SHE_ERC_RNG_SEED             = -2207,
+    WH_SHE_ERC_NO_DEBUGGING         = -2208,
+    WH_SHE_ERC_BUSY                 = -2209,
+    WH_SHE_ERC_MEMORY_FAILURE       = -2210,
+    WH_SHE_ERC_GENERAL_ERROR        = -2211,
 };
 
 #define WH_SHE_ERC_NO_ERROR WH_ERROR_OK

--- a/wolfhsm/wh_flash.h
+++ b/wolfhsm/wh_flash.h
@@ -35,22 +35,124 @@ typedef struct {
     int (*Init)(void* context,const void* config);
     int (*Cleanup)(void* context);
 
+/**
+ * @brief Returns the partition size in bytes (usually half of the total size).
+ *
+ * The partition size is the minimum size that the NVM Flash driver will erase
+ * when using a wh_flash interface.  This also represents the offset alignment.
+ *
+ * @param[in] context Pointer to the flash context.
+ * @return uint32_t Returns 0 on error, >0 for the partition size
+ */
     uint32_t (*PartitionSize)(void* context);
 
+/**
+ * @brief Requests a write lock on at least the requested offset and size.
+ *
+ * Mark at least the requested area as "locked", meaning requests to program or
+ * erase this area will return an error.  Locks are not nested, so a single
+ * unlock request is sufficient.  Repeated locking of the same area is not an
+ * error.
+ *
+ * @param[in] context Pointer to the flash context.
+ * @param[in] offset Offset in bytes to the start of the requested locked area
+ * @param[in] size Size in bytes of the requested locked area
+ * @return int Returns 0 on success, <0 on error WH_ERROR_*
+ */
     int (*WriteLock)(void* context,
             uint32_t offset, uint32_t size);
+/**
+ * @brief Requests a write unlock on at least the requested offset and size.
+ *
+ * Mark at least the requested area as "unlocked", meaning requests to program
+ * or erase this area will not return an error.  Repeated unlocking of the same
+ * area is not an error.
+ *
+ * @param[in] context Pointer to the flash context.
+ * @param[in] offset Offset in bytes to the start of the requested unlocked area
+ * @param[in] size Size in bytes of the unrequested locked area
+ * @return int Returns 0 on success, <0 on error WH_ERROR_*
+ */
     int (*WriteUnlock)(void* context,
             uint32_t offset, uint32_t size);
 
+/**
+ * @brief Read from requested offset and size into data.
+ *
+ * Copy data from the flash partition into the buffer pointed to be data.  It is
+ * an error to pass data==NULL and size!=0.  If size==0, then the offset should
+ * be tested to for validity.
+ *
+ * @param[in] context Pointer to the flash context.
+ * @param[in] offset Offset in bytes to the start of the requested area
+ * @param[in] size Size in bytes of the requested area
+ * @param[in] data Pointer to buffer of at least size bytes
+ * @return int Returns 0 on success, <0 on error WH_ERROR_*
+ */
     int (*Read)(void* context,
             uint32_t offset, uint32_t size, uint8_t* data);
+
+/**
+ * @brief Program at the requested offset and size from data.
+ *
+ * Copy data from the buffer pointed to be data into the flash partition.  It is
+ * an error to pass data==NULL and size!=0.  If size==0, then the offset should
+ * be tested to for validity.  Most flash devices must be Erased before
+ * Programming, but this function is not expected to Erase automatically.
+ * Offset must honor any restrictions of the device.
+ *
+ * @param[in] context Pointer to the flash context.
+ * @param[in] offset Offset in bytes to the start of the requested area
+ * @param[in] size Size in bytes of the requested area
+ * @param[in] data Pointer to buffer of at least size bytes
+ * @return int Returns 0 on success, <0 on error WH_ERROR_*
+ */
     int (*Program)(void* context,
             uint32_t offset, uint32_t size, const uint8_t* data);
+
+/**
+ * @brief Erase at the requested offset and size.
+ *
+ * Erase the flash at the requested offset and size.  The device will likely
+ * erase a larger size that around the requested offset, with this library
+ * assuming that size and granularity is the Partition Size.  If size==0, then
+ * the offset should be tested to for validity.
+ *
+ * @param[in] context Pointer to the flash context.
+ * @param[in] offset Offset in bytes to the start of the requested area
+ * @param[in] size Size in bytes of the requested area
+ * @return int Returns 0 on success, <0 on error WH_ERROR_*
+ */
     int (*Erase)(void* context,
             uint32_t offset, uint32_t size);
 
+/**
+ * @brief Read from requested offset and size to verify is matches data.
+ *
+ * Compare the contents of the flash with the contents pointed to by data.  It
+ * is an error to pass data==NULL and size!=0.  If size==0, then the offset
+ * should be tested to for validity.
+ *
+ * @param[in] context Pointer to the flash context.
+ * @param[in] offset Offset in bytes to the start of the requested area
+ * @param[in] size Size in bytes of the requested area
+ * @param[in] data Pointer to buffer of at least size bytes
+ * @return int Returns 0 on success, <0 on error WH_ERROR_*
+ */
     int (*Verify)(void* context,
             uint32_t offset, uint32_t size, const uint8_t* data);
+
+/**
+ * @brief Check the requested offset and size is erased on the flash.
+ *
+ * Check that the contents of the flash are erased for the requested area. If
+ * size==0, then the offset should be tested to for validity.
+ *
+ * @param[in] context Pointer to the flash context.
+ * @param[in] offset Offset in bytes to the start of the requested area
+ * @param[in] size Size in bytes of the requested area
+ * @return int Returns 0 on success, <0 on error WH_ERROR_*
+ */
     int (*BlankCheck)(void* context,
             uint32_t offset, uint32_t size);
 } whFlashCb;


### PR DESCRIPTION
1. Correct potential flash_unit error where program was being called with a 0 count.
2. Add standalone flash and flash_unit tests.
3. Shift wh_error codes to not conflict with wolfcrypt/error-ssl.h codes
4. Use wolfcrypt CURVE25519 export buffer size if available.
5. Update wh_flash.h interface documentation to better explain the expected behavior.