### PR TITLE
add missing wc_AesFree on AesGcmSetKey failure in key/data unwrap

### DIFF
--- a/src/wh_server_keystore.c
+++ b/src/wh_server_keystore.c
@@ -1037,6 +1037,7 @@ static int _AesGcmKeyUnwrap(whServerContext* server, uint16_t serverKeyId,
 
     ret = wc_AesGcmSetKey(aes, serverKey, serverKeySz);
     if (ret != 0) {
+        wc_AesFree(aes);
         return ret;
     }
 
@@ -1171,6 +1172,7 @@ static int _AesGcmDataUnwrap(whServerContext* server, uint16_t serverKeyId,
 
     ret = wc_AesGcmSetKey(aes, serverKey, serverKeySz);
     if (ret != 0) {
+        wc_AesFree(aes);
         return ret;
     }
 


### PR DESCRIPTION
This pull request introduces a small but important fix to the AES-GCM key handling logic. Specifically, it ensures that resources are properly freed if key setup fails, preventing potential memory leaks.

- Memory management improvements:
  * Added calls to `wc_AesFree(aes)` in both `_AesGcmKeyUnwrap` and `_AesGcmDataUnwrap` to free AES context memory if `wc_AesGcmSetKey` fails. (`src/wh_server_keystore.c`) [[1]](diffhunk://#diff-b73ead40ddfb635a1b47615bc173400e1fff3a98ee590628e9549b43519ba7bcR1040) [[2]](diffhunk://#diff-b73ead40ddfb635a1b47615bc173400e1fff3a98ee590628e9549b43519ba7bcR1175)