### PR TITLE
bugfix: add missing key usage flags to message translation

### DIFF
--- a/src/wh_message_cert.c
+++ b/src/wh_message_cert.c
@@ -165,6 +165,7 @@ int wh_MessageCert_TranslateVerifyDmaRequest(
     WH_T32(magic, dest, src, cert_len);
     WH_T16(magic, dest, src, trustedRootNvmId);
     WH_T16(magic, dest, src, flags);
+    WH_T16(magic, dest, src, cachedKeyFlags);
     WH_T16(magic, dest, src, keyId);
     return 0;
 }


### PR DESCRIPTION
Cert verify request message translation was missing a translation for cached key flags, meaning they weren't propagated to server