### PR TITLE
Add WOLFHSM_CFG_CANCEL_API for opt-in cancellation support

### DIFF
--- a/src/wh_client.c
+++ b/src/wh_client.c
@@ -77,8 +77,10 @@ int wh_Client_Init(whClientContext* c, const whClientConfig* config)
     }
 
     memset(c, 0, sizeof(*c));
+#ifdef WOLFHSM_CFG_CANCEL_API
     /* register the cancel callback */
     c->cancelCb = config->cancelCb;
+#endif
 
     rc = wh_CommClient_Init(c->comm, config->comm);
 
@@ -464,6 +466,7 @@ int wh_Client_CommClose(whClientContext* c)
     return rc;
 }
 
+#ifdef WOLFHSM_CFG_CANCEL_API
 int wh_Client_EnableCancel(whClientContext* c)
 {
     if (c == NULL)
@@ -529,6 +532,7 @@ int wh_Client_Cancel(whClientContext* c)
     }
     return ret;
 }
+#endif /* WOLFHSM_CFG_CANCEL_API */
 
 int wh_Client_EchoRequest(whClientContext* c, uint16_t size, const void* data)
 {

--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -2394,11 +2394,13 @@ int wh_Client_Cmac(whClientContext* ctx, Cmac* cmac, CmacType type,
     if (ret == WH_ERROR_OK) {
         /* Update the local type since call succeeded */
         cmac->type = type;
+#ifdef WOLFHSM_CFG_CANCEL_API
         /* if the client marked they may want to cancel, handle the
          * response in a separate call */
         if (ctx->cancelable) {
             return ret;
         }
+#endif
 
         uint16_t res_len = 0;
         do {
@@ -2434,6 +2436,7 @@ int wh_Client_Cmac(whClientContext* ctx, Cmac* cmac, CmacType type,
 
 #endif /* !NO_AES */
 
+#ifdef WOLFHSM_CFG_CANCEL_API
 int wh_Client_CmacCancelableResponse(whClientContext* c, Cmac* cmac,
                                      uint8_t* out, uint16_t* outSz)
 {
@@ -2485,6 +2488,7 @@ int wh_Client_CmacCancelableResponse(whClientContext* c, Cmac* cmac,
     }
     return ret;
 }
+#endif /* WOLFHSM_CFG_CANCEL_API */
 
 #ifdef WOLFHSM_CFG_DMA
 int wh_Client_CmacDma(whClientContext* ctx, Cmac* cmac, CmacType type,

--- a/src/wh_server.c
+++ b/src/wh_server.c
@@ -149,6 +149,7 @@ int wh_Server_GetConnected(whServerContext *server,
     return WH_ERROR_OK;
 }
 
+#ifdef WOLFHSM_CFG_CANCEL_API
 int wh_Server_GetCanceledSequence(whServerContext* server, uint16_t* outSeq)
 {
     if (server == NULL || outSeq == NULL)
@@ -166,6 +167,7 @@ int wh_Server_SetCanceledSequence(whServerContext* server, uint16_t cancelSeq)
     server->cancelSeq = cancelSeq;
     return WH_ERROR_OK;
 }
+#endif /* WOLFHSM_CFG_CANCEL_API */
 
 static int _wh_Server_HandleCommRequest(whServerContext* server,
         uint16_t magic, uint16_t action, uint16_t seq,
@@ -375,6 +377,7 @@ int wh_Server_HandleRequestMessage(whServerContext* server)
 
         /* Send a response */
         /* TODO: Respond with ErrorResponse if handler returns an error */
+#ifdef WOLFHSM_CFG_CANCEL_API
         if (rc == 0 || rc == WH_ERROR_CANCEL) {
             /* notify the client that their request was canceled */
             if (rc == WH_ERROR_CANCEL) {
@@ -382,6 +385,9 @@ int wh_Server_HandleRequestMessage(whServerContext* server)
                 size = 0;
                 data = NULL;
             }
+#else
+        if (rc == 0) {
+#endif
             do {
                 rc = wh_CommServer_SendResponse(server->comm, magic, kind, seq,
                     size, data);

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -1799,7 +1799,9 @@ static int _HandleCmac(whServerContext* ctx, uint16_t magic, uint16_t seq,
 
     uint32_t i;
     word32 len;
+#ifdef WOLFHSM_CFG_CANCEL_API
     uint16_t cancelSeq;
+#endif
     whKeyId keyId = WH_KEYID_ERASED;
 
     /* Setup fixed size fields */
@@ -1896,12 +1898,16 @@ static int _HandleCmac(whServerContext* ctx, uint16_t magic, uint16_t seq,
                     }
                     ret = wc_CmacUpdate(ctx->crypto->algoCtx.cmac, in + i,
                         blockSz);
+#ifdef WOLFHSM_CFG_CANCEL_API
                     if (ret == 0) {
                         ret = wh_Server_GetCanceledSequence(ctx, &cancelSeq);
                         if (ret == 0 && cancelSeq == seq) {
                             ret = WH_ERROR_CANCEL;
                         }
                     }
+#else
+                    (void)seq;
+#endif
                 }
 #ifdef DEBUG_CRYPTOCB_VERBOSE
                 printf("[server] cmac update done. ret:%d\n", ret);
@@ -1909,8 +1915,13 @@ static int _HandleCmac(whServerContext* ctx, uint16_t magic, uint16_t seq,
             }
             /* do final and evict the struct if outSz is set, otherwise cache the
              * struct for a future call */
+#ifdef WOLFHSM_CFG_CANCEL_API
             if ((ret == 0 && req.outSz != 0) || ret == WH_ERROR_CANCEL) {
                 if (ret != WH_ERROR_CANCEL) {
+#else
+            if (ret == 0 && req.outSz != 0) {
+                {
+#endif
                     keyId = req.keyId;
                     len = req.outSz;
 #ifdef DEBUG_CRYPTOCB_VERBOSE
@@ -1921,7 +1932,11 @@ static int _HandleCmac(whServerContext* ctx, uint16_t magic, uint16_t seq,
                     res.keyId = WH_KEYID_ERASED;
                 }
                 /* evict the key, canceling means abandoning the current state */
+#ifdef WOLFHSM_CFG_CANCEL_API
                 if (ret == 0 || ret == WH_ERROR_CANCEL) {
+#else
+                if (ret == 0) {
+#endif
                     if (!WH_KEYID_ISERASED(keyId)) {
                         /* Don't override return value except on failure */
                         int tmpRet = wh_Server_KeystoreEvictKey(
@@ -2930,9 +2945,13 @@ int wh_Server_HandleCryptoRequest(whServerContext* ctx, uint16_t magic,
     /* Since crypto error codes are propagated to the client in the response
      * packet, return success to the caller unless a cancellation has occurred
      */
+#ifdef WOLFHSM_CFG_CANCEL_API
     if (ret != WH_ERROR_CANCEL) {
         ret = WH_ERROR_OK;
     }
+#else
+    ret = WH_ERROR_OK;
+#endif
     return ret;
 }
 
@@ -4303,9 +4322,13 @@ int wh_Server_HandleCryptoDmaRequest(whServerContext* ctx, uint16_t magic,
     /* Since crypto error codes are propagated to the client in the response
      * packet, return success to the caller unless a cancellation has occurred
      */
+#ifdef WOLFHSM_CFG_CANCEL_API
     if (ret != WH_ERROR_CANCEL) {
         ret = WH_ERROR_OK;
     }
+#else
+    ret = WH_ERROR_OK;
+#endif
     return ret;
 }
 #endif /* WOLFHSM_CFG_DMA */

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -86,14 +86,15 @@ enum {
 int serverDelay = 0;
 #endif
 
-#if defined(WOLFHSM_CFG_TEST_POSIX) && defined(WOLFHSM_CFG_ENABLE_CLIENT) && \
-    defined(WOLFHSM_CFG_ENABLE_SERVER)
+#if defined(WOLFHSM_CFG_IS_TEST_SERVER) && defined(WOLFHSM_CFG_TEST_POSIX) && \
+    defined(WOLFHSM_CFG_ENABLE_CLIENT) && defined(WOLFHSM_CFG_ENABLE_SERVER) && \
+    defined(WOLFHSM_CFG_CANCEL_API)
 /* pointer to expose server context cancel sequence to the client cancel
  * callback */
 static uint16_t* cancelSeqP;
 
-#endif /* WOLFHSM_CFG_TEST_POSIX && WOLFHSM_CFG_ENABLE_CLIENT && \
-          WOLFHSM_CFG_ENABLE_SERVER */
+#endif /* WOLFHSM_CFG_IS_TEST_SERVER && WOLFHSM_CFG_TEST_POSIX && WOLFHSM_CFG_ENABLE_CLIENT && \
+          WOLFHSM_CFG_ENABLE_SERVER && WOLFHSM_CFG_CANCEL_API */
 
 #if defined(WOLFHSM_CFG_TEST_VERBOSE) && defined(WOLFHSM_CFG_ENABLE_CLIENT)
 static int whTest_ShowNvmAvailable(whClientContext* ctx)
@@ -2460,17 +2461,16 @@ static int whTestCrypto_Cmac(whClientContext* ctx, int devId, WC_RNG* rng)
         }
     }
 
-#if !defined(WOLFHSM_CFG_TEST_CLIENT_ONLY_TCP)
+#ifdef WOLFHSM_CFG_CANCEL_API
     /* test CMAC cancellation for supported devIds */
     if (ret == 0
 #ifdef WOLFHSM_CFG_DMA
         && devId != WH_DEV_ID_DMA
 #endif
     ) {
-#ifdef WOLFHSM_CFG_IS_TEST_SERVER
         #define WH_TEST_CMAC_TEXTSIZE 1000
         char cmacFodder[WH_TEST_CMAC_TEXTSIZE] = {0};
-#endif
+        
         ret = wh_Client_EnableCancel(ctx);
         if (ret != 0) {
             WH_ERROR_PRINT("Failed to wh_Client_EnableCancel %d\n", ret);
@@ -2494,7 +2494,9 @@ static int whTestCrypto_Cmac(whClientContext* ctx, int devId, WC_RNG* rng)
                      */
                     /* delay the server so scheduling doesn't interfere with the
                      * timing */
+                    #if 0 /* Temporarily disable server delay for this deliverable - see PR #168 */
                     serverDelay = 1;
+                    #endif
 
                     ret = wc_CmacUpdate(cmac, (byte*)cmacFodder,
                                         sizeof(cmacFodder));
@@ -2508,7 +2510,9 @@ static int whTestCrypto_Cmac(whClientContext* ctx, int devId, WC_RNG* rng)
                                 "Failed to wh_Client_CancelRequest %d\n", ret);
                         }
                         else {
+                            #if 0 /* Temporarily disable server delay for this deliverable - see PR #168 */
                             serverDelay = 0;
+                            #endif
                             do {
                                 ret = wh_Client_CancelResponse(ctx);
                             } while (ret == WH_ERROR_NOTREADY);
@@ -2596,7 +2600,7 @@ static int whTestCrypto_Cmac(whClientContext* ctx, int devId, WC_RNG* rng)
             }
         }
     }
-#endif /* !defined(WOLFHSM_CFG_TEST_CLIENT_ONLY_TCP) */
+#endif /* WOLFHSM_CFG_CANCEL_API */
     if (ret == 0) {
         printf("CMAC DEVID=0x%X SUCCESS\n", devId);
     }
@@ -3508,7 +3512,8 @@ int whTest_CryptoServerConfig(whServerConfig* config)
         return WH_ERROR_BADARGS;
     }
 
-#if defined(WOLFHSM_CFG_TEST_POSIX)
+#if defined(WOLFHSM_CFG_IS_TEST_SERVER) && defined(WOLFHSM_CFG_TEST_POSIX) && \
+    defined(WOLFHSM_CFG_CANCEL_API)
     /* expose server ctx to client cancel callback */
     cancelSeqP = &server->cancelSeq;
 #endif
@@ -3578,6 +3583,7 @@ static void* _whServerTask(void* cf)
 #if defined(WOLFHSM_CFG_TEST_POSIX) && defined(WOLFHSM_CFG_ENABLE_CLIENT) && \
     defined(WOLFHSM_CFG_ENABLE_SERVER)
 
+#if defined(WOLFHSM_CFG_IS_TEST_SERVER) && defined(WOLFHSM_CFG_CANCEL_API)
 /* Test client cancel callback that directly sets the sequence to cancel in the
  * server context */
 static int _cancelCb(uint16_t seq)
@@ -3585,6 +3591,7 @@ static int _cancelCb(uint16_t seq)
     *cancelSeqP = seq;
     return 0;
 }
+#endif
 
 static void _whClientServerThreadTest(whClientConfig* c_conf,
                                 whServerConfig* s_conf)
@@ -3633,7 +3640,13 @@ static int wh_ClientServer_MemThreadTest(void)
     }};
     whClientConfig c_conf[1] = {{
        .comm = cc_conf,
+#ifdef WOLFHSM_CFG_CANCEL_API
+    #ifdef WOLFHSM_CFG_IS_TEST_SERVER
        .cancelCb = _cancelCb,
+    #else
+       .cancelCb = NULL,
+    #endif
+#endif
     }};
     /* Server configuration/contexts */
     whTransportServerCb         tscb[1]   = {WH_TRANSPORT_MEM_SERVER_CB};

--- a/wolfhsm/wh_client.h
+++ b/wolfhsm/wh_client.h
@@ -79,15 +79,19 @@ typedef int (*whClientCancelCb)(uint16_t cancelSeq);
 struct whClientContext_t {
     uint16_t     last_req_id;
     uint16_t     last_req_kind;
+#ifdef WOLFHSM_CFG_CANCEL_API
     uint8_t      cancelable;
-    whCommClient comm[1];
     whClientCancelCb cancelCb;
+#endif
+    whCommClient comm[1];
 };
 typedef struct whClientContext_t whClientContext;
 
 struct whClientConfig_t {
     whCommClientConfig* comm;
+#ifdef WOLFHSM_CFG_CANCEL_API
     whClientCancelCb cancelCb;
+#endif
 };
 typedef struct whClientConfig_t whClientConfig;
 
@@ -318,6 +322,7 @@ int wh_Client_CommInfo(whClientContext* c,
  */
 int wh_Client_CommCloseRequest(whClientContext* c);
 
+#ifdef WOLFHSM_CFG_CANCEL_API
 /**
  * @brief Enables request cancellation.
  *
@@ -376,6 +381,7 @@ int wh_Client_CancelResponse(whClientContext* c);
  *    error code on failure.
  */
 int wh_Client_Cancel(whClientContext* c);
+#endif /* WOLFHSM_CFG_CANCEL_API */
 
 /**
  * @brief Receives a communication close response from the server.

--- a/wolfhsm/wh_server.h
+++ b/wolfhsm/wh_server.h
@@ -221,7 +221,9 @@ struct whServerContext_t {
     whServerCustomCb   customHandlerTable[WOLFHSM_CFG_SERVER_CUSTOMCB_COUNT];
     whServerDmaContext dma;
     int                connected;
+#ifdef WOLFHSM_CFG_CANCEL_API
     uint16_t           cancelSeq;
+#endif
 };
 
 
@@ -284,6 +286,7 @@ int wh_Server_SetConnectedCb(void* s, whCommConnected connected);
 int wh_Server_GetConnected(whServerContext* server,
                            whCommConnected* out_connected);
 
+#ifdef WOLFHSM_CFG_CANCEL_API
 /**
  * @brief Gets the canceled sequence number of the server.
  *
@@ -311,6 +314,7 @@ int wh_Server_GetCanceledSequence(whServerContext* server, uint16_t* outSeq);
  *
  */
 int wh_Server_SetCanceledSequence(whServerContext* server, uint16_t cancelSeq);
+#endif /* WOLFHSM_CFG_CANCEL_API */
 
 /**
  * @brief Handles incoming request messages and dispatches them to the

--- a/wolfhsm/wh_settings.h
+++ b/wolfhsm/wh_settings.h
@@ -79,6 +79,12 @@
  * test harness.
  *     Default: Not defined
  *
+ *  WOLFHSM_CFG_CANCEL_API - If defined, enables the cancellation API support
+ * allowing clients to cancel in-progress operations. This includes the client
+ * cancel functions and server-side cancellation handling. When not defined,
+ * all cancellation code is compiled out.
+ *     Default: Not defined
+ *
  *  Overridable porting functions:
  *
  *  XMEMFENCE() - Create a sequential memory consistency sync point.  Note this


### PR DESCRIPTION
Fix for https://github.com/wolfSSL/wolfHSM/pull/168#pullrequestreview-3218249934

- Revert broad WOLFHSM_CFG_TEST_CLIENT_ONLY_TCP gating
- Add WOLFHSM_CFG_CANCEL_API to compile out cancellation by default  
- Properly guard test server instrumentation with WOLFHSM_CFG_IS_TEST_SERVER
- Disabled serverDelay