### PR TITLE
quickfix: makefile path capitalization

### DIFF
--- a/benchmark/Makefile
+++ b/benchmark/Makefile
@@ -11,7 +11,7 @@ MODULES_DIR			?= $(PROJECT_DIR)/bench_modules
 CONFIG_DIR			?= $(PROJECT_DIR)/config
 # wolfSSL and wolfHSM directories
 WOLFSSL_DIR			?= ../../wolfssl
-WOLFHSM_DIR			?= ../../wolfHSM
+WOLFHSM_DIR			?= ../
 WOLFHSM_PORT_DIR	?= $(WOLFHSM_DIR)/port/posix
 
 # Output directory for build files

--- a/examples/posix/tcp/wh_client_tcp/Makefile
+++ b/examples/posix/tcp/wh_client_tcp/Makefile
@@ -10,7 +10,7 @@ PROJECT_DIR				?= .
 CONFIG_DIR				?= $(PROJECT_DIR)/config
 # wolfSSL and wolfHSM directories
 WOLFSSL_DIR				?= ../../../../../wolfssl
-WOLFHSM_DIR				?= ../../../../../wolfHSM
+WOLFHSM_DIR				?= ../../../../
 WOLFHSM_PORT_DIR		?= $(WOLFHSM_DIR)/port/posix
 WOLFHSM_DEMO_CLIENT_DIR	?= $(WOLFHSM_DIR)/examples/demo/client
 

--- a/examples/posix/tcp/wh_server_tcp/Makefile
+++ b/examples/posix/tcp/wh_server_tcp/Makefile
@@ -10,7 +10,7 @@ PROJECT_DIR			?= .
 CONFIG_DIR			?= $(PROJECT_DIR)/config
 # wolfSSL and wolfHSM directories
 WOLFSSL_DIR			?= ../../../../../wolfssl
-WOLFHSM_DIR			?= ../../../../../wolfHSM
+WOLFHSM_DIR			?= ../../../../
 WOLFHSM_PORT_DIR	?= $(WOLFHSM_DIR)/port/posix
 
 # Output directory for build files

--- a/test/Makefile
+++ b/test/Makefile
@@ -10,7 +10,7 @@ PROJECT_DIR			?= .
 CONFIG_DIR			?= $(PROJECT_DIR)/config
 # wolfSSL and wolfHSM directories
 WOLFSSL_DIR			?= ../../wolfssl
-WOLFHSM_DIR			?= ../../wolfHSM
+WOLFHSM_DIR			?= ../
 WOLFHSM_PORT_DIR	?= $(WOLFHSM_DIR)/port/posix
 
 # Output directory for build files


### PR DESCRIPTION
default wolfHSM path capitalization is wrong (introduced in https://github.com/wolfSSL/wolfHSM/pull/156) leading to build errors when running make