### PR TITLE
Add explicit read-only permissions to all CI workflow files

### DIFF
--- a/.github/workflows/build-and-bench.yml
+++ b/.github/workflows/build-and-bench.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ '*' ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/build-and-run-examples.yml
+++ b/.github/workflows/build-and-run-examples.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ '*' ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/build-and-test-clientonly.yml
+++ b/.github/workflows/build-and-test-clientonly.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ '*' ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/build-and-test-stress.yml
+++ b/.github/workflows/build-and-test-stress.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ '*' ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/build-and-test-whnvmtool.yml
+++ b/.github/workflows/build-and-test-whnvmtool.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ '*' ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ '*' ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   clang-format-check:
     name: Check PR formatting with clang-format-15

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ '*' ]
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [ main, master ]
 
+permissions:
+  contents: read
+
 jobs:
   cppcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to explicitly set the `permissions` for workflow runs. The main change is the addition of `permissions: contents: read` to each workflow, which improves security by restricting the workflow's access to repository contents.

Security and permissions improvements to GitHub Actions workflows:

* Added `permissions: contents: read` to the following workflow files to restrict workflow token permissions:
  - `.github/workflows/build-and-bench.yml`
  - `.github/workflows/build-and-run-examples.yml`
  - `.github/workflows/build-and-test-clientonly.yml`
  - `.github/workflows/build-and-test-stress.yml`
  - `.github/workflows/build-and-test-whnvmtool.yml`
  - `.github/workflows/build-and-test.yml`
  - `.github/workflows/clang-format-check.yml`
  - `.github/workflows/code-coverage.yml`
  - `.github/workflows/static-analysis.yml`