### PR TITLE
dma: remove refactor artifact

### DIFF
--- a/wolfhsm/wh_dma.h
+++ b/wolfhsm/wh_dma.h
@@ -45,13 +45,6 @@ typedef enum {
     WH_DMA_OPER_CLIENT_WRITE_POST = 3,
 } whDmaOper;
 
-#ifdef WOLFHSM_CFG_DMA_CUSTOM_CLIENT_COPY
-typedef enum {
-    WH_DMA_COPY_OPER_CLIENT_READ  = 0,
-    WH_DMA_COPY_OPER_CLIENT_WRITE = 1,
-} whDmaCopyOper;
-#endif /* WOLFHSM_CFG_DMA_CUSTOM_CLIENT_COPY */
-
 /* Flags embedded in request/response structs provided by client */
 typedef struct {
     uint8_t cacheForceInvalidate : 1;


### PR DESCRIPTION
9e6a072b added a enum that adds a name clashes when WOLFHSM_CFG_DMA_CUSTOM_CLIENT_COPY is defined. As the enum looks unused, it's probably just a artifact of a refactoring.