### PR TITLE
Reset key and iv prior to aes decryption in crypto demo

### DIFF
--- a/examples/demo/client/wh_demo_client_crypto.c
+++ b/examples/demo/client/wh_demo_client_crypto.c
@@ -853,10 +853,10 @@ int wh_DemoClient_CryptoAesCbc(whClientContext* clientContext)
         }
 
         if (ret == 0) {
-            /* Reset the IV so we can decrypt */
-            ret = wc_AesSetIV(aes, NULL);
+            /* Reset the key schedule for decryption and reset the IV */
+            ret = wc_AesSetKey(aes, key, sizeof(key), NULL, AES_DECRYPTION);
             if (ret != 0) {
-                WOLFHSM_CFG_PRINTF("Failed to wc_AesSetIV %d\n", ret);
+                WOLFHSM_CFG_PRINTF("Failed to wc_AesSetKey %d\n", ret);
             }
         }
 


### PR DESCRIPTION
fixes #287 

Fix AES CBC decryption in the crypto demo by using wc_AesSetKey instead of wc_AesSetIV to properly reset both the key schedule for decryption and the IV before decryptin