### PR TITLE
Fix uint16_t truncation

### DIFF
--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -2704,11 +2704,12 @@ int wh_Client_Ed25519Sign(whClientContext* ctx, ed25519_key* key,
         return WH_ERROR_BADARGS;
     }
 
-    uint16_t req_len = sizeof(whMessageCrypto_GenericRequestHeader) +
-                       sizeof(*req) + msgLen + contextLen;
-    if (req_len > WOLFHSM_CFG_COMM_DATA_LEN) {
+    uint32_t total_len = sizeof(whMessageCrypto_GenericRequestHeader) +
+                         sizeof(*req) + msgLen + contextLen;
+    if (total_len > WOLFHSM_CFG_COMM_DATA_LEN) {
         return WH_ERROR_BADARGS;
     }
+    uint16_t req_len = (uint16_t)total_len;
 
     if (WH_KEYID_ISERASED(key_id)) {
         uint8_t    keyLabel[] = "TempEd25519Sign";
@@ -2820,9 +2821,9 @@ int wh_Client_Ed25519Verify(whClientContext* ctx, ed25519_key* key,
     whMessageCrypto_Ed25519VerifyResponse* res     = NULL;
     uint8_t*                               dataPtr = NULL;
     whKeyId  key_id  = WH_DEVCTX_TO_KEYID(key->devCtx);
-    int      evict   = 0;
-    uint16_t req_len = sizeof(whMessageCrypto_GenericRequestHeader) +
-                       sizeof(*req) + sigLen + msgLen + contextLen;
+    int      evict     = 0;
+    uint32_t total_len = sizeof(whMessageCrypto_GenericRequestHeader) +
+                         sizeof(*req) + sigLen + msgLen + contextLen;
 
     if ((ctx == NULL) || (key == NULL) || (sig == NULL) || (msg == NULL) ||
         (out_res == NULL) || ((context == NULL) && (contextLen > 0))) {
@@ -2840,9 +2841,10 @@ int wh_Client_Ed25519Verify(whClientContext* ctx, ed25519_key* key,
         return WH_ERROR_BADARGS;
     }
 
-    if (req_len > WOLFHSM_CFG_COMM_DATA_LEN) {
+    if (total_len > WOLFHSM_CFG_COMM_DATA_LEN) {
         return WH_ERROR_BADARGS;
     }
+    uint16_t req_len = (uint16_t)total_len;
 
     *out_res = 0;
 
@@ -3712,8 +3714,12 @@ static int _HkdfMakeKey(whClientContext* ctx, int hashType, whKeyId keyIdIn,
         dataPtr, WC_ALGO_TYPE_KDF, WC_KDF_TYPE_HKDF, ctx->cryptoAffinity);
 
     /* Calculate request length including variable-length data */
-    uint16_t req_len = sizeof(whMessageCrypto_GenericRequestHeader) +
-                       sizeof(*req) + inKeySz + saltSz + infoSz;
+    uint32_t total_len = sizeof(whMessageCrypto_GenericRequestHeader) +
+                         sizeof(*req) + inKeySz + saltSz + infoSz;
+    if (total_len > WOLFHSM_CFG_COMM_DATA_LEN) {
+        return WH_ERROR_BADARGS;
+    }
+    uint16_t req_len = (uint16_t)total_len;
 
     /* Use the supplied key id if provided */
     if (inout_key_id != NULL) {
@@ -5710,8 +5716,8 @@ int wh_Client_MlDsaSign(whClientContext* ctx, const byte* in, word32 in_len,
         uint16_t group  = WH_MESSAGE_GROUP_CRYPTO;
         uint16_t action = WC_ALGO_TYPE_PK;
 
-        uint16_t req_len = sizeof(whMessageCrypto_GenericRequestHeader) +
-                           sizeof(*req) + in_len + contextLen;
+        uint32_t total_len = sizeof(whMessageCrypto_GenericRequestHeader) +
+                             sizeof(*req) + in_len + contextLen;
         uint32_t options = 0;
 
         /* Get data pointer from the context to use as request/response storage
@@ -5727,7 +5733,8 @@ int wh_Client_MlDsaSign(whClientContext* ctx, const byte* in, word32 in_len,
                 dataPtr, WC_PK_TYPE_PQC_SIG_SIGN, WC_PQC_SIG_TYPE_DILITHIUM,
                 ctx->cryptoAffinity);
 
-        if (req_len <= WOLFHSM_CFG_COMM_DATA_LEN) {
+        if (total_len <= WOLFHSM_CFG_COMM_DATA_LEN) {
+            uint16_t req_len = (uint16_t)total_len;
             uint8_t* req_data = (uint8_t*)(req + 1);
             if (evict != 0) {
                 options |= WH_MESSAGE_CRYPTO_MLDSA_SIGN_OPTIONS_EVICT;
@@ -5845,8 +5852,8 @@ int wh_Client_MlDsaVerify(whClientContext* ctx, const byte* sig, word32 sig_len,
         uint16_t action  = WC_ALGO_TYPE_PK;
         uint32_t options = 0;
 
-        uint16_t req_len = sizeof(whMessageCrypto_GenericRequestHeader) +
-                           sizeof(*req) + sig_len + msg_len + contextLen;
+        uint32_t total_len = sizeof(whMessageCrypto_GenericRequestHeader) +
+                             sizeof(*req) + sig_len + msg_len + contextLen;
 
 
         /* Get data pointer from the context to use as request/response storage
@@ -5862,7 +5869,8 @@ int wh_Client_MlDsaVerify(whClientContext* ctx, const byte* sig, word32 sig_len,
                                             WC_PQC_SIG_TYPE_DILITHIUM,
                                             ctx->cryptoAffinity);
 
-        if (req_len <= WOLFHSM_CFG_COMM_DATA_LEN) {
+        if (total_len <= WOLFHSM_CFG_COMM_DATA_LEN) {
+            uint16_t req_len = (uint16_t)total_len;
             uint8_t* req_sig  = (uint8_t*)(req + 1);
             uint8_t* req_hash = req_sig + sig_len;
 


### PR DESCRIPTION
… functions by using uint32_t for intermediate length computation before bounds check
This pull request addresses a medium-severity bug involving potential integer truncation when calculating request lengths in several cryptographic functions. The main fix is to use a wider integer type (`uint32_t`) for intermediate length computations, ensuring that values are properly validated before being cast to `uint16_t`. This prevents silent wrapping and potential security issues when handling large data sizes.

**Bug documentation and guidance:**

* Added a new file, `bug-fix.txt`, documenting the bug, its impact, and recommended steps for confirming and fixing similar issues in the future. The file specifically describes the integer truncation bug in `wh_Client_MlDsaSign` and `wh_Client_MlDsaVerify` and provides a pattern for safe length computation.

**Length computation and validation fixes:**

* Updated `wh_Client_Ed25519Sign`, `wh_Client_Ed25519Verify`, `wh_Client_MlDsaSign`, `wh_Client_MlDsaVerify`, and `_HkdfMakeKey` functions in `src/wh_client_crypto.c` to:
  - Compute request lengths using `uint32_t` for all intermediate calculations.
  - Validate the `uint32_t` value against `WOLFHSM_CFG_COMM_DATA_LEN` before casting to `uint16_t`.
  - Only assign to `uint16_t req_len` after passing the bounds check, following the recommended safe pattern. [[1]](diffhunk://#diff-7a17a6535a5f2b7d1a63255c135acff3635b62f8f5ffd7a39f97b77e6462048dL2707-R2712) [[2]](diffhunk://#diff-7a17a6535a5f2b7d1a63255c135acff3635b62f8f5ffd7a39f97b77e6462048dL2824-R2825) [[3]](diffhunk://#diff-7a17a6535a5f2b7d1a63255c135acff3635b62f8f5ffd7a39f97b77e6462048dL2843-R2847) [[4]](diffhunk://#diff-7a17a6535a5f2b7d1a63255c135acff3635b62f8f5ffd7a39f97b77e6462048dL3715-R3722) [[5]](diffhunk://#diff-7a17a6535a5f2b7d1a63255c135acff3635b62f8f5ffd7a39f97b77e6462048dL5713-R5719) [[6]](diffhunk://#diff-7a17a6535a5f2b7d1a63255c135acff3635b62f8f5ffd7a39f97b77e6462048dL5730-R5737) [[7]](diffhunk://#diff-7a17a6535a5f2b7d1a63255c135acff3635b62f8f5ffd7a39f97b77e6462048dL5848-R5855) [[8]](diffhunk://#diff-7a17a6535a5f2b7d1a63255c135acff3635b62f8f5ffd7a39f97b77e6462048dL5865-R5873)