### PR TITLE
fix (wh_message): Standardize Message Translation and Enhance Safety

### DIFF
--- a/src/wh_message_comm.c
+++ b/src/wh_message_comm.c
@@ -41,7 +41,7 @@ int wh_MessageComm_TranslateInitRequest(uint16_t magic,
             (dest == NULL)  ) {
         return WH_ERROR_BADARGS;
     }
-    dest->client_id = wh_Translate32(magic, src->client_id);
+    WH_T32(magic, dest, src, client_id);
     return 0;
 }
 
@@ -53,8 +53,8 @@ int wh_MessageComm_TranslateInitResponse(uint16_t magic,
             (dest == NULL)  ) {
         return WH_ERROR_BADARGS;
     }
-    dest->client_id = wh_Translate32(magic, src->client_id);
-    dest->server_id = wh_Translate32(magic, src->server_id);
+    WH_T32(magic, dest, src, client_id);
+    WH_T32(magic, dest, src, server_id);
     return 0;
 }
 
@@ -68,18 +68,18 @@ int wh_MessageComm_TranslateInfoResponse(uint16_t magic,
     }
     memcpy(dest->version, src->version, sizeof(dest->version));
     memcpy(dest->build, src->build, sizeof(dest->build));
-    dest->cfg_comm_data_len = wh_Translate32(magic, src->cfg_comm_data_len);
-    dest->cfg_nvm_object_count = wh_Translate32(magic, src->cfg_nvm_object_count);
-    dest->cfg_server_keycache_count = wh_Translate32(magic, src->cfg_server_keycache_count);
-    dest->cfg_server_keycache_bufsize = wh_Translate32(magic, src->cfg_server_keycache_bufsize);
-    dest->cfg_server_keycache_bigcount = wh_Translate32(magic, src->cfg_server_keycache_bigcount);
-    dest->cfg_server_keycache_bigbufsize = wh_Translate32(magic, src->cfg_server_keycache_bigbufsize);
-    dest->cfg_server_customcb_count = wh_Translate32(magic, src->cfg_server_customcb_count);
-    dest->cfg_server_dmaaddr_count = wh_Translate32(magic, src->cfg_server_dmaaddr_count);
-    dest->debug_state = wh_Translate32(magic, src->debug_state);
-    dest->boot_state = wh_Translate32(magic, src->boot_state);
-    dest->lifecycle_state = wh_Translate32(magic, src->lifecycle_state);
-    dest->nvm_state = wh_Translate32(magic, src->nvm_state);
+    WH_T32(magic, dest, src, cfg_comm_data_len);
+    WH_T32(magic, dest, src, cfg_nvm_object_count);
+    WH_T32(magic, dest, src, cfg_server_keycache_count);
+    WH_T32(magic, dest, src, cfg_server_keycache_bufsize);
+    WH_T32(magic, dest, src, cfg_server_keycache_bigcount);
+    WH_T32(magic, dest, src, cfg_server_keycache_bigbufsize);
+    WH_T32(magic, dest, src, cfg_server_customcb_count);
+    WH_T32(magic, dest, src, cfg_server_dmaaddr_count);
+    WH_T32(magic, dest, src, debug_state);
+    WH_T32(magic, dest, src, boot_state);
+    WH_T32(magic, dest, src, lifecycle_state);
+    WH_T32(magic, dest, src, nvm_state);
     return 0;
 }
 

--- a/src/wh_message_crypto.c
+++ b/src/wh_message_crypto.c
@@ -730,7 +730,7 @@ int wh_MessageCrypto_TranslateMlDsaVerifyResponse(
  */
 
 /* DMA Buffer translation */
-int wh_MessageCrypto_TranslateDmaBuffer(uint16_t                         magic,
+static int wh_MessageCrypto_TranslateDmaBuffer(uint16_t                         magic,
                                         const whMessageCrypto_DmaBuffer* src,
                                         whMessageCrypto_DmaBuffer*       dest)
 {
@@ -743,13 +743,17 @@ int wh_MessageCrypto_TranslateDmaBuffer(uint16_t                         magic,
 }
 
 /* DMA Address status translation */
-int wh_MessageCrypto_TranslateDmaAddrStatus(
+static int wh_MessageCrypto_TranslateDmaAddrStatus(
     uint16_t magic, const whMessageCrypto_DmaAddrStatus* src,
     whMessageCrypto_DmaAddrStatus* dest)
 {
+    if ((src == NULL) || (dest == NULL)) {
+        return WH_ERROR_BADARGS;
+    }
     return wh_MessageCrypto_TranslateDmaBuffer(magic, &src->badAddr,
                                                &dest->badAddr);
 }
+
 /* SHA224 DMA Request translation */
 int wh_MessageCrypto_TranslateSha2DmaRequest(
     uint16_t magic, const whMessageCrypto_Sha2DmaRequest* src,

--- a/src/wh_message_customcb.c
+++ b/src/wh_message_customcb.c
@@ -43,24 +43,16 @@ static void _translateCustomData(uint16_t magic, uint32_t translatedType,
                 /* right now, no further translations required */
             } break;
             case WH_MESSAGE_CUSTOM_CB_TYPE_DMA32: {
-                dst->dma32.client_addr =
-                    wh_Translate32(magic, src->dma32.client_addr);
-                dst->dma32.client_sz =
-                    wh_Translate32(magic, src->dma32.client_sz);
-                dst->dma32.server_addr =
-                    wh_Translate32(magic, src->dma32.server_addr);
-                dst->dma32.server_sz =
-                    wh_Translate32(magic, src->dma32.server_sz);
+                WH_T32(magic, dst, src, dma32.client_addr);
+                WH_T32(magic, dst, src, dma32.client_sz);
+                WH_T32(magic, dst, src, dma32.server_addr);
+                WH_T32(magic, dst, src, dma32.server_sz);
             } break;
             case WH_MESSAGE_CUSTOM_CB_TYPE_DMA64: {
-                dst->dma64.client_addr =
-                    wh_Translate64(magic, src->dma64.client_addr);
-                dst->dma64.client_sz =
-                    wh_Translate64(magic, src->dma64.client_sz);
-                dst->dma64.server_addr =
-                    wh_Translate64(magic, src->dma64.server_addr);
-                dst->dma64.server_sz =
-                    wh_Translate64(magic, src->dma64.server_sz);
+                WH_T64(magic, dst, src, dma64.client_addr);
+                WH_T64(magic, dst, src, dma64.client_sz);
+                WH_T64(magic, dst, src, dma64.server_addr);
+                WH_T64(magic, dst, src, dma64.server_sz);
             } break;
             default: {
                 /* reserved message types - no translation for now */
@@ -82,8 +74,8 @@ int wh_MessageCustomCb_TranslateRequest(uint16_t                         magic,
         return WH_ERROR_BADARGS;
     }
 
-    dst->id   = wh_Translate32(magic, src->id);
-    dst->type = wh_Translate32(magic, src->type);
+    WH_T32(magic, dst, src, id);
+    WH_T32(magic, dst, src, type);
     _translateCustomData(magic, dst->type, &src->data, &dst->data);
 
     return WH_ERROR_OK;
@@ -97,14 +89,13 @@ int wh_MessageCustomCb_TranslateResponse(uint16_t magic,
     if ((src == NULL) || (dst == NULL)) {
         return WH_ERROR_BADARGS;
     }
-
-    dst->rc  = wh_Translate32(magic, src->rc);
-    dst->err = wh_Translate32(magic, src->err);
+    WH_T32(magic, dst, src, rc);
+    WH_T32(magic, dst, src, err);
 
     /* TODO: should we continue to translate responses for err != 0?
      * Probably still should...*/
-    dst->id   = wh_Translate32(magic, src->id);
-    dst->type = wh_Translate32(magic, src->type);
+    WH_T32(magic, dst, src, id);
+    WH_T32(magic, dst, src, type);
     _translateCustomData(magic, dst->type, &src->data, &dst->data);
 
     return WH_ERROR_OK;

--- a/wolfhsm/wh_message_crypto.h
+++ b/wolfhsm/wh_message_crypto.h
@@ -676,7 +676,7 @@ typedef struct {
         uint32_t loLen;
         /* intermediate hash value */
         uint8_t hash[64]; /* TODO (HM) WC_SHA512_DIGEST_SIZE */
-        int     hashType;
+        uint32_t hashType;
     } resumeState;
     /* Flag indicating to the server that this is the last block and it should
      * finalize the hash. If set, inBlock may be only partially full*/
@@ -694,7 +694,7 @@ typedef struct {
     uint32_t hiLen;
     uint32_t loLen;
     uint8_t  hash[64]; /* TODO WC_SHA512_DIGEST_SIZE */
-    int      hashType;
+    uint32_t hashType;
 } whMessageCrypto_Sha2Response;
 
 int wh_MessageCrypto_TranslateSha512Request(


### PR DESCRIPTION
This Pull Request standardizes message field translation using internal macros and implements several fixes to enhance message handling safety and consistency across communication and crypto message files;

**Key changes:**
- Replace wh_Translate32/64 usages with WH_T32/WH_T64/WH_T64 macros in message translation files.
- Make internal DMA translation helpers static and add NULL checks.
- Change hashType from int to uint32_t in wh_message_crypto.h for consistent (de)serialization.