### PR TITLE
Reject unformatted PRs

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,65 @@
+name: Clang Format Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  clang-format-check:
+    name: Check PR formatting with clang-format-15
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Need full history to compare with main branch
+
+    - name: Install clang-format-15
+      run: |
+        sudo apt-get install -y clang-format-15
+
+    - name: Fetch base branch
+      env:
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
+      run: |
+        git fetch origin "$BASE_REF:$BASE_REF"
+
+    - name: Check formatting
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        BASE_REF: ${{ github.event.pull_request.base.ref }}
+      run: |
+        echo "Running git-clang-format-15 to check for formatting issues..."
+        echo "Comparing against base branch: $BASE_REF"
+
+        # Create a temporary file for the diff and ensure cleanup
+        DIFF_FILE="$(mktemp)"
+        trap 'rm -f "$DIFF_FILE"' EXIT
+
+        # Run git-clang-format against the PR base commit and capture status safely under set -e
+        if git-clang-format-15 --diff "$BASE_REF" --binary clang-format-15 > "$DIFF_FILE"; then
+          status=0
+        else
+          status=$?
+        fi
+        if [ "$status" -eq 0 ]; then
+          echo "✅ Code is properly formatted!"
+          exit 0
+        elif [ "$status" -eq 1 ]; then
+          echo "❌ Code formatting issues detected!"
+          echo ""
+          echo "The following changes would be made by clang-format-15:"
+          echo "=================================================="
+          cat "$DIFF_FILE"
+          echo "=================================================="
+          echo ""
+          echo "Please run the following command locally on your feature branch and commit the changes:"
+          echo "  git-clang-format-15 --binary clang-format-15 $BASE_REF"
+          exit 1
+        else
+          echo "❌ git-clang-format-15 failed with exit code $status"
+          echo "Output (if any):"
+          cat "$DIFF_FILE"
+          exit 1
+        fi


### PR DESCRIPTION
Adds a GH action that enforces code formatting on a PR (only on the diff against the PR target branch, not on all files).

The action runs `git-clang-format` against the target branch (usually `main`) to see if there are any formatting changes that would be made (indicating the PR author didn't run the command locally). If there are changes, the action fails, prompting the PR author to run `git-clang-format` locally and commit the changes.
