### PR TITLE
Fix a few compile errors  due to config

### DIFF
--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -118,11 +118,7 @@ static int      _getCryptoResponse(uint8_t* respBuf, uint16_t type,
 /* Helper function to prepare a crypto request buffer with generic header */
 static uint8_t* _createCryptoRequest(uint8_t* reqBuf, uint16_t type)
 {
-    whMessageCrypto_GenericRequestHeader* header =
-        (whMessageCrypto_GenericRequestHeader*)reqBuf;
-    header->algoType    = type;
-    header->algoSubType = WH_MESSAGE_CRYPTO_ALGO_SUBTYPE_NONE;
-    return reqBuf + sizeof(whMessageCrypto_GenericRequestHeader);
+    return _createCryptoRequestWithSubtype(reqBuf, type, WH_MESSAGE_CRYPTO_ALGO_SUBTYPE_NONE);
 }
 
 /* Helper function to prepare a crypto request buffer with generic header and
@@ -2549,9 +2545,11 @@ int wh_Client_Sha256(whClientContext* ctx, wc_Sha256* sha256, const uint8_t* in,
 
         /* reset the state of the sha context (without blowing away devId) */
         sha256->buffLen = 0;
-        sha256->flags   = 0;
         sha256->hiLen   = 0;
         sha256->loLen   = 0;
+#ifdef WOLFSSL_HASH_FLAGS
+        sha256->flags   = 0;
+#endif
         memset(sha256->digest, 0, sizeof(sha256->digest));
     }
 

--- a/src/wh_server_keystore.c
+++ b/src/wh_server_keystore.c
@@ -707,7 +707,12 @@ int wh_Server_HandleKeyRequest(whServerContext* server, uint16_t magic,
             ret = WH_ERROR_OK;
 
             if (ret == WH_ERROR_OK) {
-                resp.len = keySz;
+                /* Only provide key output if no error */
+                if (resp.rc == WH_ERROR_OK) {
+                    resp.len = keySz;
+                } else {
+                    resp.len = 0;
+                }
                 memcpy(resp.label, meta->label, sizeof(meta->label));
 
                 (void)wh_MessageKeystore_TranslateExportResponse(

--- a/src/wh_server_keystore.c
+++ b/src/wh_server_keystore.c
@@ -719,7 +719,7 @@ int wh_Server_HandleKeyRequest(whServerContext* server, uint16_t magic,
                     magic, &resp,
                     (whMessageKeystore_ExportResponse*)resp_packet);
 
-                *out_resp_size = sizeof(resp) + keySz;
+                *out_resp_size = sizeof(resp) + resp.len;
             }
         } break;
 


### PR DESCRIPTION
When building wolfHSM-examples, a couple of config errors were found:
1. _create_crypto_request_with_subtype was never called when pqc in not enabled.  Fixed by routing _crete_crypto_request through this function
2. sha256->flags only exists when WOLFSSL_HASH_FLAGS is set, which is not required.  Fix conditionally handles this.
3. only provide key export data on non-error.   