### PR TITLE
Fixes scan-build issues 

### DIFF
--- a/benchmark/bench_modules/wh_bench_mod_rsa.c
+++ b/benchmark/bench_modules/wh_bench_mod_rsa.c
@@ -394,9 +394,6 @@ int _benchRsaCrypt(whClientContext* client, whBenchOpContext* ctx, int id,
         WH_BENCH_PRINTF("Failed to wc_RsaPublicEncrypt %d\n", ret);
         goto exit;
     }
-    else {
-        ret = 0;
-    }
 
     /* Set the data size for the benchmark */
     ret = wh_Bench_SetDataSize(ctx, id, encSz);

--- a/examples/demo/client/wh_demo_client_crypto.c
+++ b/examples/demo/client/wh_demo_client_crypto.c
@@ -91,7 +91,6 @@ int wh_DemoClient_CryptoRsa(whClientContext* clientContext)
         printf("Failed to wc_RsaPublicEncrypt %d\n", ret);
         goto exit;
     }
-    ret = 0;
 
     /* decrypt the ciphertext */
     ret = wc_RsaPrivateDecrypt(cipherText, encSz, plainText, sizeof(plainText),
@@ -194,7 +193,6 @@ int wh_DemoClient_CryptoRsaImport(whClientContext* clientContext)
         printf("Failed to wc_RsaPublicEncrypt %d\n", ret);
         goto exit;
     }
-    ret = 0;
 
     /* decrypt the ciphertext */
     ret = wc_RsaPrivateDecrypt(cipherText, encSz, plainText, sizeof(plainText),

--- a/examples/demo/client/wh_demo_client_secboot.c
+++ b/examples/demo/client/wh_demo_client_secboot.c
@@ -277,7 +277,7 @@ int wh_DemoClient_SecBoot_Boot(whClientContext* clientContext)
             printf("Read Object %d failed with error code: %d, server error "
                    "code: %d\n",
                    sig_nvmId, ret, rc);
-            return (ret != 0) ? ret : rc;
+            return (ret != WH_ERROR_OK) ? ret : rc;
         }
         wh_Utils_Hexdump("Signature:\n", sig, siglen);
 

--- a/examples/demo/client/wh_demo_client_secboot.c
+++ b/examples/demo/client/wh_demo_client_secboot.c
@@ -22,19 +22,19 @@
 
 /* Provisioning process:
  * 1. Generate a server keypair into key cache as keyId 27
- * 2. Commit the server keypair to server NVM 
+ * 2. Commit the server keypair to server NVM
  * 3. Map a file into memory and ask server to hash it using SHA256
  * 4. Sign the hash using the server keypair
- * 5. Store the signature to server NVM as object 29 
+ * 5. Store the signature to server NVM as object 29
  * 6. Hexdump hash, public key, and signature
  * Note: Provisioning can also be done offline using the whnvmtool
- * 
+ *
  * SecBoot process:
  * 1. Load the signature from server NVM as object 29
  * 2. Map a file into memory and ask server to hash it using SHA256
  * 3. Verify the signature using server keyId 27
  * 4. Hexdump hash, public key, and signature
- * 
+ *
  * Zeroization process:
  * 1. Destroy keyId 27
  * 2. Destroy nvmId 29
@@ -52,13 +52,13 @@ static int _showNvm(whClientContext* clientContext);
 
 static int _provisionMakeCommitKey(whClientContext* clientContext);
 static int _sha256File(const char* file_to_measure, uint8_t* hash);
-static int _signHash(   const uint8_t* hash, size_t hash_len, 
+static int _signHash(   const uint8_t* hash, size_t hash_len,
                         uint8_t* sig, uint16_t* sig_len);
-static int _verifyHash( const uint8_t* hash, size_t hash_len, 
+static int _verifyHash( const uint8_t* hash, size_t hash_len,
                         const uint8_t* sig, uint16_t sig_len,
                         int32_t* rc);
 
-static int _showNvm(whClientContext* clientContext)   
+static int _showNvm(whClientContext* clientContext)
 {
     int ret = 0;
     whNvmAccess access = WH_NVM_ACCESS_ANY;
@@ -68,33 +68,33 @@ static int _showNvm(whClientContext* clientContext)
 
     printf("NVM Contents:\n");
     do {
-        ret = wh_Client_NvmList(    clientContext, 
-                                    access, flags, 
-                                    id, NULL, 
+        ret = wh_Client_NvmList(    clientContext,
+                                    access, flags,
+                                    id, NULL,
                                     &count, &id);
         if (ret != WH_ERROR_OK) {
             printf("wh_Client_NvmList failed with ret:%d\n", ret);
             break;
         }
-        printf( "NVM List: count=%u, id=%u\n", 
+        printf( "NVM List: count=%u, id=%u\n",
                 (unsigned int)count, (unsigned int)id);
 
         if (count > 0) {
             whNvmSize data_len = 0;
             uint8_t label[WH_NVM_LABEL_LEN] = {0};
-            ret = wh_Client_NvmGetMetadata( clientContext, id, 
-                                            NULL, NULL, 
-                                            NULL, NULL, 
-                                            &data_len, 
+            ret = wh_Client_NvmGetMetadata( clientContext, id,
+                                            NULL, NULL,
+                                            NULL, NULL,
+                                            &data_len,
                                             sizeof(label), label);
             if (ret != WH_ERROR_OK) {
                 printf("wh_Client_NvmGetMetadata failed with ret:%d\n", ret);
                 break;
             }
 
-            printf( "NVM Object ID %u has label '%-*s' and size:%u\n", 
-                    (unsigned int)id, 
-                    (int)sizeof(label), label, 
+            printf( "NVM Object ID %u has label '%-*s' and size:%u\n",
+                    (unsigned int)id,
+                    (int)sizeof(label), label,
                     (unsigned int)data_len);
         }
     } while (count > 0);
@@ -102,17 +102,17 @@ static int _showNvm(whClientContext* clientContext)
     return ret;
 }
 
-static int _provisionMakeCommitKey(whClientContext* clientContext) 
+static int _provisionMakeCommitKey(whClientContext* clientContext)
 {
     int ret;
-    
+
     /* Use the default ECC curve for 32 byte key, likely P256r1 */
     whKeyId keyId = prov_keyId;
     uint8_t keyLabel[WH_NVM_LABEL_LEN] = {0};
     memcpy(keyLabel, prov_keyLabel, sizeof(prov_keyLabel));
 
-    ret = wh_Client_EccMakeCacheKey(clientContext, 32, ECC_CURVE_DEF, 
-                                    &keyId, WH_NVM_FLAGS_NONE, 
+    ret = wh_Client_EccMakeCacheKey(clientContext, 32, ECC_CURVE_DEF,
+                                    &keyId, WH_NVM_FLAGS_NONE,
                                     sizeof(prov_keyLabel), keyLabel);
     if (ret == WH_ERROR_OK) {
         ret = wh_Client_KeyCommit(clientContext, prov_keyId);
@@ -132,7 +132,7 @@ static int _sha256File(const char* file_to_measure, uint8_t* hash)
         close(fd);
 
         if (ptr != (void*)-1) {
-            printf("Generating SHA256 of %s over %u bytes at %p\n", 
+            printf("Generating SHA256 of %s over %u bytes at %p\n",
                 file_to_measure, (unsigned int)size, ptr);
             wc_Sha256 sha256[1];
             ret = wc_InitSha256_ex(sha256, NULL, WH_DEV_ID);
@@ -157,7 +157,7 @@ static int _sha256File(const char* file_to_measure, uint8_t* hash)
     return ret;
 }
 
-static int _signHash(   const uint8_t* hash, size_t hash_len, 
+static int _signHash(   const uint8_t* hash, size_t hash_len,
                         uint8_t* sig, uint16_t* sig_len)
 {
     ecc_key key[1];
@@ -177,7 +177,7 @@ static int _signHash(   const uint8_t* hash, size_t hash_len,
     return ret;
 }
 
-static int _verifyHash( const uint8_t* hash, size_t hash_len, 
+static int _verifyHash( const uint8_t* hash, size_t hash_len,
                         const uint8_t* sig, uint16_t sig_len,
                         int32_t* rc)
 {
@@ -187,8 +187,8 @@ static int _verifyHash( const uint8_t* hash, size_t hash_len,
         ret = wh_Client_EccSetKeyId(key, prov_keyId);
         if (ret == 0) {
             int res = 0;
-            ret = wc_ecc_verify_hash(   sig, (word32)sig_len, 
-                                        hash, (word32)hash_len, 
+            ret = wc_ecc_verify_hash(   sig, (word32)sig_len,
+                                        hash, (word32)hash_len,
                                         &res, key);
             if (ret == 0) {
                 *rc = res;
@@ -208,7 +208,7 @@ int wh_DemoClient_SecBoot_Provision(whClientContext* clientContext)
     if (clientContext == NULL) {
         return WH_ERROR_BADARGS;
     }
-    
+
     ret = wh_Client_CommInit(clientContext, &client_id, &server_id);
     if (ret == WH_ERROR_OK) {
         printf("Provision client connected to server id %u with client id %u\n",
@@ -227,7 +227,7 @@ int wh_DemoClient_SecBoot_Provision(whClientContext* clientContext)
                 uint16_t siglen = sizeof(sig);
 
                 printf("Signing hash...\n");
-                ret = _signHash(    hash, sizeof(hash), 
+                ret = _signHash(    hash, sizeof(hash),
                                     sig, &siglen);
                 if (ret == WH_ERROR_OK) {
                     int32_t rc = 0;
@@ -238,9 +238,9 @@ int wh_DemoClient_SecBoot_Provision(whClientContext* clientContext)
                     printf("Storing the signature in NVM as nvmId %u\n",
                             sig_nvmId);
                     ret = wh_Client_NvmAddObject(clientContext, sig_nvmId,
-                                        WH_NVM_ACCESS_NONE, WH_NVM_FLAGS_NONE, 
+                                        WH_NVM_ACCESS_NONE, WH_NVM_FLAGS_NONE,
                                         sizeof(sig_nvmLabel), sigLabel,
-                                        siglen, sig, 
+                                        siglen, sig,
                                         &rc);
                     printf("Stored signature with ret:%d and rc:%d\n", ret, rc);
                 }
@@ -266,7 +266,7 @@ int wh_DemoClient_SecBoot_Boot(whClientContext* clientContext)
     if (ret == WH_ERROR_OK) {
         printf("SecBoot Client connected to server id %u with client id %u\n",
                 server_id, client_id);
-        
+
         _showNvm(clientContext);
 
         uint8_t sig[ECC_MAX_SIG_SIZE] = {0};
@@ -276,10 +276,20 @@ int wh_DemoClient_SecBoot_Boot(whClientContext* clientContext)
                 sig_nvmId);
         ret = wh_Client_NvmGetMetadata(clientContext,
             sig_nvmId, &rc, NULL, NULL, NULL, &siglen, 0, NULL);
+        if (ret != WH_ERROR_OK) {
+            printf("wh_Client_NvmGetMetadata failed with ret:%d\n", ret);
+            return ret;
+        }
         printf("SecBoot got siglen %d with ret:%d rc:%d\n", siglen, ret, rc);
-        ret = wh_Client_NvmRead(clientContext, sig_nvmId, 
-                                0, siglen, &rc, 
+        ret = wh_Client_NvmRead(clientContext, sig_nvmId,
+                                0, siglen, &rc,
                                 NULL, sig);
+        if (ret != WH_ERROR_OK || rc != 0) {
+            printf("Read Object %d failed with error code: %d, server error "
+                   "code: %d\n",
+                   sig_nvmId, ret, rc);
+            return (ret != 0) ? ret : rc;
+        }
         wh_Utils_Hexdump("Signature:\n", sig, siglen);
 
 
@@ -289,8 +299,8 @@ int wh_DemoClient_SecBoot_Boot(whClientContext* clientContext)
         if (ret == WH_ERROR_OK) {
 
             printf("SecBoot Client Verifying signature using keyId %u\n", prov_keyId);
-            ret = _verifyHash(  hash, sizeof(hash), 
-                                sig, siglen, 
+            ret = _verifyHash(  hash, sizeof(hash),
+                                sig, siglen,
                                 &rc);
             printf("ecc_verify:%d rc:%d\n", ret, rc);
 
@@ -326,7 +336,7 @@ int wh_DemoClient_SecBoot_Zeroize(whClientContext* clientContext)
         printf("Zeroize Client erased keyId:%u ret:%d\n", prov_keyId, ret);
 
         ret = wh_Client_NvmDestroyObjects(clientContext, 1, &sig_nvmId, &rc);
-        printf("Zeroize Client destroyed NVM object:%u ret:%d with rc:%d\n", 
+        printf("Zeroize Client destroyed NVM object:%u ret:%d with rc:%d\n",
             sig_nvmId, ret, rc);
 
         _showNvm(clientContext);

--- a/examples/posix/wh_posix_server/wh_posix_server.c
+++ b/examples/posix/wh_posix_server/wh_posix_server.c
@@ -391,7 +391,10 @@ int main(int argc, char** argv)
     }
 
     rc = wh_ServerTask(s_conf, keyFilePath, keyId, clientId);
-
+    if (rc != WH_ERROR_OK) {
+        printf("Server task failed: %d\n", rc);
+        return rc;
+    }
     rc = wc_FreeRng(crypto->rng);
     if (rc != 0) {
         printf("Failed to wc_FreeRng: %d\n", rc);

--- a/examples/posix/wh_posix_server/wh_posix_server_cfg.c
+++ b/examples/posix/wh_posix_server/wh_posix_server_cfg.c
@@ -515,52 +515,5 @@ int wh_PosixServer_ExampleNvmConfig(void* conf, const char* nvmInitFilePath)
         printf("NVM initialization completed successfully\n");
     }
 
-    /* Initialize crypto library and hardware */
-    wolfCrypt_Init();
-
-    /* Context 3: Server Software Crypto */
-    WC_RNG rng[1];
-    uint8_t buffer[128] = {0};
-    wc_InitRng_ex(rng, NULL, INVALID_DEVID);
-    wc_RNG_GenerateBlock(rng, buffer, sizeof(buffer));
-    wc_FreeRng(rng);
-    wh_Utils_Hexdump("Context 3: Server SW RNG:\n", buffer, sizeof(buffer));
-
-    /* Context 4: Server Hardware Crypto */
-    #define HW_DEV_ID 100
-    memset(buffer, 0, sizeof(buffer));
-    wc_CryptoCb_RegisterDevice(HW_DEV_ID, _hardwareCryptoCb, NULL);
-    wc_InitRng_ex(rng, NULL, HW_DEV_ID);
-    wc_RNG_GenerateBlock(rng, buffer, sizeof(buffer));
-    wc_FreeRng(rng);
-    wh_Utils_Hexdump("Context 4: Server HW RNG:\n", buffer, sizeof(buffer));
-
-    /* Context 5: Set default server crypto to use cryptocb */
-    crypto->devId = HW_DEV_ID;
-    printf("Context 5: Setting up default server crypto with devId=%d\n",
-                crypto->devId);
-
-    rc = wc_InitRng_ex(crypto->rng, NULL, crypto->devId);
-    if (rc != 0) {
-        printf("Failed to wc_InitRng_ex: %d\n", rc);
-        return rc;
-    }
-
-    rc = wh_ServerTask(s_conf, keyFilePath, keyId, clientId);
-    if (rc != 0) {
-        printf("Failed to wh_ServerTask: %d\n", rc);
-        return rc;
-    }
-    rc = wc_FreeRng(crypto->rng);
-    if (rc != 0) {
-        printf("Failed to wc_FreeRng: %d\n", rc);
-        return rc;
-    }
-    rc = wolfCrypt_Cleanup();
-    if (rc != 0) {
-        printf("Failed to wolfCrypt_Cleanup: %d\n", rc);
-        return rc;
-    }
-
-    return rc;
+    return WH_ERROR_OK;
 }

--- a/src/wh_nvm_flash.c
+++ b/src/wh_nvm_flash.c
@@ -360,9 +360,9 @@ static int nfPartition_ReadMemDirectory(whNvmFlashContext* context, int partitio
     memset(directory, 0, sizeof(*directory));
 
     for(index = 0; (index < WOLFHSM_CFG_NVM_OBJECT_COUNT) && (ret == 0); index++) {
-        /* TODO: Handle errors better here.  Break out of loop? */
-        nfMemObject_Read(context, offset + NF_DIRECTORY_OBJECT_OFFSET(index),
-                         &directory->objects[index]);
+        (void)nfMemObject_Read(context,
+                    offset + NF_DIRECTORY_OBJECT_OFFSET(index),
+                    &directory->objects[index]);
     }
     return ret;
 }

--- a/src/wh_nvm_flash.c
+++ b/src/wh_nvm_flash.c
@@ -360,7 +360,7 @@ static int nfPartition_ReadMemDirectory(whNvmFlashContext* context, int partitio
     memset(directory, 0, sizeof(*directory));
 
     for(index = 0; (index < WOLFHSM_CFG_NVM_OBJECT_COUNT) && (ret == 0); index++) {
-        (void)nfMemObject_Read(context,
+        ret = nfMemObject_Read(context,
                     offset + NF_DIRECTORY_OBJECT_OFFSET(index),
                     &directory->objects[index]);
     }

--- a/src/wh_nvm_flash.c
+++ b/src/wh_nvm_flash.c
@@ -361,10 +361,8 @@ static int nfPartition_ReadMemDirectory(whNvmFlashContext* context, int partitio
 
     for(index = 0; (index < WOLFHSM_CFG_NVM_OBJECT_COUNT) && (ret == 0); index++) {
         /* TODO: Handle errors better here.  Break out of loop? */
-        nfMemObject_Read(
-                context,
-                offset + NF_DIRECTORY_OBJECT_OFFSET(index),
-                &directory->objects[index]);
+        nfMemObject_Read(context, offset + NF_DIRECTORY_OBJECT_OFFSET(index),
+                         &directory->objects[index]);
     }
     return ret;
 }

--- a/src/wh_nvm_flash.c
+++ b/src/wh_nvm_flash.c
@@ -359,8 +359,11 @@ static int nfPartition_ReadMemDirectory(whNvmFlashContext* context, int partitio
                 NF_PARTITION_DIRECTORY_OFFSET;
     memset(directory, 0, sizeof(*directory));
 
-    for(index = 0; (index < WOLFHSM_CFG_NVM_OBJECT_COUNT) && (ret == 0); index++) {
-        ret = nfMemObject_Read(context,
+    for (index = 0; (index < WOLFHSM_CFG_NVM_OBJECT_COUNT); index++) {
+        /* Read all objects from the Partition Directory.
+         * Don't break on an error.
+         */
+        (void)nfMemObject_Read(context,
                                offset + NF_DIRECTORY_OBJECT_OFFSET(index),
                                &directory->objects[index]);
     }

--- a/src/wh_nvm_flash.c
+++ b/src/wh_nvm_flash.c
@@ -361,8 +361,8 @@ static int nfPartition_ReadMemDirectory(whNvmFlashContext* context, int partitio
 
     for(index = 0; (index < WOLFHSM_CFG_NVM_OBJECT_COUNT) && (ret == 0); index++) {
         ret = nfMemObject_Read(context,
-                    offset + NF_DIRECTORY_OBJECT_OFFSET(index),
-                    &directory->objects[index]);
+                               offset + NF_DIRECTORY_OBJECT_OFFSET(index),
+                               &directory->objects[index]);
     }
     return ret;
 }

--- a/src/wh_nvm_flash.c
+++ b/src/wh_nvm_flash.c
@@ -25,7 +25,7 @@
 
 /* Pick up compile-time configuration */
 #include "wolfhsm/wh_settings.h"
-
+#include <stdio.h>
 #include <stdint.h>
 #include <stddef.h>     /* For NULL */
 #include <string.h>     /* For memset, memcpy */
@@ -361,7 +361,7 @@ static int nfPartition_ReadMemDirectory(whNvmFlashContext* context, int partitio
 
     for(index = 0; (index < WOLFHSM_CFG_NVM_OBJECT_COUNT) && (ret == 0); index++) {
         /* TODO: Handle errors better here.  Break out of loop? */
-        ret = nfMemObject_Read(
+        nfMemObject_Read(
                 context,
                 offset + NF_DIRECTORY_OBJECT_OFFSET(index),
                 &directory->objects[index]);
@@ -1087,8 +1087,8 @@ int wh_NvmFlash_AddObject(void* c, whNvmMetadata *meta,
     }
 
     /* Find existing object so we can increment the epoch */
-    (void)nfMemDirectory_FindObjectIndexById(d, meta->id, &oldentry);
-    if (oldentry >= 0) {
+    ret = nfMemDirectory_FindObjectIndexById(d, meta->id, &oldentry);
+    if (oldentry >= 0 && ret != WH_ERROR_NOTFOUND) {
         epoch = d->objects[oldentry].state.epoch + 1;
     }
 

--- a/src/wh_nvm_flash.c
+++ b/src/wh_nvm_flash.c
@@ -25,7 +25,7 @@
 
 /* Pick up compile-time configuration */
 #include "wolfhsm/wh_settings.h"
-#include <stdio.h>
+
 #include <stdint.h>
 #include <stddef.h>     /* For NULL */
 #include <string.h>     /* For memset, memcpy */
@@ -1086,7 +1086,7 @@ int wh_NvmFlash_AddObject(void* c, whNvmMetadata *meta,
 
     /* Find existing object so we can increment the epoch */
     ret = nfMemDirectory_FindObjectIndexById(d, meta->id, &oldentry);
-    if (oldentry >= 0 && ret != WH_ERROR_NOTFOUND) {
+    if (ret != WH_ERROR_NOTFOUND && oldentry >= 0) {
         epoch = d->objects[oldentry].state.epoch + 1;
     }
 

--- a/src/wh_nvm_flash.c
+++ b/src/wh_nvm_flash.c
@@ -1086,7 +1086,7 @@ int wh_NvmFlash_AddObject(void* c, whNvmMetadata *meta,
 
     /* Find existing object so we can increment the epoch */
     ret = nfMemDirectory_FindObjectIndexById(d, meta->id, &oldentry);
-    if (ret != WH_ERROR_NOTFOUND && oldentry >= 0) {
+    if (ret == WH_ERROR_OK && oldentry >= 0) {
         epoch = d->objects[oldentry].state.epoch + 1;
     }
 

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -314,8 +314,8 @@ static int _HandleRsaKeyGen(whServerContext* ctx, uint16_t magic,
                                                       label_size, label);
                 }
 #ifdef DEBUG_CRYPTOCB_VERBOSE
-                printf("[server] RsaKeyGen CacheKeyRsa: keyId:%u, ret:%d\n",
-                       key_id, ret);
+                    printf("[server] RsaKeyGen CacheKeyRsa: keyId:%u, ret:%d\n",
+                           key_id, ret);
 #endif
                 if (ret == 0) {
                     res.keyId = WH_KEYID_ID(key_id);
@@ -763,7 +763,7 @@ static int _HandleEccKeyGen(whServerContext* ctx, uint16_t magic,
                 }
 #ifdef DEBUG_CRYPTOCB
                 printf("[server] %s CacheImport: keyId:%u, ret:%d\n", __func__,
-                       key_id, ret);
+                        key_id, ret);
 #endif
                 /* TODO: RSA has the following, should we do the same? */
                 /*
@@ -1187,8 +1187,8 @@ static int _HandleCurve25519KeyGen(whServerContext* ctx, uint16_t magic,
                         ctx, key, key_id, flags, label_size, label);
                 }
 #ifdef DEBUG_CRYPTOCB
-                printf("[server] %s CacheImport: keyId:%u, ret:%d\n", __func__,
-                       key_id, ret);
+                printf("[server] %s CacheImport: keyId:%u, ret:%d\n",
+                        __func__, key_id, ret);
 #endif
             }
         }
@@ -1941,6 +1941,8 @@ static int _HandleCmac(whServerContext* ctx, uint16_t magic, uint16_t seq,
                                             ctx->comm->client_id,
                                             WH_KEYID_ERASED);
                     ret   = wh_Server_KeystoreGetUniqueId(ctx, &keyId);
+                    if (ret != 0)
+                        return ret;
                 }
                 else {
                     keyId = WH_MAKE_KEYID(  WH_KEYTYPE_CRYPTO,
@@ -1949,7 +1951,7 @@ static int _HandleCmac(whServerContext* ctx, uint16_t magic, uint16_t seq,
                 }
                 /* evict the aes sized key in the normal cache */
                 if (moveToBigCache == 1) {
-                    ret = wh_Server_KeystoreEvictKey(ctx, keyId);
+                    (void)wh_Server_KeystoreEvictKey(ctx, keyId);
                 }
                 if (ret == 0) {
                     meta->id  = keyId;
@@ -2393,7 +2395,7 @@ static int _HandleMlDsaKeyGen(whServerContext* ctx, uint16_t magic,
                         }
 #ifdef DEBUG_CRYPTOCB
                         printf("[server] %s CacheImport: keyId:%u, ret:%d\n",
-                               __func__, key_id, ret);
+                             __func__, key_id, ret);
 #endif
                     }
                 }

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -820,7 +820,7 @@ static int _HandleEccSharedSecret(whServerContext* ctx, uint16_t magic,
         (byte*)cryptoDataOut + sizeof(whMessageCrypto_EcdhResponse);
     word32 max_len = (word32)(WOLFHSM_CFG_COMM_DATA_LEN -
                               (res_out - (uint8_t*)cryptoDataOut));
-    word32 res_len;
+    word32 res_len = 0;
 
     /* init ecc keys */
     ret = wc_ecc_init_ex(pub_key, NULL, ctx->crypto->devId);
@@ -974,7 +974,7 @@ static int _HandleEccVerify(whServerContext* ctx, uint16_t magic,
     word32   max_size = (word32)(WOLFHSM_CFG_COMM_DATA_LEN -
                                (res_pub - (uint8_t*)cryptoDataOut));
     uint32_t pub_size = 0;
-    int      result;
+    int      result = 0;
 
     /* init public key */
     ret = wc_ecc_init_ex(key, NULL, ctx->crypto->devId);
@@ -2546,7 +2546,7 @@ static int _HandleMlDsaVerify(whServerContext* ctx, uint16_t magic,
     int      evict = !!(options & WH_MESSAGE_CRYPTO_MLDSA_VERIFY_OPTIONS_EVICT);
 
     /* Response message */
-    int result;
+    int result = 0;
 
     /* init public key */
     ret = wc_MlDsaKey_Init(key, NULL, ctx->crypto->devId);

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -974,7 +974,7 @@ static int _HandleEccVerify(whServerContext* ctx, uint16_t magic,
     word32   max_size = (word32)(WOLFHSM_CFG_COMM_DATA_LEN -
                                (res_pub - (uint8_t*)cryptoDataOut));
     uint32_t pub_size = 0;
-    int      result = 0;
+    int      result   = 0;
 
     /* init public key */
     ret = wc_ecc_init_ex(key, NULL, ctx->crypto->devId);

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -1941,7 +1941,7 @@ static int _HandleCmac(whServerContext* ctx, uint16_t magic, uint16_t seq,
                                             ctx->comm->client_id,
                                             WH_KEYID_ERASED);
                     ret   = wh_Server_KeystoreGetUniqueId(ctx, &keyId);
-                    if (ret != 0)
+                    if (ret != WH_ERROR_OK)
                         return ret;
                 }
                 else {

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -409,7 +409,7 @@ static int _HandleRsaFunction( whServerContext* ctx, uint16_t magic,
         wc_FreeRsaKey(rsa);
     }
     if (evict != 0) {
-        (void)wh_Server_KeystoreEvictKey(ctx, key_id);
+        ret = wh_Server_KeystoreEvictKey(ctx, key_id);
     }
     if (ret == 0) {
         whMessageCrypto_RsaResponse res;
@@ -468,7 +468,7 @@ static int _HandleRsaGetSize(whServerContext* ctx, uint16_t magic,
         printf("[server] %s evicting temp key:%x options:%u evict:%u\n",
                __func__, key_id, options, evict);
 #endif
-        (void)wh_Server_KeystoreEvictKey(ctx, key_id);
+        ret = wh_Server_KeystoreEvictKey(ctx, key_id);
     }
     if (ret == 0) {
         res.keySize = key_size;
@@ -847,10 +847,10 @@ static int _HandleEccSharedSecret(whServerContext* ctx, uint16_t magic,
         wc_ecc_free(pub_key);
     }
     if (evict_pub) {
-        (void)wh_Server_KeystoreEvictKey(ctx, pub_key_id);
+        ret = wh_Server_KeystoreEvictKey(ctx, pub_key_id);
     }
-    if (evict_prv) {
-        (void)wh_Server_KeystoreEvictKey(ctx, prv_key_id);
+    if (ret == WH_ERROR_OK && evict_prv) {
+        ret = wh_Server_KeystoreEvictKey(ctx, prv_key_id);
     }
     if (ret == 0) {
         whMessageCrypto_EcdhResponse res;
@@ -921,7 +921,7 @@ static int _HandleEccSign(whServerContext* ctx, uint16_t magic,
         wc_ecc_free(key);
     }
     if (evict != 0) {
-        (void)wh_Server_KeystoreEvictKey(ctx, key_id);
+        ret = wh_Server_KeystoreEvictKey(ctx, key_id);
     }
     if (ret == 0) {
         whMessageCrypto_EccSignResponse res;
@@ -1011,7 +1011,7 @@ static int _HandleEccVerify(whServerContext* ctx, uint16_t magic,
     }
     if (evict != 0) {
         /* User requested to evict from cache, even if the call failed */
-        (void)wh_Server_KeystoreEvictKey(ctx, key_id);
+        ret = wh_Server_KeystoreEvictKey(ctx, key_id);
     }
     if (ret == 0) {
         res.pubSz = pub_size;
@@ -1276,10 +1276,10 @@ static int _HandleCurve25519SharedSecret(whServerContext* ctx, uint16_t magic,
         wc_curve25519_free(priv);
     }
     if (evict_pub) {
-        (void)wh_Server_KeystoreEvictKey(ctx, pub_key_id);
+        ret = wh_Server_KeystoreEvictKey(ctx, pub_key_id);
     }
-    if (evict_prv) {
-        (void)wh_Server_KeystoreEvictKey(ctx, prv_key_id);
+    if (ret == WH_ERROR_OK && evict_prv) {
+        ret = wh_Server_KeystoreEvictKey(ctx, prv_key_id);
     }
     if (ret == 0) {
         res.sz = res_len;
@@ -1951,7 +1951,7 @@ static int _HandleCmac(whServerContext* ctx, uint16_t magic, uint16_t seq,
                 }
                 /* evict the aes sized key in the normal cache */
                 if (moveToBigCache == 1) {
-                    (void)wh_Server_KeystoreEvictKey(ctx, keyId);
+                    ret = wh_Server_KeystoreEvictKey(ctx, keyId);
                 }
                 if (ret == 0) {
                     meta->id  = keyId;
@@ -2482,7 +2482,7 @@ static int _HandleMlDsaSign(whServerContext* ctx, uint16_t magic,
         wc_MlDsaKey_Free(key);
     }
     if (evict != 0) {
-        (void)wh_Server_KeystoreEvictKey(ctx, key_id);
+        ret = wh_Server_KeystoreEvictKey(ctx, key_id);
     }
     if (ret == 0) {
         res.sz   = res_len;
@@ -2562,7 +2562,7 @@ static int _HandleMlDsaVerify(whServerContext* ctx, uint16_t magic,
     }
     if (evict != 0) {
         /* User requested to evict from cache, even if the call failed */
-        (void)wh_Server_KeystoreEvictKey(ctx, key_id);
+        ret = wh_Server_KeystoreEvictKey(ctx, key_id);
     }
     if (ret == 0) {
         res.res  = result;
@@ -3656,7 +3656,7 @@ static int _HandleMlDsaSignDma(whServerContext* ctx, uint16_t magic,
 
             /* Evict key if requested */
             if (evict) {
-                (void)wh_Server_KeystoreEvictKey(ctx, key_id);
+                ret = wh_Server_KeystoreEvictKey(ctx, key_id);
             }
         }
         wc_MlDsaKey_Free(key);
@@ -3763,7 +3763,7 @@ static int _HandleMlDsaVerifyDma(whServerContext* ctx, uint16_t magic,
 
         /* Evict key if requested */
         if (evict) {
-            (void)wh_Server_KeystoreEvictKey(ctx, key_id);
+            ret = wh_Server_KeystoreEvictKey(ctx, key_id);
         }
     }
 

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -409,7 +409,8 @@ static int _HandleRsaFunction( whServerContext* ctx, uint16_t magic,
         wc_FreeRsaKey(rsa);
     }
     if (evict != 0) {
-        ret = wh_Server_KeystoreEvictKey(ctx, key_id);
+        /* User requested to evict from cache, even if the call failed */
+        (void)wh_Server_KeystoreEvictKey(ctx, key_id);
     }
     if (ret == 0) {
         whMessageCrypto_RsaResponse res;
@@ -468,7 +469,8 @@ static int _HandleRsaGetSize(whServerContext* ctx, uint16_t magic,
         printf("[server] %s evicting temp key:%x options:%u evict:%u\n",
                __func__, key_id, options, evict);
 #endif
-        ret = wh_Server_KeystoreEvictKey(ctx, key_id);
+        /* User requested to evict from cache, even if the call failed */
+        (void)wh_Server_KeystoreEvictKey(ctx, key_id);
     }
     if (ret == 0) {
         res.keySize = key_size;
@@ -847,10 +849,12 @@ static int _HandleEccSharedSecret(whServerContext* ctx, uint16_t magic,
         wc_ecc_free(pub_key);
     }
     if (evict_pub) {
-        ret = wh_Server_KeystoreEvictKey(ctx, pub_key_id);
+        /* User requested to evict from cache, even if the call failed */
+        (void)wh_Server_KeystoreEvictKey(ctx, pub_key_id);
     }
-    if (ret == WH_ERROR_OK && evict_prv) {
-        ret = wh_Server_KeystoreEvictKey(ctx, prv_key_id);
+    if (evict_prv) {
+        /* User requested to evict from cache, even if the call failed */
+        (void)wh_Server_KeystoreEvictKey(ctx, prv_key_id);
     }
     if (ret == 0) {
         whMessageCrypto_EcdhResponse res;
@@ -921,7 +925,8 @@ static int _HandleEccSign(whServerContext* ctx, uint16_t magic,
         wc_ecc_free(key);
     }
     if (evict != 0) {
-        ret = wh_Server_KeystoreEvictKey(ctx, key_id);
+        /* typecasting to void so that not overwrite ret */
+        (void)wh_Server_KeystoreEvictKey(ctx, key_id);
     }
     if (ret == 0) {
         whMessageCrypto_EccSignResponse res;
@@ -1011,7 +1016,7 @@ static int _HandleEccVerify(whServerContext* ctx, uint16_t magic,
     }
     if (evict != 0) {
         /* User requested to evict from cache, even if the call failed */
-        ret = wh_Server_KeystoreEvictKey(ctx, key_id);
+        (void)wh_Server_KeystoreEvictKey(ctx, key_id);
     }
     if (ret == 0) {
         res.pubSz = pub_size;
@@ -1276,10 +1281,12 @@ static int _HandleCurve25519SharedSecret(whServerContext* ctx, uint16_t magic,
         wc_curve25519_free(priv);
     }
     if (evict_pub) {
-        ret = wh_Server_KeystoreEvictKey(ctx, pub_key_id);
+        /* User requested to evict from cache, even if the call failed */
+        (void)wh_Server_KeystoreEvictKey(ctx, pub_key_id);
     }
-    if (ret == WH_ERROR_OK && evict_prv) {
-        ret = wh_Server_KeystoreEvictKey(ctx, prv_key_id);
+    if (evict_prv) {
+        /* User requested to evict from cache, even if the call failed */
+        (void)wh_Server_KeystoreEvictKey(ctx, prv_key_id);
     }
     if (ret == 0) {
         res.sz = res_len;
@@ -2482,7 +2489,8 @@ static int _HandleMlDsaSign(whServerContext* ctx, uint16_t magic,
         wc_MlDsaKey_Free(key);
     }
     if (evict != 0) {
-        ret = wh_Server_KeystoreEvictKey(ctx, key_id);
+        /* User requested to evict from cache, even if the call failed */
+        (void)wh_Server_KeystoreEvictKey(ctx, key_id);
     }
     if (ret == 0) {
         res.sz   = res_len;
@@ -2562,7 +2570,7 @@ static int _HandleMlDsaVerify(whServerContext* ctx, uint16_t magic,
     }
     if (evict != 0) {
         /* User requested to evict from cache, even if the call failed */
-        ret = wh_Server_KeystoreEvictKey(ctx, key_id);
+        (void)wh_Server_KeystoreEvictKey(ctx, key_id);
     }
     if (ret == 0) {
         res.res  = result;
@@ -3656,7 +3664,9 @@ static int _HandleMlDsaSignDma(whServerContext* ctx, uint16_t magic,
 
             /* Evict key if requested */
             if (evict) {
-                ret = wh_Server_KeystoreEvictKey(ctx, key_id);
+                /* User requested to evict from cache, even if the call failed
+                 */
+                (void)wh_Server_KeystoreEvictKey(ctx, key_id);
             }
         }
         wc_MlDsaKey_Free(key);
@@ -3763,7 +3773,8 @@ static int _HandleMlDsaVerifyDma(whServerContext* ctx, uint16_t magic,
 
         /* Evict key if requested */
         if (evict) {
-            ret = wh_Server_KeystoreEvictKey(ctx, key_id);
+            /* User requested to evict from cache, even if the call failed */
+            (void)wh_Server_KeystoreEvictKey(ctx, key_id);
         }
     }
 

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -314,8 +314,8 @@ static int _HandleRsaKeyGen(whServerContext* ctx, uint16_t magic,
                                                       label_size, label);
                 }
 #ifdef DEBUG_CRYPTOCB_VERBOSE
-                    printf("[server] RsaKeyGen CacheKeyRsa: keyId:%u, ret:%d\n",
-                           key_id, ret);
+                printf("[server] RsaKeyGen CacheKeyRsa: keyId:%u, ret:%d\n",
+                       key_id, ret);
 #endif
                 if (ret == 0) {
                     res.keyId = WH_KEYID_ID(key_id);
@@ -763,7 +763,7 @@ static int _HandleEccKeyGen(whServerContext* ctx, uint16_t magic,
                 }
 #ifdef DEBUG_CRYPTOCB
                 printf("[server] %s CacheImport: keyId:%u, ret:%d\n", __func__,
-                        key_id, ret);
+                       key_id, ret);
 #endif
                 /* TODO: RSA has the following, should we do the same? */
                 /*
@@ -1187,8 +1187,8 @@ static int _HandleCurve25519KeyGen(whServerContext* ctx, uint16_t magic,
                         ctx, key, key_id, flags, label_size, label);
                 }
 #ifdef DEBUG_CRYPTOCB
-                printf("[server] %s CacheImport: keyId:%u, ret:%d\n",
-                        __func__, key_id, ret);
+                printf("[server] %s CacheImport: keyId:%u, ret:%d\n", __func__,
+                       key_id, ret);
 #endif
             }
         }
@@ -2395,7 +2395,7 @@ static int _HandleMlDsaKeyGen(whServerContext* ctx, uint16_t magic,
                         }
 #ifdef DEBUG_CRYPTOCB
                         printf("[server] %s CacheImport: keyId:%u, ret:%d\n",
-                             __func__, key_id, ret);
+                               __func__, key_id, ret);
 #endif
                     }
                 }

--- a/test/wh_test_clientserver.c
+++ b/test/wh_test_clientserver.c
@@ -116,8 +116,8 @@ static int _customServerCb(whServerContext*                 server,
         resp->data.dma32.client_sz = req->data.dma32.server_sz;
         copySz                     = req->data.dma32.server_sz;
     }
-
-    memcpy(clientPtr, serverPtr, copySz);
+    if (clientPtr != NULL && serverPtr != NULL && copySz > 0)
+        memcpy(clientPtr, serverPtr, copySz);
 
     return req->id;
 }

--- a/test/wh_test_clientserver.c
+++ b/test/wh_test_clientserver.c
@@ -116,7 +116,7 @@ static int _customServerCb(whServerContext*                 server,
         resp->data.dma32.client_sz = req->data.dma32.server_sz;
         copySz                     = req->data.dma32.server_sz;
     }
-    if (clientPtr != NULL && serverPtr != NULL && copySz > 0) {
+    if ((clientPtr != NULL) && (serverPtr != NULL) && (copySz > 0)) {
         memcpy(clientPtr, serverPtr, copySz);
     }
 

--- a/test/wh_test_clientserver.c
+++ b/test/wh_test_clientserver.c
@@ -116,8 +116,9 @@ static int _customServerCb(whServerContext*                 server,
         resp->data.dma32.client_sz = req->data.dma32.server_sz;
         copySz                     = req->data.dma32.server_sz;
     }
-    if (clientPtr != NULL && serverPtr != NULL && copySz > 0)
+    if (clientPtr != NULL && serverPtr != NULL && copySz > 0) {
         memcpy(clientPtr, serverPtr, copySz);
+    }
 
     return req->id;
 }

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -353,7 +353,6 @@ static int whTest_CryptoEcc(whClientContext* ctx, int devId, WC_RNG* rng)
                             }
                             else {
                                 WH_ERROR_PRINT("ECDH FAILED TO MATCH\n");
-                                ret = -1;
                             }
                         }
                     }
@@ -2672,7 +2671,6 @@ static int whTestCrypto_MlDsaWolfCrypt(whClientContext* ctx, int devId,
 
     if (!verified) {
         WH_ERROR_PRINT("ML DSA signature verification failed\n");
-        ret = -1;
     }
 
     /* Modify signature to ensure verification fails */


### PR DESCRIPTION
Fixes issues on scan-build LLVM-19

```
scan-build --status-bugs make -C test/ 
scan-build --status-bugs make -C benchmark/ 
scan-build --status-bugs make -C examples/ 
scan-build --status-bugs make -C tools/whnvmtool/
```

There is one issue, which is `warning: Value stored to 'ret' is never read` in `wolfcrypt\src\random.c` against `tools/whnvmtool/`, remaining. That will be separately fixed.

Github action addition for changes in the future will be submitted as separate PR.
