### PR TITLE
zero-initialize SHA-224/384/512 response structs

### DIFF
--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -3743,7 +3743,7 @@ static int _HandleSha224(whServerContext* ctx, uint16_t magic, int devId,
     wc_Sha224                     sha224[1];
     (void)ctx;
     whMessageCrypto_Sha256Request req;
-    whMessageCrypto_Sha2Response  res;
+    whMessageCrypto_Sha2Response  res = {0};
 
     /* Validate minimum size */
     if (inSize < sizeof(whMessageCrypto_Sha256Request)) {
@@ -3818,7 +3818,7 @@ static int _HandleSha384(whServerContext* ctx, uint16_t magic, int devId,
     wc_Sha384                     sha384[1];
     (void)ctx;
     whMessageCrypto_Sha512Request req;
-    whMessageCrypto_Sha2Response  res;
+    whMessageCrypto_Sha2Response  res = {0};
 
     /* Validate minimum size */
     if (inSize < sizeof(whMessageCrypto_Sha512Request)) {
@@ -3896,7 +3896,7 @@ static int _HandleSha512(whServerContext* ctx, uint16_t magic, int devId,
     wc_Sha512                     sha512[1];
     (void)ctx;
     whMessageCrypto_Sha512Request req;
-    whMessageCrypto_Sha2Response  res;
+    whMessageCrypto_Sha2Response  res = {0};
     int                           hashType = WC_HASH_TYPE_SHA512;
 
     /* Validate minimum size */


### PR DESCRIPTION
This pull request makes a small but important change to the initialization of the `whMessageCrypto_Sha2Response` structure in several SHA handler functions. The structure is now zero-initialized at declaration to prevent potential issues with uninitialized memory.

- Crypto handler improvements:
  * Zero-initialize the `whMessageCrypto_Sha2Response` variable in the `_HandleSha224`, `_HandleSha384`, and `_HandleSha512` functions in `src/wh_server_crypto.c` to ensure all fields are set to known values before use. [[1]](diffhunk://#diff-446b88572bf243d9336b5ea249b53061536fe2c9d006f36fde4e1b7abdb1c015L3746-R3746) [[2]](diffhunk://#diff-446b88572bf243d9336b5ea249b53061536fe2c9d006f36fde4e1b7abdb1c015L3821-R3821) [[3]](diffhunk://#diff-446b88572bf243d9336b5ea249b53061536fe2c9d006f36fde4e1b7abdb1c015L3899-R3899)