### PR TITLE
Increase request and response buffers for shared memory posix example

### DIFF
--- a/examples/posix/wh_posix_cfg.h
+++ b/examples/posix/wh_posix_cfg.h
@@ -24,8 +24,8 @@
  * =========================================== */
 
 /* Request and Response Buffer Sizes */
-#define WH_POSIX_REQ_SIZE 1024
-#define WH_POSIX_RESP_SIZE 1024
+#define WH_POSIX_REQ_SIZE 2048
+#define WH_POSIX_RESP_SIZE 2048
 #define WH_POSIX_DMA_SIZE 8000
 
 /* Data Buffer Sizes */


### PR DESCRIPTION
Increase the request and response shared memory buffer size to 2048 from
1024. This fixes a bad args failure when trying to send the generated rsa back to the client since the response buffer was too small.

fixes #266 