### PR TITLE
Fix off-by-one in wh_Utils_memeqzero that skipped checking buffer[0]

### DIFF
--- a/src/wh_utils.c
+++ b/src/wh_utils.c
@@ -83,7 +83,7 @@ uint32_t wh_Utils_ntohl(uint32_t networklong) {
 
 int wh_Utils_memeqzero(uint8_t* buffer, uint32_t size)
 {
-    while (size > 1) {
+    while (size > 0) {
         size--;
         if (buffer[size] != 0)
             return 0;


### PR DESCRIPTION
This pull request makes a small correction to the `wh_Utils_memeqzero` function in `src/wh_utils.c`, fixing the loop condition to ensure all bytes in the buffer are checked.

* Fixed the loop condition in `wh_Utils_memeqzero` to iterate over all bytes, including the first, by changing `while (size > 1)` to `while (size > 0)`.