### PR TITLE
Fix SHA-512 Finalize Re-Init Error Overwrite

### DIFF
--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -5298,13 +5298,13 @@ int wh_Client_Sha512(whClientContext* ctx, wc_Sha512* sha512, const uint8_t* in,
          */
         switch (hashType) {
             case WC_HASH_TYPE_SHA512_224:
-                ret = wc_InitSha512_224_ex(sha512, NULL, sha512->devId);
+                (void)wc_InitSha512_224_ex(sha512, NULL, sha512->devId);
                 break;
             case WC_HASH_TYPE_SHA512_256:
-                ret = wc_InitSha512_256_ex(sha512, NULL, sha512->devId);
+                (void)wc_InitSha512_256_ex(sha512, NULL, sha512->devId);
                 break;
             default:
-                ret = wc_InitSha512_ex(sha512, NULL, sha512->devId);
+                (void)wc_InitSha512_ex(sha512, NULL, sha512->devId);
                 break;
         }
     }


### PR DESCRIPTION
This pull request makes a minor change to the `wh_Client_Sha512` function in `src/wh_client_crypto.c` by discarding the return values of hash initialization functions, instead of assigning them to `ret`. This simplifies the code and indicates that the return values are intentionally unused.