### PR TITLE
fix for callback heap hint used

### DIFF
--- a/port/posix/posix_transport_shm.c
+++ b/port/posix/posix_transport_shm.c
@@ -578,7 +578,7 @@ int posixTransportShm_ClientStaticMemDmaCallback(
         isInDma   = 1;
     }
     else {
-        heap = client->dma.heap;
+        heap = posixTransportShm_GetDmaHeap(client->comm->transport_context);
         if (heap == NULL) {
             return WH_ERROR_NOTREADY;
         }


### PR DESCRIPTION
PR (https://github.com/wolfSSL/wolfHSM/pull/158) I missed updating the setting of heap hint in the provided DMA static memory callback function.