### PR TITLE
Unify client/server and NVM setup/teardown

### DIFF
--- a/test/wh_test_cert.c
+++ b/test/wh_test_cert.c
@@ -53,9 +53,6 @@
 static int whTest_CertNonExportable(whClientContext* client);
 #endif
 
-#define FLASH_RAM_SIZE (1024 * 1024) /* 1MB */
-#define FLASH_SECTOR_SIZE (128 * 1024) /* 128KB */
-#define FLASH_PAGE_SIZE (8) /* 8B */
 
 #ifdef WOLFHSM_CFG_ENABLE_SERVER
 /* Run certificate configuration tests */
@@ -583,46 +580,20 @@ static int whTest_CertNonExportable(whClientContext* client)
 #ifdef WOLFHSM_CFG_ENABLE_SERVER
 int whTest_CertRamSim(whTestNvmBackendType nvmType)
 {
-    int            rc          = WH_ERROR_OK;
-    const uint32_t BUFFER_SIZE = 1024;
+    int rc = WH_ERROR_OK;
 
-    /* Transport memory configuration */
-    uint8_t              req[BUFFER_SIZE];
-    uint8_t              resp[BUFFER_SIZE];
-    whTransportMemConfig tmcf[1] = {{
-        .req       = (whTransportMemCsr*)req,
-        .req_size  = sizeof(req),
-        .resp      = (whTransportMemCsr*)resp,
-        .resp_size = sizeof(resp),
-    }};
-
-    /* Server configuration/contexts */
-    whTransportServerCb         tscb[1]    = {WH_TRANSPORT_MEM_SERVER_CB};
-    whTransportMemServerContext tmsc[1]    = {0};
-    whCommServerConfig          cs_conf[1] = {{
-                 .transport_cb      = tscb,
-                 .transport_context = (void*)tmsc,
-                 .transport_config  = (void*)tmcf,
-                 .server_id         = 124,
-    }};
-    /* RamSim Flash state and configuration */
-    uint8_t memory[FLASH_RAM_SIZE] = {0};
-    whFlashRamsimCtx fc[1]      = {0};
-    whFlashRamsimCfg fc_conf[1] = {{
-        .size       = FLASH_RAM_SIZE,    /* 1MB  Flash */
-        .sectorSize = FLASH_SECTOR_SIZE, /* 128KB  Sector Size */
-        .pageSize   = FLASH_PAGE_SIZE,   /* 8B   Page Size */
-        .erasedByte = ~(uint8_t)0,
-        .memory     = memory,
-    }};
-    const whFlashCb  fcb[1]     = {WH_FLASH_RAMSIM_CB};
-
-    whTestNvmBackendUnion nvm_setup;
-    whNvmConfig           n_conf[1] = {0};
-    whNvmContext nvm[1]    = {{0}};
-
+    whTest_ClientServerMemSetup* csSetup = NULL;
+    whCommClientConfig* cc_conf = NULL;
+    whCommServerConfig* cs_conf = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_Init(
+        &csSetup, WH_TEST_DEFAULT_CLIENT_ID, WH_TEST_SERVER_ID, NULL,
+        &cc_conf, &cs_conf));
     WH_TEST_RETURN_ON_FAIL(
-        whTest_NvmCfgBackend(nvmType, &nvm_setup, n_conf, fc_conf, fc, fcb));
+        whTest_ClientServerMemSetup_ResizeBuffers(csSetup, 1024));
+
+    whTest_NvmSetup* nvmSetup = NULL;
+    whNvmContext* nvm = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_NvmSetup_Init(&nvmSetup, nvmType, &nvm));
 
 #ifndef WOLFHSM_CFG_NO_CRYPTO
     whServerCryptoContext crypto[1] = {0};
@@ -638,8 +609,6 @@ int whTest_CertRamSim(whTestNvmBackendType nvmType)
 
     WH_TEST_PRINT("Testing Server Certificate with RAM sim...\n");
 
-    /* Initialize NVM */
-    WH_TEST_RETURN_ON_FAIL(wh_Nvm_Init(nvm, n_conf));
 #ifndef WOLFHSM_CFG_NO_CRYPTO
     WH_TEST_RETURN_ON_FAIL(wolfCrypt_Init());
     WH_TEST_RETURN_ON_FAIL(wc_InitRng_ex(crypto->rng, NULL, INVALID_DEVID));
@@ -651,12 +620,13 @@ int whTest_CertRamSim(whTestNvmBackendType nvmType)
         WH_ERROR_PRINT("Certificate server config tests failed: %d\n", rc);
     }
 
-    /* Cleanup NVM */
-    wh_Nvm_Cleanup(nvm);
+    /* Cleanup */
 #ifndef WOLFHSM_CFG_NO_CRYPTO
     wc_FreeRng(crypto->rng);
     wolfCrypt_Cleanup();
 #endif
+    whTest_NvmSetup_Cleanup(nvmSetup);
+    whTest_ClientServerMemSetup_Cleanup(csSetup);
 
     return rc;
 }

--- a/test/wh_test_clientserver.c
+++ b/test/wh_test_clientserver.c
@@ -60,14 +60,10 @@
 #endif
 
 
-#define BUFFER_SIZE 4096
 #define REQ_SIZE 32
 #define RESP_SIZE 64
 #define REPEAT_COUNT 10
 #define ONE_MS 1000
-#define FLASH_RAM_SIZE (1024 * 1024) /* 1MB */
-#define FLASH_SECTOR_SIZE (128 * 1024) /* 128KB */
-#define FLASH_PAGE_SIZE (8) /* 8B */
 
 #ifdef WOLFHSM_CFG_DMA
 #define DMA_TEST_MEM_NWORDS 3
@@ -569,61 +565,23 @@ int whTest_ClientServerSequential(whTestNvmBackendType nvmType)
 {
     int ret = 0;
 
-    /* Transport memory configuration */
-    uint8_t              req[BUFFER_SIZE];
-    uint8_t              resp[BUFFER_SIZE];
-    whTransportMemConfig tmcf[1] = {{
-        .req       = (whTransportMemCsr*)req,
-        .req_size  = sizeof(req),
-        .resp      = (whTransportMemCsr*)resp,
-        .resp_size = sizeof(resp),
-    }};
-
-    /* Client configuration/contexts */
-    whTransportClientCb         tccb[1]    = {WH_TRANSPORT_MEM_CLIENT_CB};
-    whTransportMemClientContext tmcc[1]    = {0};
-    whCommClientConfig          cc_conf[1] = {{
-                 .transport_cb      = tccb,
-                 .transport_context = (void*)tmcc,
-                 .transport_config  = (void*)tmcf,
-                 .client_id         = WH_TEST_DEFAULT_CLIENT_ID,
-                 .connect_cb        = _clientServerSequentialTestConnectCb,
-    }};
+    /* Set up client/server memory transport using opaque helper */
+    whTest_ClientServerMemSetup* csSetup = NULL;
+    whCommClientConfig* cc_conf = NULL;
+    whCommServerConfig* cs_conf = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_Init(
+        &csSetup, WH_TEST_DEFAULT_CLIENT_ID, WH_TEST_SERVER_ID,
+        _clientServerSequentialTestConnectCb, &cc_conf, &cs_conf));
 
     whClientContext client[1] = {0};
-
     whClientConfig c_conf[1] = {{
         .comm = cc_conf,
     }};
 
-    /* Server configuration/contexts */
-    whTransportServerCb         tscb[1]    = {WH_TRANSPORT_MEM_SERVER_CB};
-    whTransportMemServerContext tmsc[1]    = {0};
-    whCommServerConfig          cs_conf[1] = {{
-                 .transport_cb      = tscb,
-                 .transport_context = (void*)tmsc,
-                 .transport_config  = (void*)tmcf,
-                 .server_id         = 124,
-    }};
-
-    /* RamSim Flash state and configuration */
-    uint8_t memory[FLASH_RAM_SIZE] = {0};
-    whFlashRamsimCtx fc[1]      = {0};
-    whFlashRamsimCfg fc_conf[1] = {{
-        .size       = FLASH_RAM_SIZE,    /* 1MB  Flash */
-        .sectorSize = FLASH_SECTOR_SIZE, /* 128KB  Sector Size */
-        .pageSize   = FLASH_PAGE_SIZE,   /* 8B   Page Size */
-        .erasedByte = ~(uint8_t)0,
-        .memory     = memory,
-    }};
-    const whFlashCb  fcb[1]     = {WH_FLASH_RAMSIM_CB};
-
-    whTestNvmBackendUnion nvm_setup;
-    whNvmConfig           n_conf[1] = {0};
-    whNvmContext nvm[1]    = {{0}};
-
-    WH_TEST_RETURN_ON_FAIL(
-        whTest_NvmCfgBackend(nvmType, &nvm_setup, n_conf, fc_conf, fc, fcb));
+    /* NVM setup using opaque helper */
+    whTest_NvmSetup* nvmSetup = NULL;
+    whNvmContext* nvm = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_NvmSetup_Init(&nvmSetup, nvmType, &nvm));
 
 #ifndef WOLFHSM_CFG_NO_CRYPTO
     whServerCryptoContext crypto[1] = {0};
@@ -647,7 +605,6 @@ int whTest_ClientServerSequential(whTestNvmBackendType nvmType)
     WH_TEST_RETURN_ON_FAIL(wolfCrypt_Init());
     WH_TEST_RETURN_ON_FAIL(wc_InitRng_ex(crypto->rng, NULL, INVALID_DEVID));
 #endif
-    WH_TEST_RETURN_ON_FAIL(wh_Nvm_Init(nvm, n_conf));
 
     /* Server API should return NOTREADY until the server is connected */
     WH_TEST_RETURN_ON_FAIL(wh_Server_GetConnected(server, &server_connected));
@@ -1125,11 +1082,12 @@ int whTest_ClientServerSequential(whTestNvmBackendType nvmType)
     WH_TEST_RETURN_ON_FAIL(wh_Server_Cleanup(server));
     WH_TEST_RETURN_ON_FAIL(wh_Client_Cleanup(client));
 
-    wh_Nvm_Cleanup(nvm);
+    whTest_NvmSetup_Cleanup(nvmSetup);
 #ifndef WOLFHSM_CFG_NO_CRYPTO
     wc_FreeRng(crypto->rng);
     wolfCrypt_Cleanup();
 #endif
+    whTest_ClientServerMemSetup_Cleanup(csSetup);
 
     return ret;
 }
@@ -1562,43 +1520,24 @@ static void _whClientServerThreadTest(whClientConfig* c_conf,
 
 static int wh_ClientServer_MemThreadTest(whTestNvmBackendType nvmType)
 {
-    uint8_t req[BUFFER_SIZE] = {0};
-    uint8_t resp[BUFFER_SIZE] = {0};
+    /* Set up client/server memory transport using opaque helper */
+    whTest_ClientServerMemSetup* csSetup = NULL;
+    whCommClientConfig* cc_conf = NULL;
+    whCommServerConfig* cs_conf = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_Init(
+        &csSetup, WH_TEST_DEFAULT_CLIENT_ID, WH_TEST_SERVER_ID, NULL,
+        &cc_conf, &cs_conf));
 
-    whTransportMemConfig tmcf[1] = {{
-        .req       = (whTransportMemCsr*)req,
-        .req_size  = sizeof(req),
-        .resp      = (whTransportMemCsr*)resp,
-        .resp_size = sizeof(resp),
-    }};
-    /* Client configuration/contexts */
-    whTransportClientCb         tccb[1]   = {WH_TRANSPORT_MEM_CLIENT_CB};
-    whTransportMemClientContext tmcc[1]   = {0};
-    whCommClientConfig          cc_conf[1] = {{
-                 .transport_cb      = tccb,
-                 .transport_context = (void*)tmcc,
-                 .transport_config  = (void*)tmcf,
-                 .client_id         = WH_TEST_DEFAULT_CLIENT_ID,
-    }};
     whClientConfig c_conf[1] = {{
        .comm = cc_conf,
     }};
-    /* Server configuration/contexts */
-    whTransportServerCb         tscb[1]   = {WH_TRANSPORT_MEM_SERVER_CB};
-    whTransportMemServerContext tmsc[1]   = {0};
-    whCommServerConfig          cs_conf[1] = {{
-                 .transport_cb      = tscb,
-                 .transport_context = (void*)tmsc,
-                 .transport_config  = (void*)tmcf,
-                 .server_id         = 124,
-    }};
 
-    /* RamSim Flash state and configuration */
-    uint8_t memory[FLASH_RAM_SIZE] = {0};
+    /* RamSim Flash state and configuration (non-default erasedByte=0) */
+    uint8_t memory[WH_TEST_FLASH_RAM_SIZE] = {0};
     whFlashRamsimCtx fc[1] = {0};
     whFlashRamsimCfg fc_conf[1] = {{
-        .size       = FLASH_RAM_SIZE,
-        .sectorSize = FLASH_RAM_SIZE/2,
+        .size       = WH_TEST_FLASH_RAM_SIZE,
+        .sectorSize = WH_TEST_FLASH_RAM_SIZE/2,
         .pageSize   = 8,
         .erasedByte = (uint8_t)0,
         .memory     = memory,
@@ -1641,6 +1580,7 @@ static int wh_ClientServer_MemThreadTest(whTestNvmBackendType nvmType)
     wc_FreeRng(crypto->rng);
     wolfCrypt_Cleanup();
 #endif
+    whTest_ClientServerMemSetup_Cleanup(csSetup);
 
     return WH_ERROR_OK;
 }
@@ -1650,8 +1590,8 @@ static int wh_ClientServer_PosixMemMapThreadTest(whTestNvmBackendType nvmType)
 {
     posixTransportShmConfig tmcf[1] = {{
         .name       = "/wh_test_clientserver_shm",
-        .req_size   = BUFFER_SIZE,
-        .resp_size  = BUFFER_SIZE,
+        .req_size   = WH_TEST_BUFFER_SIZE,
+        .resp_size  = WH_TEST_BUFFER_SIZE,
     }};
 
     /* Client configuration/contexts */
@@ -1677,11 +1617,11 @@ static int wh_ClientServer_PosixMemMapThreadTest(whTestNvmBackendType nvmType)
     }};
 
     /* RamSim Flash state and configuration */
-    uint8_t memory[FLASH_RAM_SIZE] = {0};
+    uint8_t memory[WH_TEST_FLASH_RAM_SIZE] = {0};
     whFlashRamsimCtx fc[1]      = {0};
     whFlashRamsimCfg fc_conf[1] = {{
-        .size       = FLASH_RAM_SIZE,
-        .sectorSize = FLASH_RAM_SIZE / 2,
+        .size       = WH_TEST_FLASH_RAM_SIZE,
+        .sectorSize = WH_TEST_FLASH_RAM_SIZE / 2,
         .pageSize   = 8,
         .erasedByte = (uint8_t)0,
         .memory     = memory,

--- a/test/wh_test_comm.c
+++ b/test/wh_test_comm.c
@@ -31,7 +31,6 @@
 
 #include "wolfhsm/wh_error.h"
 #include "wolfhsm/wh_comm.h"
-#include "wolfhsm/wh_transport_mem.h"
 
 #ifdef WOLFHSM_CFG_ENABLE_SERVER
 #include "wolfhsm/wh_server.h"
@@ -53,7 +52,6 @@ const struct timespec ONE_MS = {.tv_sec = 0, .tv_nsec = 1000000};
 
 #include "wh_test_comm.h"
 
-#define BUFFER_SIZE 4096
 #define REQ_SIZE 32
 #define RESP_SIZE 64
 #define REPEAT_COUNT 10
@@ -64,37 +62,14 @@ int whTest_CommMem(void)
 {
     int ret = 0;
 
-    /* Transport memory configuration */
-    uint8_t              req[BUFFER_SIZE] = {0};
-    uint8_t              resp[BUFFER_SIZE] = {0};
-    whTransportMemConfig tmcf[1] = {{
-        .req       = (whTransportMemCsr*)req,
-        .req_size  = sizeof(req),
-        .resp      = (whTransportMemCsr*)resp,
-        .resp_size = sizeof(resp),
-    }};
-
-
-    /* Client configuration/contexts */
-    whTransportClientCb         tccb[1]   = {WH_TRANSPORT_MEM_CLIENT_CB};
-    whTransportMemClientContext tmcc[1]   = {0};
-    whCommClientConfig          c_conf[1] = {{
-                 .transport_cb      = tccb,
-                 .transport_context = (void*)tmcc,
-                 .transport_config  = (void*)tmcf,
-                 .client_id         = WH_TEST_DEFAULT_CLIENT_ID,
-    }};
+    /* Set up client/server memory transport using opaque helper */
+    whTest_ClientServerMemSetup* csSetup = NULL;
+    whCommClientConfig* c_conf = NULL;
+    whCommServerConfig* s_conf = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_Init(
+        &csSetup, WH_TEST_DEFAULT_CLIENT_ID, WH_TEST_SERVER_ID, NULL,
+        &c_conf, &s_conf));
     whCommClient                client[1] = {0};
-
-    /* Server configuration/contexts */
-    whTransportServerCb         tscb[1]   = {WH_TRANSPORT_MEM_SERVER_CB};
-    whTransportMemServerContext tmsc[1]   = {0};
-    whCommServerConfig          s_conf[1] = {{
-                 .transport_cb      = tscb,
-                 .transport_context = (void*)tmsc,
-                 .transport_config  = (void*)tmcf,
-                 .server_id         = 124,
-    }};
     whCommServer                server[1] = {0};
 
     /* Init client and server */
@@ -184,6 +159,8 @@ int whTest_CommMem(void)
 
     WH_TEST_RETURN_ON_FAIL(wh_CommServer_Cleanup(server));
     WH_TEST_RETURN_ON_FAIL(wh_CommClient_Cleanup(client));
+
+    whTest_ClientServerMemSetup_Cleanup(csSetup);
 
     return ret;
 }
@@ -368,37 +345,17 @@ static void _whCommClientServerThreadTest(whCommClientConfig* c_conf,
 
 void wh_CommClientServer_MemThreadTest(void)
 {
-    /* Transport memory configuration */
-    uint8_t              req[BUFFER_SIZE] = {0};
-    uint8_t              resp[BUFFER_SIZE] = {0};
-    whTransportMemConfig tmcf[1] = {{
-        .req       = (whTransportMemCsr*)req,
-        .req_size  = sizeof(req),
-        .resp      = (whTransportMemCsr*)resp,
-        .resp_size = sizeof(resp),
-    }};
-
-    /* Client configuration/contexts */
-    whTransportClientCb         tmccb[1]  = {WH_TRANSPORT_MEM_CLIENT_CB};
-    whTransportMemClientContext csc[1]    = {0};
-    whCommClientConfig          c_conf[1] = {{
-                 .transport_cb      = tmccb,
-                 .transport_context = (void*)csc,
-                 .transport_config  = (void*)tmcf,
-                 .client_id         = WH_TEST_DEFAULT_CLIENT_ID,
-    }};
-
-    /* Server configuration/contexts */
-    whTransportServerCb         tmscb[1]  = {WH_TRANSPORT_MEM_SERVER_CB};
-    whTransportMemServerContext css[1]    = {0};
-    whCommServerConfig          s_conf[1] = {{
-                 .transport_cb      = tmscb,
-                 .transport_context = (void*)css,
-                 .transport_config  = (void*)tmcf,
-                 .server_id         = 0xF,
-    }};
+    /* Set up client/server memory transport using opaque helper */
+    whTest_ClientServerMemSetup* csSetup = NULL;
+    whCommClientConfig* c_conf = NULL;
+    whCommServerConfig* s_conf = NULL;
+    whTest_ClientServerMemSetup_Init(
+        &csSetup, WH_TEST_DEFAULT_CLIENT_ID, 0xF, NULL,
+        &c_conf, &s_conf);
 
     _whCommClientServerThreadTest(c_conf, s_conf);
+
+    whTest_ClientServerMemSetup_Cleanup(csSetup);
 }
 
 void wh_CommClientServer_ShMemThreadTest(void)
@@ -406,9 +363,9 @@ void wh_CommClientServer_ShMemThreadTest(void)
     /* Transport memory configuration */
     posixTransportShmConfig tmcf[1] = {{
         .name = "/wh_test_comm_shm",
-        .req_size   = BUFFER_SIZE,
-        .resp_size  = BUFFER_SIZE,
-        .dma_size = BUFFER_SIZE * 4,
+        .req_size   = WH_TEST_BUFFER_SIZE,
+        .resp_size  = WH_TEST_BUFFER_SIZE,
+        .dma_size = WH_TEST_BUFFER_SIZE * 4,
     }};
 
     /* Make unique name for this test */

--- a/test/wh_test_common.c
+++ b/test/wh_test_common.c
@@ -17,15 +17,44 @@
  * along with wolfHSM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdlib.h>
 #include <string.h>
 
 #include <wolfhsm/wh_nvm.h>
 #include <wolfhsm/wh_nvm_flash.h>
 #include <wolfhsm/wh_nvm_flash_log.h>
 #include <wolfhsm/wh_flash_ramsim.h>
+#include <wolfhsm/wh_transport_mem.h>
 #include <wolfhsm/wh_error.h>
 
 #include "wh_test_common.h"
+
+
+/* Opaque struct for client+server memory transport setup */
+struct whTest_ClientServerMemSetup {
+    uint8_t*                    req;
+    uint8_t*                    resp;
+    int                         bufferSize;
+    whTransportMemConfig        transportMemCfg;
+    whTransportClientCb         transportClientCb;
+    whTransportMemClientContext transportMemClientCtx;
+    whCommClientConfig          commClientCfg;
+    whTransportServerCb         transportServerCb;
+    whTransportMemServerContext transportMemServerCtx;
+    whCommServerConfig          commServerCfg;
+};
+
+/* Opaque struct for NVM setup */
+struct whTest_NvmSetup {
+    uint8_t*              memory;
+    int                   flashRamSize;
+    whFlashRamsimCtx      flashRamsimCtx;
+    whFlashRamsimCfg      flashRamsimCfg;
+    whFlashCb             flashCb;
+    whTestNvmBackendUnion nvmBackendUnion;
+    whNvmConfig           nvmConfig;
+    whNvmContext          nvmContext;
+};
 
 
 /**
@@ -89,4 +118,259 @@ int whTest_NvmCfgBackend(whTestNvmBackendType   type,
     }
 
     return 0;
+}
+
+
+/*
+ * Helper to wire (or re-wire) the transport mem config from the current
+ * buffer pointers and size stored in the setup struct.
+ */
+static void _csMemSetup_WireTransportCfg(whTest_ClientServerMemSetup* setup)
+{
+    memset(&setup->transportMemCfg, 0, sizeof(setup->transportMemCfg));
+    setup->transportMemCfg.req       = (whTransportMemCsr*)setup->req;
+    setup->transportMemCfg.req_size  = setup->bufferSize;
+    setup->transportMemCfg.resp      = (whTransportMemCsr*)setup->resp;
+    setup->transportMemCfg.resp_size = setup->bufferSize;
+}
+
+int whTest_ClientServerMemSetup_Init(
+    whTest_ClientServerMemSetup** outSetup,
+    int                           clientId,
+    int                           serverId,
+    whCommSetConnectedCb          connectCb,
+    whCommClientConfig**          outCommClientCfg,
+    whCommServerConfig**          outCommServerCfg)
+{
+    whTest_ClientServerMemSetup* setup;
+
+    if (outSetup == NULL || outCommClientCfg == NULL ||
+        outCommServerCfg == NULL) {
+        return WH_ERROR_BADARGS;
+    }
+
+    setup = malloc(sizeof(*setup));
+    if (setup == NULL) {
+        return WH_ERROR_ABORTED;
+    }
+    memset(setup, 0, sizeof(*setup));
+
+    /* Allocate default-sized buffers */
+    setup->bufferSize = WH_TEST_BUFFER_SIZE;
+    setup->req = malloc(setup->bufferSize);
+    setup->resp = malloc(setup->bufferSize);
+    if (setup->req == NULL || setup->resp == NULL) {
+        free(setup->req);
+        free(setup->resp);
+        free(setup);
+        return WH_ERROR_ABORTED;
+    }
+    memset(setup->req, 0, setup->bufferSize);
+    memset(setup->resp, 0, setup->bufferSize);
+
+    /* Wire transport memory config */
+    _csMemSetup_WireTransportCfg(setup);
+
+    /* Client transport */
+    whTransportClientCb clientCb = WH_TRANSPORT_MEM_CLIENT_CB;
+    setup->transportClientCb = clientCb;
+    memset(&setup->transportMemClientCtx, 0,
+           sizeof(setup->transportMemClientCtx));
+
+    /* Client comm config */
+    memset(&setup->commClientCfg, 0, sizeof(setup->commClientCfg));
+    setup->commClientCfg.transport_cb      = &setup->transportClientCb;
+    setup->commClientCfg.transport_context = (void*)&setup->transportMemClientCtx;
+    setup->commClientCfg.transport_config  = (void*)&setup->transportMemCfg;
+    setup->commClientCfg.client_id         = clientId;
+    setup->commClientCfg.connect_cb        = connectCb;
+
+    /* Server transport */
+    whTransportServerCb serverCb = WH_TRANSPORT_MEM_SERVER_CB;
+    setup->transportServerCb = serverCb;
+    memset(&setup->transportMemServerCtx, 0,
+           sizeof(setup->transportMemServerCtx));
+
+    /* Server comm config */
+    memset(&setup->commServerCfg, 0, sizeof(setup->commServerCfg));
+    setup->commServerCfg.transport_cb      = &setup->transportServerCb;
+    setup->commServerCfg.transport_context = (void*)&setup->transportMemServerCtx;
+    setup->commServerCfg.transport_config  = (void*)&setup->transportMemCfg;
+    setup->commServerCfg.server_id         = serverId;
+
+    *outSetup         = setup;
+    *outCommClientCfg = &setup->commClientCfg;
+    *outCommServerCfg = &setup->commServerCfg;
+
+    return WH_ERROR_OK;
+}
+
+int whTest_ClientServerMemSetup_ResizeBuffers(
+    whTest_ClientServerMemSetup* setup,
+    int                          newBufferSize)
+{
+    uint8_t* newReq;
+    uint8_t* newResp;
+
+    if (setup == NULL || newBufferSize <= 0) {
+        return WH_ERROR_BADARGS;
+    }
+
+    newReq = malloc(newBufferSize);
+    newResp = malloc(newBufferSize);
+    if (newReq == NULL || newResp == NULL) {
+        free(newReq);
+        free(newResp);
+        return WH_ERROR_ABORTED;
+    }
+    memset(newReq, 0, newBufferSize);
+    memset(newResp, 0, newBufferSize);
+
+    /* Free old buffers and install new ones */
+    free(setup->req);
+    free(setup->resp);
+    setup->req        = newReq;
+    setup->resp       = newResp;
+    setup->bufferSize = newBufferSize;
+
+    /* Re-wire the transport config to point at the new buffers */
+    _csMemSetup_WireTransportCfg(setup);
+
+    return WH_ERROR_OK;
+}
+
+int whTest_ClientServerMemSetup_Cleanup(
+    whTest_ClientServerMemSetup* setup)
+{
+    if (setup == NULL) {
+        return WH_ERROR_BADARGS;
+    }
+
+    free(setup->req);
+    free(setup->resp);
+    free(setup);
+
+    return WH_ERROR_OK;
+}
+
+
+int whTest_NvmSetup_Init(
+    whTest_NvmSetup**    outSetup,
+    whTestNvmBackendType nvmType,
+    whNvmContext**       outNvmContext)
+{
+    whTest_NvmSetup* setup;
+    int              rc;
+
+    if (outSetup == NULL || outNvmContext == NULL) {
+        return WH_ERROR_BADARGS;
+    }
+
+    setup = malloc(sizeof(*setup));
+    if (setup == NULL) {
+        return WH_ERROR_ABORTED;
+    }
+    memset(setup, 0, sizeof(*setup));
+
+    /* Allocate default flash memory */
+    setup->flashRamSize = WH_TEST_FLASH_RAM_SIZE;
+    setup->memory = malloc(setup->flashRamSize);
+    if (setup->memory == NULL) {
+        free(setup);
+        return WH_ERROR_ABORTED;
+    }
+    memset(setup->memory, 0, setup->flashRamSize);
+
+    /* Configure flash ramsim */
+    setup->flashRamsimCfg.size       = setup->flashRamSize;
+    setup->flashRamsimCfg.sectorSize = WH_TEST_FLASH_SECTOR_SIZE;
+    setup->flashRamsimCfg.pageSize   = WH_TEST_FLASH_PAGE_SIZE;
+    setup->flashRamsimCfg.erasedByte = ~(uint8_t)0;
+    setup->flashRamsimCfg.memory     = setup->memory;
+
+    {
+        whFlashCb cb = WH_FLASH_RAMSIM_CB;
+        setup->flashCb = cb;
+    }
+
+    /* Configure NVM backend */
+    memset(&setup->nvmConfig, 0, sizeof(setup->nvmConfig));
+    rc = whTest_NvmCfgBackend(nvmType, &setup->nvmBackendUnion,
+                              &setup->nvmConfig, &setup->flashRamsimCfg,
+                              &setup->flashRamsimCtx, &setup->flashCb);
+    if (rc != 0) {
+        free(setup->memory);
+        free(setup);
+        return rc;
+    }
+
+    /* Init NVM */
+    rc = wh_Nvm_Init(&setup->nvmContext, &setup->nvmConfig);
+    if (rc != 0) {
+        free(setup->memory);
+        free(setup);
+        return rc;
+    }
+
+    *outSetup      = setup;
+    *outNvmContext  = &setup->nvmContext;
+
+    return WH_ERROR_OK;
+}
+
+int whTest_NvmSetup_ResizeFlash(
+    whTest_NvmSetup* setup,
+    int              flashRamSize,
+    int              flashSectorSize,
+    int              flashPageSize)
+{
+    uint8_t* newMemory;
+    int      rc;
+
+    if (setup == NULL || flashRamSize <= 0 || flashSectorSize <= 0 ||
+        flashPageSize <= 0) {
+        return WH_ERROR_BADARGS;
+    }
+
+    /* Cleanup existing NVM state */
+    wh_Nvm_Cleanup(&setup->nvmContext);
+
+    /* Reallocate flash memory */
+    newMemory = malloc(flashRamSize);
+    if (newMemory == NULL) {
+        return WH_ERROR_ABORTED;
+    }
+    memset(newMemory, 0, flashRamSize);
+
+    free(setup->memory);
+    setup->memory       = newMemory;
+    setup->flashRamSize = flashRamSize;
+
+    /* Reconfigure flash ramsim */
+    setup->flashRamsimCfg.size       = flashRamSize;
+    setup->flashRamsimCfg.sectorSize = flashSectorSize;
+    setup->flashRamsimCfg.pageSize   = flashPageSize;
+    setup->flashRamsimCfg.memory     = setup->memory;
+
+    /* Re-init NVM */
+    rc = wh_Nvm_Init(&setup->nvmContext, &setup->nvmConfig);
+    if (rc != 0) {
+        return rc;
+    }
+
+    return WH_ERROR_OK;
+}
+
+int whTest_NvmSetup_Cleanup(
+    whTest_NvmSetup* setup)
+{
+    if (setup == NULL) {
+        return WH_ERROR_BADARGS;
+    }
+
+    wh_Nvm_Cleanup(&setup->nvmContext);
+    free(setup->memory);
+    free(setup);
+
+    return WH_ERROR_OK;
 }

--- a/test/wh_test_common.h
+++ b/test/wh_test_common.h
@@ -26,6 +26,7 @@
 #include <assert.h>
 #endif
 
+#include <wolfhsm/wh_comm.h>
 #include <wolfhsm/wh_nvm.h>
 #include <wolfhsm/wh_flash_ramsim.h>
 #include <wolfhsm/wh_nvm_flash.h>
@@ -34,6 +35,13 @@
 #define WH_TEST_FAIL (-1)
 #define WH_TEST_SUCCESS (0)
 #define WH_TEST_DEFAULT_CLIENT_ID (1)
+
+/* Default test configuration constants */
+#define WH_TEST_BUFFER_SIZE       4096
+#define WH_TEST_FLASH_RAM_SIZE    (1024 * 1024)
+#define WH_TEST_FLASH_SECTOR_SIZE (128 * 1024)
+#define WH_TEST_FLASH_PAGE_SIZE   8
+#define WH_TEST_SERVER_ID         124
 
 /* Test-specific print macro that always prints (replacement for printf in tests)
  * This internally uses WOLFHSM_CFG_PRINTF for consistency */
@@ -144,4 +152,48 @@ int whTest_NvmCfgBackend(whTestNvmBackendType   type,
                          whTestNvmBackendUnion* nvmSetup, whNvmConfig* nvmCfg,
                          whFlashRamsimCfg* fCfg, whFlashRamsimCtx* fCtx,
                          const whFlashCb* fCb);
+
+/*
+ * Client+Server memory transport setup helpers.
+ * The struct is opaque; all internal wiring (transport buffers, transport CBs,
+ * transport contexts) is hidden in the .c file.
+ */
+typedef struct whTest_ClientServerMemSetup whTest_ClientServerMemSetup;
+
+int whTest_ClientServerMemSetup_Init(
+    whTest_ClientServerMemSetup** outSetup,
+    int                           clientId,
+    int                           serverId,
+    whCommSetConnectedCb          connectCb,
+    whCommClientConfig**          outCommClientCfg,
+    whCommServerConfig**          outCommServerCfg);
+
+int whTest_ClientServerMemSetup_ResizeBuffers(
+    whTest_ClientServerMemSetup* setup,
+    int                          newBufferSize);
+
+int whTest_ClientServerMemSetup_Cleanup(
+    whTest_ClientServerMemSetup* setup);
+
+/*
+ * NVM setup helpers.
+ * The struct is opaque; all internal wiring (flash ramsim, NVM backend union)
+ * is hidden in the .c file.
+ */
+typedef struct whTest_NvmSetup whTest_NvmSetup;
+
+int whTest_NvmSetup_Init(
+    whTest_NvmSetup**    outSetup,
+    whTestNvmBackendType nvmType,
+    whNvmContext**       outNvmContext);
+
+int whTest_NvmSetup_ResizeFlash(
+    whTest_NvmSetup* setup,
+    int              flashRamSize,
+    int              flashSectorSize,
+    int              flashPageSize);
+
+int whTest_NvmSetup_Cleanup(
+    whTest_NvmSetup* setup);
+
 #endif /* WH_TEST_COMMON_H_ */

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -67,9 +67,6 @@
 #include "port/posix/posix_flash_file.h"
 #endif
 
-#define FLASH_RAM_SIZE (1024 * 1024) /* 1MB */
-#define FLASH_SECTOR_SIZE (128 * 1024) /* 128KB */
-#define FLASH_PAGE_SIZE (8) /* 8B */
 
 #define ALT_CLIENT_ID (2)
 
@@ -6117,26 +6114,18 @@ static void _whClientServerThreadTest(whClientConfig* c_conf,
 
 static int wh_ClientServer_MemThreadTest(whTestNvmBackendType nvmType)
 {
-    int     ret               = 0;
-    uint8_t req[BUFFER_SIZE] = {0};
-    uint8_t resp[BUFFER_SIZE] = {0};
+    whTest_ClientServerMemSetup* csSetup = NULL;
+    whCommClientConfig* cc_conf = NULL;
+    whCommServerConfig* cs_conf = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_Init(
+        &csSetup, WH_TEST_DEFAULT_CLIENT_ID, WH_TEST_SERVER_ID, NULL,
+        &cc_conf, &cs_conf));
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_ResizeBuffers(
+        csSetup, BUFFER_SIZE));
 
-    whTransportMemConfig tmcf[1] = {{
-        .req        = (whTransportMemCsr*)req,
-        .req_size   = sizeof(req),
-        .resp       = (whTransportMemCsr*)resp,
-        .resp_size  = sizeof(resp),
-    }};
-
-    /* Client configuration/contexts */
-    whTransportClientCb         tccb[1]   = {WH_TRANSPORT_MEM_CLIENT_CB};
-    whTransportMemClientContext tmcc[1]   = {0};
-    whCommClientConfig          cc_conf[1] = {{
-                 .transport_cb      = tccb,
-                 .transport_context = (void*)tmcc,
-                 .transport_config  = (void*)tmcf,
-                 .client_id         = WH_TEST_DEFAULT_CLIENT_ID,
-    }};
+    whTest_NvmSetup* nvmSetup = NULL;
+    whNvmContext* nvm = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_NvmSetup_Init(&nvmSetup, nvmType, &nvm));
 
 #ifdef WOLFHSM_CFG_DMA
     whClientDmaConfig clientDmaConfig = {0};
@@ -6148,38 +6137,8 @@ static int wh_ClientServer_MemThreadTest(whTestNvmBackendType nvmType)
 #endif
     }};
 
-    /* Server configuration/contexts */
-    whTransportServerCb         tscb[1]   = {WH_TRANSPORT_MEM_SERVER_CB};
-    whTransportMemServerContext tmsc[1]   = {0};
-    whCommServerConfig          cs_conf[1] = {{
-                 .transport_cb      = tscb,
-                 .transport_context = (void*)tmsc,
-                 .transport_config  = (void*)tmcf,
-                 .server_id         = 124,
-    }};
-
-    /* RamSim Flash state and configuration */
-    uint8_t memory[FLASH_RAM_SIZE] = {0};
-    whFlashRamsimCtx fc[1] = {0};
-    whFlashRamsimCfg fc_conf[1] = {{
-        .size       = FLASH_RAM_SIZE, /* 1MB  Flash */
-        .sectorSize = FLASH_SECTOR_SIZE,  /* 128KB  Sector Size */
-        .pageSize   = FLASH_PAGE_SIZE,           /* 8B   Page Size */
-        .erasedByte = ~(uint8_t)0,
-        .memory     = memory,
-    }};
-    const whFlashCb  fcb[1]          = {WH_FLASH_RAMSIM_CB};
-
-    whTestNvmBackendUnion nvm_setup;
-    whNvmConfig           n_conf[1] = {0};
-    whNvmContext nvm[1] = {{0}};
-
-    WH_TEST_RETURN_ON_FAIL(
-        whTest_NvmCfgBackend(nvmType, &nvm_setup, n_conf, fc_conf, fc, fcb));
-
     /* Crypto context */
     whServerCryptoContext crypto[1] = {0};
-
 
     whServerConfig s_conf[1] = {{
         .comm_config = cs_conf,
@@ -6188,9 +6147,7 @@ static int wh_ClientServer_MemThreadTest(whTestNvmBackendType nvmType)
         .devId       = INVALID_DEVID,
     }};
 
-    WH_TEST_RETURN_ON_FAIL(wh_Nvm_Init(nvm, n_conf));
-
-    ret = wolfCrypt_Init();
+    int ret = wolfCrypt_Init();
     if (ret == 0) {
         ret = wc_InitRng_ex(crypto->rng, NULL, INVALID_DEVID);
         if (ret != 0) {
@@ -6204,9 +6161,10 @@ static int wh_ClientServer_MemThreadTest(whTestNvmBackendType nvmType)
         WH_ERROR_PRINT("Failed to initialize wolfCrypt: %d\n", ret);
     }
 
-    wh_Nvm_Cleanup(nvm);
+    whTest_NvmSetup_Cleanup(nvmSetup);
     wc_FreeRng(crypto->rng);
     wolfCrypt_Cleanup();
+    whTest_ClientServerMemSetup_Cleanup(csSetup);
 
     return WH_ERROR_OK;
 }

--- a/test/wh_test_crypto_affinity.c
+++ b/test/wh_test_crypto_affinity.c
@@ -52,10 +52,6 @@
 #include "wh_test_common.h"
 #include "wh_test_crypto_affinity.h"
 
-#define BUFFER_SIZE 4096
-#define FLASH_RAM_SIZE (1024 * 1024)
-#define FLASH_SECTOR_SIZE (128 * 1024)
-#define FLASH_PAGE_SIZE (8)
 #define TEST_DEV_ID 0xCA
 
 /* Counter to track how many times the crypto callback is invoked */
@@ -100,68 +96,20 @@ static int whTest_CryptoAffinityWithCb(void)
     int      rc       = 0;
     uint32_t affinity = 0;
 
-    /* Transport memory configuration */
-    uint8_t              req[BUFFER_SIZE]  = {0};
-    uint8_t              resp[BUFFER_SIZE] = {0};
-    whTransportMemConfig tmcf[1]           = {{
-                  .req       = (whTransportMemCsr*)req,
-                  .req_size  = sizeof(req),
-                  .resp      = (whTransportMemCsr*)resp,
-                  .resp_size = sizeof(resp),
-    }};
+    whTest_ClientServerMemSetup* csSetup = NULL;
+    whCommClientConfig* cc_conf = NULL;
+    whCommServerConfig* cs_conf = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_Init(
+        &csSetup, 1, 123, _cryptoAffinityTestConnectCb,
+        &cc_conf, &cs_conf));
 
-    /* Client configuration/contexts */
-    whTransportClientCb         tccb[1]    = {WH_TRANSPORT_MEM_CLIENT_CB};
-    whTransportMemClientContext tmcc[1]    = {0};
-    whCommClientConfig          cc_conf[1] = {{
-                 .transport_cb      = tccb,
-                 .transport_context = (void*)tmcc,
-                 .transport_config  = (void*)tmcf,
-                 .client_id         = 1,
-                 .connect_cb        = _cryptoAffinityTestConnectCb,
-    }};
-    whClientConfig              c_conf[1]  = {{
-                      .comm = cc_conf,
-    }};
-    whClientContext             client[1]  = {0};
+    whClientConfig c_conf[1] = {{.comm = cc_conf}};
+    whClientContext client[1] = {0};
 
-    /* Server configuration/contexts */
-    whTransportServerCb         tscb[1]    = {WH_TRANSPORT_MEM_SERVER_CB};
-    whTransportMemServerContext tmsc[1]    = {0};
-    whCommServerConfig          cs_conf[1] = {{
-                 .transport_cb      = tscb,
-                 .transport_context = (void*)tmsc,
-                 .transport_config  = (void*)tmcf,
-                 .server_id         = 123,
-    }};
-
-    /* Flash/NVM configuration */
-    uint8_t          flash_memory[FLASH_RAM_SIZE] = {0};
-    whFlashRamsimCtx fc[1]                        = {0};
-    whFlashRamsimCfg fc_conf[1]                   = {{
-                          .size       = FLASH_RAM_SIZE,
-                          .sectorSize = FLASH_SECTOR_SIZE,
-                          .pageSize   = FLASH_PAGE_SIZE,
-                          .erasedByte = ~(uint8_t)0,
-                          .memory     = flash_memory,
-    }};
-    const whFlashCb  fcb[1]                       = {WH_FLASH_RAMSIM_CB};
-
-    whNvmFlashContext nfc[1]     = {0};
-    whNvmFlashConfig  nf_conf[1] = {{
-         .cb      = fcb,
-         .context = fc,
-         .config  = fc_conf,
-    }};
-
-
-    whNvmCb      nfcb[1]   = {WH_NVM_FLASH_CB};
-    whNvmConfig  n_conf[1] = {{
-         .cb      = nfcb,
-         .context = nfc,
-         .config  = nf_conf,
-    }};
-    whNvmContext nvm[1]    = {0};
+    whTest_NvmSetup* nvmSetup = NULL;
+    whNvmContext* nvm = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_NvmSetup_Init(
+        &nvmSetup, WH_NVM_TEST_BACKEND_FLASH, &nvm));
 
     /* Crypto context */
     whServerCryptoContext crypto[1] = {0};
@@ -182,9 +130,6 @@ static int whTest_CryptoAffinityWithCb(void)
     WH_TEST_RETURN_ON_FAIL(wolfCrypt_Init());
     WH_TEST_RETURN_ON_FAIL(
         wc_CryptoCb_RegisterDevice(TEST_DEV_ID, _testCryptoCb, NULL));
-
-    /* Initialize NVM */
-    WH_TEST_RETURN_ON_FAIL(wh_Nvm_Init(nvm, n_conf));
 
     /* Initialize RNG */
     WH_TEST_RETURN_ON_FAIL(wc_InitRng_ex(crypto->rng, NULL, INVALID_DEVID));
@@ -306,9 +251,10 @@ static int whTest_CryptoAffinityWithCb(void)
     WH_TEST_RETURN_ON_FAIL(wh_Client_Cleanup(client));
 
     wc_FreeRng(crypto->rng);
-    wh_Nvm_Cleanup(nvm);
+    whTest_NvmSetup_Cleanup(nvmSetup);
     wc_CryptoCb_UnRegisterDevice(TEST_DEV_ID);
     wolfCrypt_Cleanup();
+    whTest_ClientServerMemSetup_Cleanup(csSetup);
 
     WH_TEST_PRINT("PASS\n");
     return WH_ERROR_OK;
@@ -320,68 +266,20 @@ static int whTest_CryptoAffinityNoCb(void)
     int      rc       = 0;
     uint32_t affinity = 0;
 
-    /* Transport memory configuration */
-    uint8_t              req[BUFFER_SIZE]  = {0};
-    uint8_t              resp[BUFFER_SIZE] = {0};
-    whTransportMemConfig tmcf[1]           = {{
-                  .req       = (whTransportMemCsr*)req,
-                  .req_size  = sizeof(req),
-                  .resp      = (whTransportMemCsr*)resp,
-                  .resp_size = sizeof(resp),
-    }};
+    whTest_ClientServerMemSetup* csSetup = NULL;
+    whCommClientConfig* cc_conf = NULL;
+    whCommServerConfig* cs_conf = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_Init(
+        &csSetup, 1, 123, _cryptoAffinityTestConnectCb,
+        &cc_conf, &cs_conf));
 
-    /* Client configuration/contexts */
-    whTransportClientCb         tccb[1]    = {WH_TRANSPORT_MEM_CLIENT_CB};
-    whTransportMemClientContext tmcc[1]    = {0};
-    whCommClientConfig          cc_conf[1] = {{
-                 .transport_cb      = tccb,
-                 .transport_context = (void*)tmcc,
-                 .transport_config  = (void*)tmcf,
-                 .client_id         = 1,
-                 .connect_cb        = _cryptoAffinityTestConnectCb,
-    }};
-    whClientConfig              c_conf[1]  = {{
-                      .comm = cc_conf,
-    }};
-    whClientContext             client[1]  = {0};
+    whClientConfig c_conf[1] = {{.comm = cc_conf}};
+    whClientContext client[1] = {0};
 
-    /* Server configuration/contexts */
-    whTransportServerCb         tscb[1]    = {WH_TRANSPORT_MEM_SERVER_CB};
-    whTransportMemServerContext tmsc[1]    = {0};
-    whCommServerConfig          cs_conf[1] = {{
-                 .transport_cb      = tscb,
-                 .transport_context = (void*)tmsc,
-                 .transport_config  = (void*)tmcf,
-                 .server_id         = 123,
-    }};
-
-    /* Flash/NVM configuration */
-    uint8_t          flash_memory[FLASH_RAM_SIZE] = {0};
-    whFlashRamsimCtx fc[1]                        = {0};
-    whFlashRamsimCfg fc_conf[1]                   = {{
-                          .size       = FLASH_RAM_SIZE,
-                          .sectorSize = FLASH_SECTOR_SIZE,
-                          .pageSize   = FLASH_PAGE_SIZE,
-                          .erasedByte = ~(uint8_t)0,
-                          .memory     = flash_memory,
-    }};
-    const whFlashCb  fcb[1]                       = {WH_FLASH_RAMSIM_CB};
-
-    whNvmFlashContext nfc[1]     = {0};
-    whNvmFlashConfig  nf_conf[1] = {{
-         .cb      = fcb,
-         .context = fc,
-         .config  = fc_conf,
-    }};
-
-
-    whNvmCb      nfcb[1]   = {WH_NVM_FLASH_CB};
-    whNvmConfig  n_conf[1] = {{
-         .cb      = nfcb,
-         .context = nfc,
-         .config  = nf_conf,
-    }};
-    whNvmContext nvm[1]    = {0};
+    whTest_NvmSetup* nvmSetup = NULL;
+    whNvmContext* nvm = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_NvmSetup_Init(
+        &nvmSetup, WH_NVM_TEST_BACKEND_FLASH, &nvm));
 
     /* Crypto context */
     whServerCryptoContext crypto[1] = {0};
@@ -400,9 +298,6 @@ static int whTest_CryptoAffinityNoCb(void)
 
     /* Initialize wolfCrypt */
     WH_TEST_RETURN_ON_FAIL(wolfCrypt_Init());
-
-    /* Initialize NVM */
-    WH_TEST_RETURN_ON_FAIL(wh_Nvm_Init(nvm, n_conf));
 
     /* Initialize RNG */
     WH_TEST_RETURN_ON_FAIL(wc_InitRng_ex(crypto->rng, NULL, INVALID_DEVID));
@@ -501,8 +396,9 @@ static int whTest_CryptoAffinityNoCb(void)
     WH_TEST_RETURN_ON_FAIL(wh_Client_Cleanup(client));
 
     wc_FreeRng(crypto->rng);
-    wh_Nvm_Cleanup(nvm);
+    whTest_NvmSetup_Cleanup(nvmSetup);
     wolfCrypt_Cleanup();
+    whTest_ClientServerMemSetup_Cleanup(csSetup);
 
     WH_TEST_PRINT("PASS\n");
     return WH_ERROR_OK;

--- a/test/wh_test_log.c
+++ b/test/wh_test_log.c
@@ -1299,9 +1299,6 @@ static int whTest_LogPosixFile_Generic(void)
 #if defined(WOLFHSM_CFG_TEST_POSIX) && defined(WOLFHSM_CFG_ENABLE_CLIENT) && \
     defined(WOLFHSM_CFG_ENABLE_SERVER)
 
-#define WH_LOG_TEST_FLASH_RAM_SIZE (1024 * 1024)
-#define WH_LOG_TEST_FLASH_SECTOR_SIZE (128 * 1024)
-#define WH_LOG_TEST_FLASH_PAGE_SIZE (8)
 #define WH_LOG_TEST_SERVER_LOG_FILE "/tmp/wh_log_clientserver_posix.txt"
 
 enum {
@@ -1428,24 +1425,14 @@ static void _whLogClientServerThreadTest(whClientConfig* c_conf,
 
 static int whTest_LogClientServerMemTransport(void)
 {
-    uint8_t              req[WH_LOG_TEST_BUFFER_SIZE]  = {0};
-    uint8_t              resp[WH_LOG_TEST_BUFFER_SIZE] = {0};
-    whTransportMemConfig tmcf[1]                       = {{
-                              .req       = (whTransportMemCsr*)req,
-                              .req_size  = sizeof(req),
-                              .resp      = (whTransportMemCsr*)resp,
-                              .resp_size = sizeof(resp),
-    }};
-
-    /* Client configuration */
-    whTransportClientCb         tccb[1]    = {WH_TRANSPORT_MEM_CLIENT_CB};
-    whTransportMemClientContext tmcc[1]    = {{0}};
-    whCommClientConfig          cc_conf[1] = {{
-                 .transport_cb      = tccb,
-                 .transport_context = (void*)tmcc,
-                 .transport_config  = (void*)tmcf,
-                 .client_id         = WH_TEST_DEFAULT_CLIENT_ID,
-    }};
+    whTest_ClientServerMemSetup* csSetup = NULL;
+    whCommClientConfig* cc_conf = NULL;
+    whCommServerConfig* cs_conf = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_Init(
+        &csSetup, WH_TEST_DEFAULT_CLIENT_ID, WH_TEST_SERVER_ID, NULL,
+        &cc_conf, &cs_conf));
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_ResizeBuffers(
+        csSetup, WH_LOG_TEST_BUFFER_SIZE));
 
 #ifdef WOLFHSM_CFG_DMA
     whClientDmaConfig clientDmaConfig = {0};
@@ -1458,33 +1445,10 @@ static int whTest_LogClientServerMemTransport(void)
 #endif
     }};
 
-    /* Server configuration */
-    whTransportServerCb         tscb[1]    = {WH_TRANSPORT_MEM_SERVER_CB};
-    whTransportMemServerContext tmsc[1]    = {{0}};
-    whCommServerConfig          cs_conf[1] = {{
-                 .transport_cb      = tscb,
-                 .transport_context = (void*)tmsc,
-                 .transport_config  = (void*)tmcf,
-                 .server_id         = 124,
-    }};
-
-    uint8_t          memory[WH_LOG_TEST_FLASH_RAM_SIZE] = {0};
-    whFlashRamsimCtx fc[1]                              = {{0}};
-    whFlashRamsimCfg fc_conf[1]                         = {{
-                                .size       = WH_LOG_TEST_FLASH_RAM_SIZE,
-                                .sectorSize = WH_LOG_TEST_FLASH_SECTOR_SIZE,
-                                .pageSize   = WH_LOG_TEST_FLASH_PAGE_SIZE,
-                                .erasedByte = ~(uint8_t)0,
-                                .memory     = memory,
-    }};
-    const whFlashCb  fcb[1]                             = {WH_FLASH_RAMSIM_CB};
-
-    whTestNvmBackendUnion nvm_setup;
-    whNvmConfig           n_conf[1] = {0};
-    whNvmContext          nvm[1] = {{0}};
-
-    WH_TEST_RETURN_ON_FAIL(whTest_NvmCfgBackend(
-        WH_NVM_TEST_BACKEND_FLASH, &nvm_setup, n_conf, fc_conf, fc, fcb));
+    whTest_NvmSetup* nvmSetup = NULL;
+    whNvmContext* nvm = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_NvmSetup_Init(
+        &nvmSetup, WH_NVM_TEST_BACKEND_FLASH, &nvm));
 
 #ifndef WOLFHSM_CFG_NO_CRYPTO
     whServerCryptoContext crypto[1] = {0};
@@ -1513,7 +1477,6 @@ static int whTest_LogClientServerMemTransport(void)
         .logConfig = logConfig,
     }};
 
-    WH_TEST_RETURN_ON_FAIL(wh_Nvm_Init(nvm, n_conf));
 
 #ifndef WOLFHSM_CFG_NO_CRYPTO
     WH_TEST_RETURN_ON_FAIL(wolfCrypt_Init());
@@ -1526,7 +1489,8 @@ static int whTest_LogClientServerMemTransport(void)
     wc_FreeRng(crypto->rng);
     wolfCrypt_Cleanup();
 #endif
-    wh_Nvm_Cleanup(nvm);
+    whTest_NvmSetup_Cleanup(nvmSetup);
+    whTest_ClientServerMemSetup_Cleanup(csSetup);
 
     return WH_ERROR_OK;
 }

--- a/test/wh_test_multiclient.c
+++ b/test/wh_test_multiclient.c
@@ -50,10 +50,6 @@
 #include "wh_test_common.h"
 
 /* Test configuration */
-#define FLASH_RAM_SIZE (1024 * 1024)   /* 1MB */
-#define FLASH_SECTOR_SIZE (128 * 1024) /* 128KB */
-#define FLASH_PAGE_SIZE (8)            /* 8B */
-#define BUFFER_SIZE 4096
 
 #ifdef WOLFHSM_CFG_GLOBAL_KEYS
 /* Test key data */
@@ -1424,81 +1420,31 @@ static int whTest_MultiClientSequential(void)
 {
     int ret = 0;
 
-    /* Transport memory configurations for both clients */
-    static uint8_t       req1[BUFFER_SIZE];
-    static uint8_t       resp1[BUFFER_SIZE];
-    whTransportMemConfig tmcf1[1] = {{
-        .req       = (whTransportMemCsr*)req1,
-        .req_size  = sizeof(req1),
-        .resp      = (whTransportMemCsr*)resp1,
-        .resp_size = sizeof(resp1),
-    }};
+    /* Client-server pair 1 */
+    whTest_ClientServerMemSetup* csSetup1 = NULL;
+    whCommClientConfig* cc_conf1 = NULL;
+    whCommServerConfig* cs_conf1 = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_Init(
+        &csSetup1, WH_TEST_DEFAULT_CLIENT_ID, 101, _connectCb1,
+        &cc_conf1, &cs_conf1));
+    whClientContext client1[1] = {0};
+    whClientConfig c_conf1[1] = {{.comm = cc_conf1}};
 
-    static uint8_t       req2[BUFFER_SIZE];
-    static uint8_t       resp2[BUFFER_SIZE];
-    whTransportMemConfig tmcf2[1] = {{
-        .req       = (whTransportMemCsr*)req2,
-        .req_size  = sizeof(req2),
-        .resp      = (whTransportMemCsr*)resp2,
-        .resp_size = sizeof(resp2),
-    }};
+    /* Client-server pair 2 */
+    whTest_ClientServerMemSetup* csSetup2 = NULL;
+    whCommClientConfig* cc_conf2 = NULL;
+    whCommServerConfig* cs_conf2 = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_Init(
+        &csSetup2, WH_TEST_DEFAULT_CLIENT_ID + 1, 102, _connectCb2,
+        &cc_conf2, &cs_conf2));
+    whClientContext client2[1] = {0};
+    whClientConfig c_conf2[1] = {{.comm = cc_conf2}};
 
-    /* Client 1 configuration */
-    whTransportClientCb         tccb1[1]    = {WH_TRANSPORT_MEM_CLIENT_CB};
-    whTransportMemClientContext tmcc1[1]    = {0};
-    whCommClientConfig          cc_conf1[1] = {{
-                 .transport_cb      = tccb1,
-                 .transport_context = (void*)tmcc1,
-                 .transport_config  = (void*)tmcf1,
-                 .client_id         = WH_TEST_DEFAULT_CLIENT_ID,
-                 .connect_cb        = _connectCb1,
-    }};
-    whClientContext             client1[1]  = {0};
-    whClientConfig              c_conf1[1]  = {{
-                      .comm = cc_conf1,
-    }};
-
-    /* Client 2 configuration */
-    whTransportClientCb         tccb2[1]    = {WH_TRANSPORT_MEM_CLIENT_CB};
-    whTransportMemClientContext tmcc2[1]    = {0};
-    whCommClientConfig          cc_conf2[1] = {{
-                 .transport_cb      = tccb2,
-                 .transport_context = (void*)tmcc2,
-                 .transport_config  = (void*)tmcf2,
-                 .client_id         = WH_TEST_DEFAULT_CLIENT_ID + 1,
-                 .connect_cb        = _connectCb2,
-    }};
-    whClientContext             client2[1]  = {0};
-    whClientConfig              c_conf2[1]  = {{
-                      .comm = cc_conf2,
-    }};
-
-    /* Shared NVM configuration using RamSim Flash */
-    static uint8_t   memory[FLASH_RAM_SIZE] = {0};
-    whFlashRamsimCtx fc[1]                  = {0};
-    whFlashRamsimCfg fc_conf[1]             = {{
-                    .size       = FLASH_RAM_SIZE,
-                    .sectorSize = FLASH_SECTOR_SIZE,
-                    .pageSize   = FLASH_PAGE_SIZE,
-                    .erasedByte = ~(uint8_t)0,
-                    .memory     = memory,
-    }};
-    const whFlashCb  fcb[1]                 = {WH_FLASH_RAMSIM_CB};
-
-    whNvmFlashConfig  nf_conf[1] = {{
-         .cb      = fcb,
-         .context = fc,
-         .config  = fc_conf,
-    }};
-    whNvmFlashContext nfc[1]     = {0};
-    whNvmCb           nfcb[1]    = {WH_NVM_FLASH_CB};
-
-    whNvmConfig  n_conf[1] = {{
-         .cb      = nfcb,
-         .context = nfc,
-         .config  = nf_conf,
-    }};
-    whNvmContext nvm[1]    = {0}; /* Shared NVM */
+    /* Shared NVM */
+    whTest_NvmSetup* nvmSetup = NULL;
+    whNvmContext* nvm = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_NvmSetup_Init(
+        &nvmSetup, WH_NVM_TEST_BACKEND_FLASH, &nvm));
 
 #if !defined(WOLFHSM_CFG_NO_CRYPTO)
     /* Crypto contexts for both servers */
@@ -1507,17 +1453,9 @@ static int whTest_MultiClientSequential(void)
 #endif
 
     /* Server 1 configuration */
-    whTransportServerCb         tscb1[1]    = {WH_TRANSPORT_MEM_SERVER_CB};
-    whTransportMemServerContext tmsc1[1]    = {0};
-    whCommServerConfig          cs_conf1[1] = {{
-                 .transport_cb      = tscb1,
-                 .transport_context = (void*)tmsc1,
-                 .transport_config  = (void*)tmcf1,
-                 .server_id         = 101,
-    }};
-    whServerConfig              s_conf1[1]  = {{
-                      .comm_config = cs_conf1,
-                      .nvm         = nvm, /* Shared NVM */
+    whServerConfig s_conf1[1] = {{
+        .comm_config = cs_conf1,
+        .nvm         = nvm,
 #if !defined(WOLFHSM_CFG_NO_CRYPTO)
         .crypto = crypto1,
 #endif
@@ -1525,18 +1463,9 @@ static int whTest_MultiClientSequential(void)
     whServerContext server1[1] = {0};
 
     /* Server 2 configuration */
-    whTransportServerCb         tscb2[1]    = {WH_TRANSPORT_MEM_SERVER_CB};
-    whTransportMemServerContext tmsc2[1]    = {0};
-    whCommServerConfig          cs_conf2[1] = {{
-                 .transport_cb      = tscb2,
-                 .transport_context = (void*)tmsc2,
-                 .transport_config  = (void*)tmcf2,
-                 .server_id         = 102,
-    }};
-    whServerConfig              s_conf2[1]  = {{
-                      .comm_config = cs_conf2,
-                      .nvm         = nvm, /* Shared NVM */
-
+    whServerConfig s_conf2[1] = {{
+        .comm_config = cs_conf2,
+        .nvm         = nvm,
 #if !defined(WOLFHSM_CFG_NO_CRYPTO)
         .crypto = crypto2,
 #endif
@@ -1554,10 +1483,7 @@ static int whTest_MultiClientSequential(void)
         return ret;
 #endif
 
-    /* Initialize NVM (shared) */
-    ret = wh_Nvm_Init(nvm, n_conf);
-    if (ret != 0)
-        return ret;
+    /* NVM already initialized by whTest_NvmSetup_Init */
 
 #if !defined(WOLFHSM_CFG_NO_CRYPTO)
     /* Initialize RNGs */
@@ -1631,7 +1557,9 @@ static int whTest_MultiClientSequential(void)
     wc_FreeRng(crypto2->rng);
     wolfCrypt_Cleanup();
 #endif
-    wh_Nvm_Cleanup(nvm);
+    whTest_NvmSetup_Cleanup(nvmSetup);
+    whTest_ClientServerMemSetup_Cleanup(csSetup1);
+    whTest_ClientServerMemSetup_Cleanup(csSetup2);
 
     WH_TEST_PRINT("=== Multi-Client Sequential Tests Complete ===\n");
 

--- a/test/wh_test_server_img_mgr.c
+++ b/test/wh_test_server_img_mgr.c
@@ -54,9 +54,6 @@
 
 #include "wh_test_common.h"
 
-#define FLASH_RAM_SIZE (1024 * 1024) /* 1MB */
-#define FLASH_SECTOR_SIZE (128 * 1024) /* 128KB */
-#define FLASH_PAGE_SIZE (8) /* 8B */
 
 /* Test data to be "verified" */
 static const uint8_t testData[] = {
@@ -1194,47 +1191,20 @@ static int whTest_ServerImgMgrServerCfgRsa2048(whServerConfig* serverCfg)
 
 int whTest_ServerImgMgr(whTestNvmBackendType nvmType)
 {
-    int            rc          = 0;
-    const uint32_t BUFFER_SIZE = 1024;
+    int rc = 0;
 
-    /* Transport memory configuration */
-    uint8_t              req[BUFFER_SIZE];
-    uint8_t              resp[BUFFER_SIZE];
-    whTransportMemConfig tmcf[1] = {{
-        .req       = (whTransportMemCsr*)req,
-        .req_size  = sizeof(req),
-        .resp      = (whTransportMemCsr*)resp,
-        .resp_size = sizeof(resp),
-    }};
-
-    /* Server configuration/contexts */
-    whTransportServerCb         tscb[1]    = {WH_TRANSPORT_MEM_SERVER_CB};
-    whTransportMemServerContext tmsc[1]    = {0};
-    whCommServerConfig          cs_conf[1] = {{
-                 .transport_cb      = tscb,
-                 .transport_context = (void*)tmsc,
-                 .transport_config  = (void*)tmcf,
-                 .server_id         = 124,
-    }};
-
-    /* RamSim Flash state and configuration */
-    uint8_t memory[FLASH_RAM_SIZE] = {0};
-    whFlashRamsimCtx fc[1]      = {0};
-    whFlashRamsimCfg fc_conf[1] = {{
-        .size       = FLASH_RAM_SIZE,    /* 1MB Flash */
-        .sectorSize = FLASH_SECTOR_SIZE, /* 128KB Sector Size */
-        .pageSize   = FLASH_PAGE_SIZE,   /* 8B Page Size */
-        .erasedByte = ~(uint8_t)0,
-        .memory     = memory,
-    }};
-    const whFlashCb  fcb[1]     = {WH_FLASH_RAMSIM_CB};
-
-    whTestNvmBackendUnion nvm_setup;
-    whNvmConfig           n_conf[1] = {0};
-    whNvmContext nvm[1]    = {{0}};
-
+    whTest_ClientServerMemSetup* csSetup = NULL;
+    whCommClientConfig* cc_conf = NULL;
+    whCommServerConfig* cs_conf = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_Init(
+        &csSetup, WH_TEST_DEFAULT_CLIENT_ID, WH_TEST_SERVER_ID, NULL,
+        &cc_conf, &cs_conf));
     WH_TEST_RETURN_ON_FAIL(
-        whTest_NvmCfgBackend(nvmType, &nvm_setup, n_conf, fc_conf, fc, fcb));
+        whTest_ClientServerMemSetup_ResizeBuffers(csSetup, 1024));
+
+    whTest_NvmSetup* nvmSetup = NULL;
+    whNvmContext* nvm = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_NvmSetup_Init(&nvmSetup, nvmType, &nvm));
 
     whServerCryptoContext crypto[1] = {0};
 
@@ -1244,13 +1214,6 @@ int whTest_ServerImgMgr(whTestNvmBackendType nvmType)
         .crypto      = crypto,
     }};
 
-    /* Initialize NVM */
-    rc = wh_Nvm_Init(nvm, n_conf);
-    if (rc != 0) {
-        WH_ERROR_PRINT("Failed to initialize NVM: %d\n", rc);
-        return rc;
-    }
-
     /* Run image manager server config tests for each built-in verify method */
 
 #ifdef HAVE_ECC
@@ -1258,7 +1221,8 @@ int whTest_ServerImgMgr(whTestNvmBackendType nvmType)
     rc = whTest_ServerImgMgrServerCfgEcc256(s_conf);
     if (rc != 0) {
         WH_ERROR_PRINT("ECC P256 image manager server config tests failed: %d\n", rc);
-        wh_Nvm_Cleanup(nvm);
+        whTest_NvmSetup_Cleanup(nvmSetup);
+        whTest_ClientServerMemSetup_Cleanup(csSetup);
         return rc;
     }
 #endif /* HAVE_ECC */
@@ -1269,7 +1233,8 @@ int whTest_ServerImgMgr(whTestNvmBackendType nvmType)
     if (rc != 0) {
         WH_ERROR_PRINT("AES128 CMAC image manager server config tests failed: %d\n",
                rc);
-        wh_Nvm_Cleanup(nvm);
+        whTest_NvmSetup_Cleanup(nvmSetup);
+        whTest_ClientServerMemSetup_Cleanup(csSetup);
         return rc;
     }
 #endif /* WOLFSSL_CMAC */
@@ -1279,13 +1244,15 @@ int whTest_ServerImgMgr(whTestNvmBackendType nvmType)
     rc = whTest_ServerImgMgrServerCfgRsa2048(s_conf);
     if (rc != 0) {
         WH_ERROR_PRINT("RSA2048 image manager server config tests failed: %d\n", rc);
-        wh_Nvm_Cleanup(nvm);
+        whTest_NvmSetup_Cleanup(nvmSetup);
+        whTest_ClientServerMemSetup_Cleanup(csSetup);
         return rc;
     }
 #endif /* !NO_RSA */
 
-    /* Cleanup NVM */
-    wh_Nvm_Cleanup(nvm);
+    /* Cleanup */
+    whTest_NvmSetup_Cleanup(nvmSetup);
+    whTest_ClientServerMemSetup_Cleanup(csSetup);
 
     return rc;
 }

--- a/test/wh_test_she.c
+++ b/test/wh_test_she.c
@@ -80,9 +80,6 @@ enum {
                   WOLFHSM_CFG_COMM_DATA_LEN,
 };
 
-#define FLASH_RAM_SIZE (1024 * 1024) /* 1MB */
-#define FLASH_SECTOR_SIZE (128 * 1024) /* 128KB */
-#define FLASH_PAGE_SIZE (8) /* 8B */
 
 #ifdef WOLFHSM_CFG_ENABLE_CLIENT
 /* Helper function to destroy a SHE key so the unit tests don't
@@ -670,64 +667,23 @@ static void _whClientServerThreadTest(whClientConfig*   c_conf,
 
 static int wh_ClientServer_MemThreadTest(whTestSheClientFn clientFn)
 {
-    uint8_t req[BUFFER_SIZE] = {0};
-    uint8_t resp[BUFFER_SIZE] = {0};
+    whTest_ClientServerMemSetup* csSetup = NULL;
+    whCommClientConfig* cc_conf = NULL;
+    whCommServerConfig* cs_conf = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_Init(
+        &csSetup, WH_TEST_DEFAULT_CLIENT_ID, WH_TEST_SERVER_ID, NULL,
+        &cc_conf, &cs_conf));
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_ResizeBuffers(
+        csSetup, BUFFER_SIZE));
 
-    whTransportMemConfig tmcf[1] = {{
-        .req       = (whTransportMemCsr*)req,
-        .req_size  = sizeof(req),
-        .resp      = (whTransportMemCsr*)resp,
-        .resp_size = sizeof(resp),
-    }};
-    /* Client configuration/contexts */
-    whTransportClientCb         tccb[1]   = {WH_TRANSPORT_MEM_CLIENT_CB};
-    whTransportMemClientContext tmcc[1]   = {0};
-    whCommClientConfig          cc_conf[1] = {{
-                 .transport_cb      = tccb,
-                 .transport_context = (void*)tmcc,
-                 .transport_config  = (void*)tmcf,
-                 .client_id         = WH_TEST_DEFAULT_CLIENT_ID,
-    }};
     whClientConfig c_conf[1] = {{
        .comm = cc_conf,
     }};
-    /* Server configuration/contexts */
-    whTransportServerCb         tscb[1]   = {WH_TRANSPORT_MEM_SERVER_CB};
-    whTransportMemServerContext tmsc[1]   = {0};
-    whCommServerConfig          cs_conf[1] = {{
-                 .transport_cb      = tscb,
-                 .transport_context = (void*)tmsc,
-                 .transport_config  = (void*)tmcf,
-                 .server_id         = 124,
-    }};
 
-    /* RamSim Flash state and configuration */
-    uint8_t memory[FLASH_RAM_SIZE] = {0};
-    whFlashRamsimCtx fc[1] = {0};
-    whFlashRamsimCfg fc_conf[1] = {{
-        .size       = FLASH_RAM_SIZE,     /* 1MB  Flash */
-        .sectorSize = FLASH_SECTOR_SIZE,  /* 128KB  Sector Size */
-        .pageSize   = FLASH_PAGE_SIZE,    /* 8B   Page Size */
-        .erasedByte = ~(uint8_t)0,
-        .memory     = memory,
-    }};
-    const whFlashCb  fcb[1]          = {WH_FLASH_RAMSIM_CB};
-
-    /* NVM Flash Configuration using RamSim HAL Flash */
-    whNvmFlashConfig nf_conf[1] = {{
-        .cb      = fcb,
-        .context = fc,
-        .config  = fc_conf,
-    }};
-    whNvmFlashContext nfc[1] = {0};
-    whNvmCb nfcb[1] = {WH_NVM_FLASH_CB};
-
-    whNvmConfig n_conf[1] = {{
-            .cb = nfcb,
-            .context = nfc,
-            .config = nf_conf,
-    }};
-    whNvmContext nvm[1] = {{0}};
+    whTest_NvmSetup* nvmSetup = NULL;
+    whNvmContext* nvm = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_NvmSetup_Init(
+        &nvmSetup, WH_NVM_TEST_BACKEND_FLASH, &nvm));
 
     /* Crypto context */
     whServerCryptoContext crypto[1] = {0};
@@ -735,7 +691,7 @@ static int wh_ClientServer_MemThreadTest(whTestSheClientFn clientFn)
     whServerSheContext she[1];
     memset(she, 0, sizeof(she));
 
-    whServerConfig                  s_conf[1] = {{
+    whServerConfig s_conf[1] = {{
        .comm_config = cs_conf,
        .nvm = nvm,
        .crypto = crypto,
@@ -743,16 +699,15 @@ static int wh_ClientServer_MemThreadTest(whTestSheClientFn clientFn)
        .devId = INVALID_DEVID,
     }};
 
-    WH_TEST_RETURN_ON_FAIL(wh_Nvm_Init(nvm, n_conf));
-
     WH_TEST_RETURN_ON_FAIL(wolfCrypt_Init());
     WH_TEST_RETURN_ON_FAIL(wc_InitRng_ex(crypto->rng, NULL, INVALID_DEVID));
 
     _whClientServerThreadTest(c_conf, s_conf, clientFn);
 
-    wh_Nvm_Cleanup(nvm);
+    whTest_NvmSetup_Cleanup(nvmSetup);
     wc_FreeRng(crypto->rng);
     wolfCrypt_Cleanup();
+    whTest_ClientServerMemSetup_Cleanup(csSetup);
 
     return WH_ERROR_OK;
 }
@@ -771,49 +726,19 @@ static int wh_She_TestMasterEcuKeyFallback(void)
     whKeyId         masterEcuKeyId;
 
     /* Transport (not used, but required for server init) */
-    uint8_t                     reqBuf[BUFFER_SIZE]  = {0};
-    uint8_t                     respBuf[BUFFER_SIZE] = {0};
-    whTransportMemConfig        tmcf[1]              = {{
-                            .req       = (whTransportMemCsr*)reqBuf,
-                            .req_size  = sizeof(reqBuf),
-                            .resp      = (whTransportMemCsr*)respBuf,
-                            .resp_size = sizeof(respBuf),
-    }};
-    whTransportServerCb         tscb[1]    = {WH_TRANSPORT_MEM_SERVER_CB};
-    whTransportMemServerContext tmsc[1]    = {0};
-    whCommServerConfig          cs_conf[1] = {{
-                 .transport_cb      = tscb,
-                 .transport_context = (void*)tmsc,
-                 .transport_config  = (void*)tmcf,
-                 .server_id         = 124,
-    }};
+    whTest_ClientServerMemSetup* csSetup = NULL;
+    whCommClientConfig* cc_conf = NULL;
+    whCommServerConfig* cs_conf = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_Init(
+        &csSetup, WH_TEST_DEFAULT_CLIENT_ID, WH_TEST_SERVER_ID, NULL,
+        &cc_conf, &cs_conf));
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_ResizeBuffers(
+        csSetup, BUFFER_SIZE));
 
-    /* RamSim Flash state and configuration */
-    uint8_t          memory[FLASH_RAM_SIZE] = {0};
-    whFlashRamsimCtx fc[1]                  = {0};
-    whFlashRamsimCfg fc_conf[1]             = {{
-                    .size       = FLASH_RAM_SIZE,
-                    .sectorSize = FLASH_SECTOR_SIZE,
-                    .pageSize   = FLASH_PAGE_SIZE,
-                    .erasedByte = ~(uint8_t)0,
-                    .memory     = memory,
-    }};
-    const whFlashCb  fcb[1]                 = {WH_FLASH_RAMSIM_CB};
-
-    /* NVM */
-    whNvmFlashConfig  nf_conf[1] = {{
-         .cb      = fcb,
-         .context = fc,
-         .config  = fc_conf,
-    }};
-    whNvmFlashContext nfc[1]     = {0};
-    whNvmCb           nfcb[1]    = {WH_NVM_FLASH_CB};
-    whNvmConfig       n_conf[1]  = {{
-               .cb      = nfcb,
-               .context = nfc,
-               .config  = nf_conf,
-    }};
-    whNvmContext      nvm[1]     = {{0}};
+    whTest_NvmSetup* nvmSetup = NULL;
+    whNvmContext* nvm = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_NvmSetup_Init(
+        &nvmSetup, WH_NVM_TEST_BACKEND_FLASH, &nvm));
 
     /* Crypto context */
     whServerCryptoContext crypto[1] = {0};
@@ -829,7 +754,6 @@ static int wh_She_TestMasterEcuKeyFallback(void)
         .devId       = INVALID_DEVID,
     }};
 
-    WH_TEST_RETURN_ON_FAIL(wh_Nvm_Init(nvm, n_conf));
     WH_TEST_RETURN_ON_FAIL(wolfCrypt_Init());
     WH_TEST_RETURN_ON_FAIL(wc_InitRng_ex(crypto->rng, NULL, s_conf->devId));
     WH_TEST_RETURN_ON_FAIL(wh_Server_Init(server, s_conf));
@@ -854,9 +778,10 @@ static int wh_She_TestMasterEcuKeyFallback(void)
     WH_TEST_PRINT("SHE master ECU key fallback metadata test SUCCESS\n");
 
     wh_Server_Cleanup(server);
-    wh_Nvm_Cleanup(nvm);
+    whTest_NvmSetup_Cleanup(nvmSetup);
     wc_FreeRng(crypto->rng);
     wolfCrypt_Cleanup();
+    whTest_ClientServerMemSetup_Cleanup(csSetup);
 
     return 0;
 }

--- a/test/wh_test_timeout.c
+++ b/test/wh_test_timeout.c
@@ -55,10 +55,6 @@
 #if defined(WOLFHSM_CFG_TEST_POSIX) && defined(WOLFHSM_CFG_ENABLE_SERVER) && \
     !defined(WOLFHSM_CFG_NO_CRYPTO) && defined(HAVE_AES_CBC)
 
-#define TIMEOUT_TEST_BUFFER_SIZE 4096
-#define TIMEOUT_TEST_FLASH_RAM_SIZE (1024 * 1024)
-#define TIMEOUT_TEST_FLASH_SECTOR_SIZE (128 * 1024)
-#define TIMEOUT_TEST_FLASH_PAGE_SIZE 8
 
 static whServerContext* timeoutTestServerCtx = NULL;
 
@@ -80,16 +76,6 @@ static int whTest_TimeoutAesCbc(void)
     int rc = 0;
     WH_TEST_PRINT("Testing timeout AES CBC...\n");
 
-    /* Transport memory configuration */
-    uint8_t              req[TIMEOUT_TEST_BUFFER_SIZE]  = {0};
-    uint8_t              resp[TIMEOUT_TEST_BUFFER_SIZE] = {0};
-    whTransportMemConfig tmcf[1]                        = {{
-                               .req       = (whTransportMemCsr*)req,
-                               .req_size  = sizeof(req),
-                               .resp      = (whTransportMemCsr*)resp,
-                               .resp_size = sizeof(resp),
-    }};
-
     /* Client configuration with timeout */
     posixTimeoutContext posixCtx       = {0};
     posixTimeoutConfig  posixCfg       = {.timeoutUs = 1};
@@ -102,49 +88,21 @@ static int whTest_TimeoutAesCbc(void)
                 .expiredCtx = NULL,
     };
 
-    whTransportClientCb         tccb[1]    = {WH_TRANSPORT_MEM_CLIENT_CB};
-    whTransportMemClientContext tmcc[1]    = {0};
-    whCommClientConfig          cc_conf[1] = {{
-                 .transport_cb      = tccb,
-                 .transport_context = (void*)tmcc,
-                 .transport_config  = (void*)tmcf,
-                 .client_id         = WH_TEST_DEFAULT_CLIENT_ID,
-                 .connect_cb        = _timeoutTestConnectCb,
-                 .respTimeoutConfig = &timeoutCfg,
-    }};
-    whClientConfig              c_conf[1]  = {{
-                      .comm = cc_conf,
-    }};
-    whClientContext             client[1]  = {0};
+    whTest_ClientServerMemSetup* csSetup = NULL;
+    whCommClientConfig* cc_conf = NULL;
+    whCommServerConfig* cs_conf = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_Init(
+        &csSetup, WH_TEST_DEFAULT_CLIENT_ID, WH_TEST_SERVER_ID,
+        _timeoutTestConnectCb, &cc_conf, &cs_conf));
+    cc_conf->respTimeoutConfig = &timeoutCfg;
 
-    /* Server configuration */
-    whTransportServerCb         tscb[1]    = {WH_TRANSPORT_MEM_SERVER_CB};
-    whTransportMemServerContext tmsc[1]    = {0};
-    whCommServerConfig          cs_conf[1] = {{
-                 .transport_cb      = tscb,
-                 .transport_context = (void*)tmsc,
-                 .transport_config  = (void*)tmcf,
-                 .server_id         = 124,
-    }};
+    whClientConfig c_conf[1] = {{.comm = cc_conf}};
+    whClientContext client[1] = {0};
 
-    /* Flash/NVM configuration */
-    uint8_t          flash_memory[TIMEOUT_TEST_FLASH_RAM_SIZE] = {0};
-    whFlashRamsimCtx fc[1]                                     = {0};
-    whFlashRamsimCfg fc_conf[1]                                = {{
-                                       .size       = TIMEOUT_TEST_FLASH_RAM_SIZE,
-                                       .sectorSize = TIMEOUT_TEST_FLASH_SECTOR_SIZE,
-                                       .pageSize   = TIMEOUT_TEST_FLASH_PAGE_SIZE,
-                                       .erasedByte = ~(uint8_t)0,
-                                       .memory     = flash_memory,
-    }};
-    const whFlashCb  fcb[1] = {WH_FLASH_RAMSIM_CB};
-
-    whTestNvmBackendUnion nvm_setup;
-    whNvmConfig           n_conf[1] = {0};
-    whNvmContext          nvm[1]    = {{0}};
-
-    WH_TEST_RETURN_ON_FAIL(whTest_NvmCfgBackend(
-        WH_NVM_TEST_BACKEND_FLASH, &nvm_setup, n_conf, fc_conf, fc, fcb));
+    whTest_NvmSetup* nvmSetup = NULL;
+    whNvmContext* nvm = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_NvmSetup_Init(
+        &nvmSetup, WH_NVM_TEST_BACKEND_FLASH, &nvm));
 
     whServerCryptoContext crypto[1] = {0};
 
@@ -159,7 +117,6 @@ static int whTest_TimeoutAesCbc(void)
     timeoutTestServerCtx = server;
 
     WH_TEST_RETURN_ON_FAIL(wolfCrypt_Init());
-    WH_TEST_RETURN_ON_FAIL(wh_Nvm_Init(nvm, n_conf));
     WH_TEST_RETURN_ON_FAIL(wc_InitRng_ex(crypto->rng, NULL, INVALID_DEVID));
 
     /* Server must be initialized before client (connect callback) */
@@ -205,8 +162,9 @@ static int whTest_TimeoutAesCbc(void)
     WH_TEST_RETURN_ON_FAIL(wh_Client_Cleanup(client));
 
     wc_FreeRng(crypto->rng);
-    wh_Nvm_Cleanup(nvm);
+    whTest_NvmSetup_Cleanup(nvmSetup);
     wolfCrypt_Cleanup();
+    whTest_ClientServerMemSetup_Cleanup(csSetup);
 
     return WH_ERROR_OK;
 }
@@ -239,16 +197,6 @@ static int whTest_TimeoutAesCbcOverride(void)
     int cb_count = 0;
     WH_TEST_PRINT("Testing timeout AES CBC with override callback...\n");
 
-    /* Transport memory configuration */
-    uint8_t              req[TIMEOUT_TEST_BUFFER_SIZE]  = {0};
-    uint8_t              resp[TIMEOUT_TEST_BUFFER_SIZE] = {0};
-    whTransportMemConfig tmcf[1]                        = {{
-                               .req       = (whTransportMemCsr*)req,
-                               .req_size  = sizeof(req),
-                               .resp      = (whTransportMemCsr*)resp,
-                               .resp_size = sizeof(resp),
-    }};
-
     /* Client configuration with timeout and override callback */
     posixTimeoutContext posixCtx       = {0};
     posixTimeoutConfig  posixCfg       = {.timeoutUs = 1};
@@ -261,49 +209,21 @@ static int whTest_TimeoutAesCbcOverride(void)
                 .expiredCtx = &cb_count,
     };
 
-    whTransportClientCb         tccb[1]    = {WH_TRANSPORT_MEM_CLIENT_CB};
-    whTransportMemClientContext tmcc[1]    = {0};
-    whCommClientConfig          cc_conf[1] = {{
-                 .transport_cb      = tccb,
-                 .transport_context = (void*)tmcc,
-                 .transport_config  = (void*)tmcf,
-                 .client_id         = WH_TEST_DEFAULT_CLIENT_ID,
-                 .connect_cb        = _timeoutTestConnectCb,
-                 .respTimeoutConfig = &timeoutCfg,
-    }};
-    whClientConfig              c_conf[1]  = {{
-                      .comm = cc_conf,
-    }};
-    whClientContext             client[1]  = {0};
+    whTest_ClientServerMemSetup* csSetup = NULL;
+    whCommClientConfig* cc_conf = NULL;
+    whCommServerConfig* cs_conf = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_Init(
+        &csSetup, WH_TEST_DEFAULT_CLIENT_ID, WH_TEST_SERVER_ID,
+        _timeoutTestConnectCb, &cc_conf, &cs_conf));
+    cc_conf->respTimeoutConfig = &timeoutCfg;
 
-    /* Server configuration */
-    whTransportServerCb         tscb[1]    = {WH_TRANSPORT_MEM_SERVER_CB};
-    whTransportMemServerContext tmsc[1]    = {0};
-    whCommServerConfig          cs_conf[1] = {{
-                 .transport_cb      = tscb,
-                 .transport_context = (void*)tmsc,
-                 .transport_config  = (void*)tmcf,
-                 .server_id         = 124,
-    }};
+    whClientConfig c_conf[1] = {{.comm = cc_conf}};
+    whClientContext client[1] = {0};
 
-    /* Flash/NVM configuration */
-    uint8_t          flash_memory[TIMEOUT_TEST_FLASH_RAM_SIZE] = {0};
-    whFlashRamsimCtx fc[1]                                     = {0};
-    whFlashRamsimCfg fc_conf[1]                                = {{
-                                       .size       = TIMEOUT_TEST_FLASH_RAM_SIZE,
-                                       .sectorSize = TIMEOUT_TEST_FLASH_SECTOR_SIZE,
-                                       .pageSize   = TIMEOUT_TEST_FLASH_PAGE_SIZE,
-                                       .erasedByte = ~(uint8_t)0,
-                                       .memory     = flash_memory,
-    }};
-    const whFlashCb  fcb[1] = {WH_FLASH_RAMSIM_CB};
-
-    whTestNvmBackendUnion nvm_setup;
-    whNvmConfig           n_conf[1] = {0};
-    whNvmContext          nvm[1]    = {{0}};
-
-    WH_TEST_RETURN_ON_FAIL(whTest_NvmCfgBackend(
-        WH_NVM_TEST_BACKEND_FLASH, &nvm_setup, n_conf, fc_conf, fc, fcb));
+    whTest_NvmSetup* nvmSetup = NULL;
+    whNvmContext* nvm = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_NvmSetup_Init(
+        &nvmSetup, WH_NVM_TEST_BACKEND_FLASH, &nvm));
 
     whServerCryptoContext crypto[1] = {0};
 
@@ -318,7 +238,6 @@ static int whTest_TimeoutAesCbcOverride(void)
     timeoutTestServerCtx = server;
 
     WH_TEST_RETURN_ON_FAIL(wolfCrypt_Init());
-    WH_TEST_RETURN_ON_FAIL(wh_Nvm_Init(nvm, n_conf));
     WH_TEST_RETURN_ON_FAIL(wc_InitRng_ex(crypto->rng, NULL, INVALID_DEVID));
 
     /* Server must be initialized before client (connect callback) */
@@ -368,8 +287,9 @@ static int whTest_TimeoutAesCbcOverride(void)
     WH_TEST_RETURN_ON_FAIL(wh_Client_Cleanup(client));
 
     wc_FreeRng(crypto->rng);
-    wh_Nvm_Cleanup(nvm);
+    whTest_NvmSetup_Cleanup(nvmSetup);
     wolfCrypt_Cleanup();
+    whTest_ClientServerMemSetup_Cleanup(csSetup);
 
     return WH_ERROR_OK;
 }
@@ -454,14 +374,6 @@ int whTest_TimeoutPosix(void)
 {
     WH_TEST_PRINT("Testing timeout (POSIX)...\n");
 
-    uint8_t              req[4096]      = {0};
-    uint8_t              resp[4096]     = {0};
-    whTransportMemConfig tmcf[1]        = {{
-               .req       = (whTransportMemCsr*)req,
-               .req_size  = sizeof(req),
-               .resp      = (whTransportMemCsr*)resp,
-               .resp_size = sizeof(resp),
-    }};
     posixTimeoutContext  posixCtx       = {0};
     posixTimeoutConfig   posixCfg       = {.timeoutUs = 1};
     whTimeoutCb          timeoutCbTable = POSIX_TIMEOUT_CB;
@@ -470,20 +382,20 @@ int whTest_TimeoutPosix(void)
                  .context = &posixCtx,
                  .config  = &posixCfg,
     };
-    whTransportClientCb         tccb[1]   = {WH_TRANSPORT_MEM_CLIENT_CB};
-    whTransportMemClientContext tmcc[1]   = {0};
-    whCommClientConfig          ccConf[1] = {{
-                 .transport_cb      = tccb,
-                 .transport_context = (void*)tmcc,
-                 .transport_config  = (void*)tmcf,
-                 .client_id         = WH_TEST_DEFAULT_CLIENT_ID,
-                 .respTimeoutConfig = &timeoutCfg,
-    }};
-    whClientConfig              cConf[1]  = {{
-                      .comm = ccConf,
-    }};
 
-    return whTest_TimeoutClientConfig(cConf);
+    whTest_ClientServerMemSetup* csSetup = NULL;
+    whCommClientConfig* ccConf = NULL;
+    whCommServerConfig* csConf = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_Init(
+        &csSetup, WH_TEST_DEFAULT_CLIENT_ID, WH_TEST_SERVER_ID, NULL,
+        &ccConf, &csConf));
+    ccConf->respTimeoutConfig = &timeoutCfg;
+
+    whClientConfig cConf[1] = {{.comm = ccConf}};
+
+    int rc = whTest_TimeoutClientConfig(cConf);
+    whTest_ClientServerMemSetup_Cleanup(csSetup);
+    return rc;
 }
 #endif /* WOLFHSM_CFG_TEST_POSIX */
 

--- a/test/wh_test_wolfcrypt_test.c
+++ b/test/wh_test_wolfcrypt_test.c
@@ -71,7 +71,6 @@
 
 
 #define BUFFER_SIZE (1024 * 8)
-#define FLASH_RAM_SIZE (1024 * 1024) /* 1MB */
 
 #if defined(WOLFHSM_CFG_ENABLE_CLIENT) && !defined(NO_CRYPT_TEST)
 int whTest_WolfCryptTestCfg(whClientConfig* config)
@@ -179,44 +178,23 @@ static void _whClientServerThreadTest(whClientConfig* c_conf,
 
 static int wh_ClientServer_MemThreadTest(void)
 {
-    int     ret               = 0;
-    uint8_t req[BUFFER_SIZE]  = {0};
-    uint8_t resp[BUFFER_SIZE] = {0};
+    whTest_ClientServerMemSetup* csSetup = NULL;
+    whCommClientConfig* cc_conf = NULL;
+    whCommServerConfig* cs_conf = NULL;
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_Init(
+        &csSetup, WH_TEST_DEFAULT_CLIENT_ID, WH_TEST_SERVER_ID, NULL,
+        &cc_conf, &cs_conf));
+    WH_TEST_RETURN_ON_FAIL(whTest_ClientServerMemSetup_ResizeBuffers(
+        csSetup, BUFFER_SIZE));
 
-    whTransportMemConfig tmcf[1] = {{
-        .req       = (whTransportMemCsr*)req,
-        .req_size  = sizeof(req),
-        .resp      = (whTransportMemCsr*)resp,
-        .resp_size = sizeof(resp),
-    }};
-    /* Client configuration/contexts */
-    whTransportClientCb         tccb[1]    = {WH_TRANSPORT_MEM_CLIENT_CB};
-    whTransportMemClientContext tmcc[1]    = {0};
-    whCommClientConfig          cc_conf[1] = {{
-                 .transport_cb      = tccb,
-                 .transport_context = (void*)tmcc,
-                 .transport_config  = (void*)tmcf,
-                 .client_id         = WH_TEST_DEFAULT_CLIENT_ID,
-    }};
-    whClientConfig              c_conf[1]  = {{
-                      .comm = cc_conf,
-    }};
-    /* Server configuration/contexts */
-    whTransportServerCb         tscb[1]    = {WH_TRANSPORT_MEM_SERVER_CB};
-    whTransportMemServerContext tmsc[1]    = {0};
-    whCommServerConfig          cs_conf[1] = {{
-                 .transport_cb      = tscb,
-                 .transport_context = (void*)tmsc,
-                 .transport_config  = (void*)tmcf,
-                 .server_id         = 124,
-    }};
+    whClientConfig c_conf[1] = {{.comm = cc_conf}};
 
     /* RamSim Flash state and configuration */
-    uint8_t memory[FLASH_RAM_SIZE] = {0};
+    uint8_t memory[WH_TEST_FLASH_RAM_SIZE] = {0};
     whFlashRamsimCtx fc[1]      = {0};
     whFlashRamsimCfg fc_conf[1] = {{
-        .size       = FLASH_RAM_SIZE,
-        .sectorSize = FLASH_RAM_SIZE / 2,
+        .size       = WH_TEST_FLASH_RAM_SIZE,
+        .sectorSize = WH_TEST_FLASH_RAM_SIZE / 2,
         .pageSize   = 8,
         .erasedByte = (uint8_t)0,
         .memory     = memory,
@@ -250,7 +228,7 @@ static int wh_ClientServer_MemThreadTest(void)
 
     WH_TEST_RETURN_ON_FAIL(wh_Nvm_Init(nvm, n_conf));
 
-    ret = wolfCrypt_Init();
+    int ret = wolfCrypt_Init();
     if (ret == 0) {
         ret = wc_InitRng_ex(crypto->rng, NULL, INVALID_DEVID);
         if (ret != 0) {
@@ -267,6 +245,7 @@ static int wh_ClientServer_MemThreadTest(void)
     wh_Nvm_Cleanup(nvm);
     wc_FreeRng(crypto->rng);
     wolfCrypt_Cleanup();
+    whTest_ClientServerMemSetup_Cleanup(csSetup);
 
     return WH_ERROR_OK;
 }


### PR DESCRIPTION
First pass unification of repetitious test code. Net reduction is about 600 lines.

To ensure that this does not significantly alter the test flows, I generated a coverage comparison script. The output below shows effectively the same level of coverage in the unit tests between this branch and `main`.

```
➜ /git/experiments/hsm-coverage/compare_coverage.sh /git/wolfHSM/coverage_out/main_summary.txt /git/wolfHSM/coverage_out/padelsbach_client-server-test-unify_summary.txt
==============================================================================
  Coverage Comparison
  Baseline: main
  Target:   padelsbach_client-server-test-unify
==============================================================================

--- Files with changed coverage ---

  File                                       Coverage        Delta    Exec           Lines
  -----------------------------------------------------------------------------------------------
  /git/wolfHSM/src/wh_server_crypto.c         83% ->  83%  (+0%)  exec: 2184->2181  lines: 2630->2627
  /git/wolfHSM/src/wh_server_keystore.c       84% ->  84%  (+0%)  exec: 792->792  lines: 938->936

--- Summary totals ---

                         Baseline     Target      Delta
  ----------------------------------------------------
  Total lines               14255      14250         -5
  Lines executed            11964      11961         -3
  Line coverage               83%        83%        +0%

  Files in baseline: 43
  Files in target:   43
```