### PR TITLE
Expand ECC tests to cover export and cache key cases

### DIFF
--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -630,7 +630,9 @@ static int whTest_CryptoEcc(whClientContext* ctx, int devId, WC_RNG* rng)
             }
         }
         /* Evict server key regardless of test success */
-        (void)wh_Client_KeyEvict(ctx, keyIdPrivate);
+        if (!WH_KEYID_ISERASED(keyIdPrivate)) {
+            (void)wh_Client_KeyEvict(ctx, keyIdPrivate);
+        }
     }
 
     if (ret == 0) {


### PR DESCRIPTION
This pull request significantly expands and refines the ECC (Elliptic Curve Cryptography) test coverage in `whTest_CryptoEcc` within `test/wh_test_crypto.c`. The changes introduce multiple new ECC test cases that cover ephemeral, exported, and cached server-side keys, and improve the clarity of test output messages for easier debugging and validation.