### PR TITLE
Define ONE_MS only when in POSIX environment

### DIFF
--- a/test/wh_test_comm.c
+++ b/test/wh_test_comm.c
@@ -47,6 +47,8 @@
 #include <time.h>    /* For nanosleep */
 #include "port/posix/posix_transport_tcp.h"
 #include "port/posix/posix_transport_shm.h"
+
+const struct timespec ONE_MS = { .tv_sec = 0, .tv_nsec = 1000000 };
 #endif
 
 #include "wh_test_comm.h"
@@ -56,7 +58,6 @@
 #define RESP_SIZE 64
 #define REPEAT_COUNT 10
 
-const struct timespec ONE_MS = { .tv_sec = 0, .tv_nsec = 1000000 };
 
 #if defined(WOLFHSM_CFG_ENABLE_CLIENT) && defined(WOLFHSM_CFG_ENABLE_SERVER)
 int whTest_CommMem(void)


### PR DESCRIPTION
In builds not in a POSIX environment this was causing a build error. The PR ensures that ONE_MS is only defined when in a POSIX environment