### PR TITLE
Guard SHA client hash block-transfer loops to propagate errors

### DIFF
--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -4433,7 +4433,7 @@ int wh_Client_Sha256(whClientContext* ctx, wc_Sha256* sha256, const uint8_t* in,
 
     /* Caller invoked SHA finalize:
      * wc_CryptoCb_Sha256Hash(sha256, NULL, 0, * hash) */
-    if (out != NULL) {
+    if (ret == 0 && out != NULL) {
         ret = _xferSha256BlockAndUpdateDigest(ctx, sha256, 1);
 
         /* Copy out the final hash value */
@@ -4723,7 +4723,7 @@ int wh_Client_Sha224(whClientContext* ctx, wc_Sha224* sha224, const uint8_t* in,
 
     /* Caller invoked SHA finalize:
      * wc_CryptoCb_Sha224Hash(sha224, NULL, 0, * hash) */
-    if (out != NULL) {
+    if (ret == 0 && out != NULL) {
         ret = _xferSha224BlockAndUpdateDigest(ctx, sha224, 1);
 
         /* Copy out the final hash value */
@@ -5004,7 +5004,7 @@ int wh_Client_Sha384(whClientContext* ctx, wc_Sha384* sha384, const uint8_t* in,
 
     /* Caller invoked SHA finalize:
      * wc_CryptoCb_Sha384Hash(sha384, NULL, 0, * hash) */
-    if (out != NULL) {
+    if (ret == 0 && out != NULL) {
         ret = _xferSha384BlockAndUpdateDigest(ctx, sha384, 1);
 
         /* Copy out the final hash value */
@@ -5284,7 +5284,7 @@ int wh_Client_Sha512(whClientContext* ctx, wc_Sha512* sha512, const uint8_t* in,
 
     /* Caller invoked SHA finalize:
      * wc_CryptoCb_Sha512Hash(sha512, NULL, 0, * hash) */
-    if (out != NULL) {
+    if (ret == 0 && out != NULL) {
         ret = _xferSha512BlockAndUpdateDigest(ctx, sha512, 1);
 
         /* Copy out the final hash value */


### PR DESCRIPTION
This pull request makes a small but important change to the SHA hash processing functions in `src/wh_client_crypto.c`. The update ensures that the block processing loops for SHA-224, SHA-256, SHA-384, and SHA-512 only continue if there have been no errors so far, improving error handling and preventing further processing after a failure.

Improved error handling in SHA hash functions:

* Updated the block processing loops in `wh_Client_Sha224`, `wh_Client_Sha256`, `wh_Client_Sha384`, and `wh_Client_Sha512` to check that `ret == 0` before each iteration, ensuring the loop exits immediately if an error occurs. [[1]](diffhunk://#diff-7a17a6535a5f2b7d1a63255c135acff3635b62f8f5ffd7a39f97b77e6462048dL4420-R4420) [[2]](diffhunk://#diff-7a17a6535a5f2b7d1a63255c135acff3635b62f8f5ffd7a39f97b77e6462048dL4710-R4710) [[3]](diffhunk://#diff-7a17a6535a5f2b7d1a63255c135acff3635b62f8f5ffd7a39f97b77e6462048dL4991-R4991) [[4]](diffhunk://#diff-7a17a6535a5f2b7d1a63255c135acff3635b62f8f5ffd7a39f97b77e6462048dL5271-R5271)