### PR TITLE
wh_server: fix server comm not initialized from config

### DIFF
--- a/src/wh_server.c
+++ b/src/wh_server.c
@@ -74,6 +74,11 @@ int wh_Server_Init(whServerContext* server, whServerConfig* config)
     }
 
     memset(server, 0, sizeof(*server));
+    if (config->comm == NULL) {
+        return WH_ERROR_BADARGS;
+    }
+    server->comm = config->comm;
+
     server->nvm = config->nvm;
 
 #ifndef WOLFHSM_CFG_NO_CRYPTO


### PR DESCRIPTION
This PR addresses an issue during **server initialization** (`wh_Server_Init`) by adding a **null pointer check** for the `config->comm` (communication context) parameter. It also explicitly assigns the `comm` context to the `server` context immediately after the check.