### PR TITLE
Various fixes

### DIFF
--- a/benchmark/bench_modules/wh_bench_mod_rsa.c
+++ b/benchmark/bench_modules/wh_bench_mod_rsa.c
@@ -16,6 +16,7 @@
  * You should have received a copy of the GNU General Public License
  * along with wolfHSM.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include <string.h>
 #include "wh_bench_mod.h"
 #include "wolfhsm/wh_error.h"
 #include "wolfhsm/wh_client.h"
@@ -384,10 +385,11 @@ int _benchRsaCrypt(whClientContext* client, whBenchOpContext* ctx, int id,
         goto exit;
     }
 
-    strcpy((char*)inBuf, inStr);
+    strncpy((char*)inBuf, inStr, sizeof(inBuf)-1);
+    inBuf[sizeof(inBuf)-1] = '\0';
 
     /* Do an initial encryption to get the size of the output */
-    encSz = ret = wc_RsaPublicEncrypt(inBuf, sizeof(inStr), outBuf,
+    encSz = ret = wc_RsaPublicEncrypt(inBuf, strlen(inStr), outBuf,
                                       sizeof(outBuf), rsa, rng);
     if (ret < 0) {
         WH_BENCH_PRINTF("Failed to wc_RsaPublicEncrypt %d\n", ret);
@@ -408,7 +410,7 @@ int _benchRsaCrypt(whClientContext* client, whBenchOpContext* ctx, int id,
 
         if (operation == RSA_PUBLIC_ENCRYPT) {
             benchStartRet = wh_Bench_StartOp(ctx, id);
-            opRet         = wc_RsaPublicEncrypt(inBuf, sizeof(inStr), outBuf,
+            opRet         = wc_RsaPublicEncrypt(inBuf, strlen(inStr), outBuf,
                                                 sizeof(outBuf), rsa, rng);
             benchStopRet  = wh_Bench_StopOp(ctx, id);
         }

--- a/benchmark/wh_bench.c
+++ b/benchmark/wh_bench.c
@@ -58,7 +58,8 @@
 /* Buffer sizes for transport */
 /* Large enough to handle an RSA 4096 key */
 #define BUFFER_SIZE \
-    sizeof(whTransportMemCsr) + sizeof(whCommHeader) + WOLFHSM_CFG_COMM_DATA_LEN
+    (sizeof(whTransportMemCsr) + sizeof(whCommHeader) + \
+     WOLFHSM_CFG_COMM_DATA_LEN)
 #define FLASH_RAM_SIZE (1024 * 1024) /* 1MB */
 
 typedef struct BenchModule {
@@ -826,14 +827,14 @@ static void _whBenchClientServerThreadTest(whClientConfig* c_conf,
         rc = pthread_create(&cthread, NULL, _whBenchClientTask, &clientData);
         if (rc == 0) {
             /* Wait for client to finish, then cancel server */
-            pthread_join(cthread, &retval);
-            pthread_cancel(sthread);
-            pthread_join(sthread, &retval);
+            (void)pthread_join(cthread, &retval);
+            (void)pthread_cancel(sthread);
+            (void)pthread_join(sthread, &retval);
         }
         else {
             /* If client thread creation failed, cancel server */
-            pthread_cancel(sthread);
-            pthread_join(sthread, &retval);
+            (void)pthread_cancel(sthread);
+            (void)pthread_join(sthread, &retval);
         }
     }
 }

--- a/benchmark/wh_bench_ops.c
+++ b/benchmark/wh_bench_ops.c
@@ -346,27 +346,27 @@ int wh_Bench_PrintResults(whBenchOpContext* ctx)
 
                 if (throughput < 1024.0) {
                     /* Bytes per second */
-                    WH_BENCH_SNPRINTF(buffer, sizeof(buffer), "%.2f B/s",
-                                      throughput);
+                    (void)WH_BENCH_SNPRINTF(buffer, sizeof(buffer), "%.2f B/s",
+                                            throughput);
                 }
                 else if (throughput < 1024.0 * 1024.0) {
                     /* Kilobytes per second */
-                    WH_BENCH_SNPRINTF(buffer, sizeof(buffer), "%.2f KB/s",
-                                      throughput / 1024.0);
+                    (void)WH_BENCH_SNPRINTF(buffer, sizeof(buffer), "%.2f KB/s",
+                                            throughput / 1024.0);
                 }
                 else {
                     /* Megabytes per second */
-                    WH_BENCH_SNPRINTF(buffer, sizeof(buffer), "%.2f MB/s",
-                                      throughput / (1024.0 * 1024.0));
+                    (void)WH_BENCH_SNPRINTF(buffer, sizeof(buffer), "%.2f MB/s",
+                                            throughput / (1024.0 * 1024.0));
                 }
             }
             else if (ctx->ops[i].throughputType == BENCH_THROUGHPUT_OPS) {
-                WH_BENCH_SNPRINTF(buffer, sizeof(buffer), "%.2f ops/s",
-                                  ctx->ops[i].throughput);
+                (void)WH_BENCH_SNPRINTF(buffer, sizeof(buffer), "%.2f ops/s",
+                                        ctx->ops[i].throughput);
             }
             else {
                 /* No throughput */
-                WH_BENCH_SNPRINTF(buffer, sizeof(buffer), "N/A");
+                (void)WH_BENCH_SNPRINTF(buffer, sizeof(buffer), "N/A");
             }
             WH_BENCH_PRINTF("%-18s |\n", buffer);
         }

--- a/examples/demo/client/wh_demo_client_crypto.c
+++ b/examples/demo/client/wh_demo_client_crypto.c
@@ -67,7 +67,8 @@ int wh_DemoClient_CryptoRsa(whClientContext* clientContext)
     WC_RNG     rng[1];
 
     /* set the plainText to the test string */
-    strcpy((char*)plainText, plainString);
+    strncpy((char*)plainText, plainString, sizeof(plainText)-1);
+    plainText[sizeof(plainText)-1] = '\0';
 
     /* initialize rng to make the rsa key */
     ret = wc_InitRng_ex(rng, NULL, WH_DEV_ID);
@@ -144,7 +145,8 @@ int wh_DemoClient_CryptoRsaImport(whClientContext* clientContext)
     WC_RNG     rng[1];
 
     /* set the plainText to the test string */
-    strcpy((char*)plainText, plainString);
+    strncpy((char*)plainText, plainString, sizeof(plainText)-1);
+    plainText[sizeof(plainText)-1] = '\0';
 
     /* initialize rng to encrypt with the rsa key */
     ret = wc_InitRng_ex(rng, NULL, WH_DEV_ID);
@@ -497,7 +499,8 @@ int wh_DemoClient_CryptoEcc(whClientContext* clientContext)
     byte       signature[128];
 
     /* Set the message to the test string */
-    strcpy((char*)message, plainMessage);
+    strncpy((char*)message, plainMessage, sizeof(message)-1);
+    message[sizeof(message)-1] = '\0';
 
     /* Initialize the rng to make the ecc keys */
     ret = wc_InitRng_ex(rng, NULL, WH_DEV_ID);
@@ -627,7 +630,8 @@ int wh_DemoClient_CryptoEccImport(whClientContext* clientContext)
     uint8_t    keyBuf[256];
 
     /* Set the message to the test string */
-    strcpy((char*)message, plainMessage);
+    strncpy((char*)message, plainMessage, sizeof(message)-1);
+    message[sizeof(message)-1] = '\0';
 
     /* Initialize the rng for signature signing */
     ret = wc_InitRng_ex(rng, NULL, WH_DEV_ID);

--- a/examples/posix/wh_posix_client/wh_posix_client_cfg.c
+++ b/examples/posix/wh_posix_client/wh_posix_client_cfg.c
@@ -188,6 +188,7 @@ static unsigned int psk_tls12_client_cb(WOLFSSL* ssl, const char* hint,
     printf("PSK server identity hint: %s\n", hint);
     printf("PSK using identity: %s\n", exampleIdentity);
     strncpy(identity, exampleIdentity, id_max_len);
+    identity[id_max_len-1] = '\0';
 
     printf("Enter PSK password: ");
     if (fgets((char*)key, key_max_len - 1, stdin) == NULL) {

--- a/examples/posix/wh_posix_server/wh_posix_server_cfg.c
+++ b/examples/posix/wh_posix_server/wh_posix_server_cfg.c
@@ -478,7 +478,7 @@ static void parseNvmInitFile(const char* filePath)
             fclose(file);
             exit(EXIT_FAILURE);
         }
-        snprintf(label, sizeof(label), "%s", token);
+        (void)snprintf(label, sizeof(label), "%s", token);
 
         /* Parse the file path */
         token = strtok(NULL, " ");
@@ -508,9 +508,9 @@ static void processEntry(Entry* entry, int isKey, whNvmContext* nvmContext)
     }
 
     /* Get the file size */
-    fseek(file, 0, SEEK_END);
+    (void)fseek(file, 0, SEEK_END);
     long fileSize = ftell(file);
-    fseek(file, 0, SEEK_SET);
+    (void)fseek(file, 0, SEEK_SET);
 
     /* Allocate memory for the file data */
     uint8_t* buffer = (uint8_t*)malloc(fileSize);
@@ -553,7 +553,7 @@ static void processEntry(Entry* entry, int isKey, whNvmContext* nvmContext)
     meta.access = entry->access;
     meta.flags  = entry->flags;
     meta.len    = fileSize;
-    snprintf((char*)meta.label, WH_NVM_LABEL_LEN, "%s", entry->label);
+    (void)snprintf((char*)meta.label, WH_NVM_LABEL_LEN, "%s", entry->label);
 
     int rc = wh_Nvm_AddObject(nvmContext, &meta, fileSize, buffer);
     if (rc != 0) {

--- a/port/posix/posix_flash_file.c
+++ b/port/posix/posix_flash_file.c
@@ -41,7 +41,7 @@ enum {
 };
 
 /** Local declarations */
-#define MAX_OFFSET(_context) (_context->partition_size * 2)
+#define MAX_OFFSET(_context) ((_context)->partition_size * 2)
 
 /* Helper for pwrite like memset.  Write the byte in c to filedes for size
  * bytes starting at offset */

--- a/port/posix/posix_log_file.c
+++ b/port/posix/posix_log_file.c
@@ -54,79 +54,81 @@ static whLogLevel posixLogFile_StringToLevel(const char* str)
     return WH_LOG_LEVEL_INFO; /* Default */
 }
 
-int posixLogFile_Init(void* c, const void* cf)
+int posixLogFile_Init(void* context, const void* config)
 {
-    posixLogFileContext*      context = c;
-    const posixLogFileConfig* config  = cf;
-    int                       rc      = 0;
+    posixLogFileContext*      ctx = context;
+    const posixLogFileConfig* cfg = config;
+    int                       rc  = 0;
 
-    if ((context == NULL) || (config == NULL) || (config->filename == NULL)) {
+    if ((ctx == NULL) || (cfg == NULL) || (cfg->filename == NULL)) {
         return WH_ERROR_BADARGS;
     }
 
     /* Initialize context */
-    memset(context, 0, sizeof(*context));
-    context->fd = -1;
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->fd = -1;
 
     /* Initialize mutex */
-    rc = pthread_mutex_init(&context->mutex, NULL);
+    rc = pthread_mutex_init(&ctx->mutex, NULL);
     if (rc != 0) {
         return WH_ERROR_ABORTED;
     }
 
     /* Copy filename */
-    strncpy(context->filename, config->filename, sizeof(context->filename) - 1);
-    context->filename[sizeof(context->filename) - 1] = '\0';
+    strncpy(ctx->filename, cfg->filename, sizeof(ctx->filename) - 1);
+    ctx->filename[sizeof(ctx->filename) - 1] = '\0';
 
     /* Open log file for append/create */
-    context->fd =
-        open(context->filename, O_RDWR | O_CREAT | O_APPEND, S_IRUSR | S_IWUSR);
-    if (context->fd < 0) {
-        pthread_mutex_destroy(&context->mutex);
+    ctx->fd =
+        open(ctx->filename, O_RDWR | O_CREAT | O_APPEND, S_IRUSR | S_IWUSR);
+    if (ctx->fd < 0) {
+        (void)pthread_mutex_destroy(&ctx->mutex);
         return WH_ERROR_ABORTED;
     }
 
-    context->initialized = 1;
+    ctx->initialized = 1;
     return WH_ERROR_OK;
 }
 
-int posixLogFile_Cleanup(void* c)
+int posixLogFile_Cleanup(void* context)
 {
-    posixLogFileContext* context = c;
+    posixLogFileContext* ctx = context;
 
-    if (context == NULL) {
+    if (ctx == NULL) {
         return WH_ERROR_BADARGS;
     }
 
-    if (context->initialized) {
-        if (context->fd >= 0) {
-            close(context->fd);
-            context->fd = -1;
+    if (ctx->initialized) {
+        if (ctx->fd >= 0) {
+            close(ctx->fd);
+            ctx->fd = -1;
         }
-        pthread_mutex_destroy(&context->mutex);
-        context->initialized = 0;
+        (void)pthread_mutex_destroy(&ctx->mutex);
+        ctx->initialized = 0;
     }
 
     return WH_ERROR_OK;
 }
 
-int posixLogFile_AddEntry(void* c, const whLogEntry* entry)
+int posixLogFile_AddEntry(void* context, const whLogEntry* entry)
 {
-    posixLogFileContext* context = c;
+    posixLogFileContext* ctx = context;
     char                 buffer[1024];
     int                  len;
     ssize_t              bytes_written;
 
-    if ((context == NULL) || (entry == NULL)) {
+    if ((ctx == NULL) || (entry == NULL)) {
         return WH_ERROR_BADARGS;
     }
 
-    if (!context->initialized || context->fd < 0) {
+    if (!ctx->initialized || ctx->fd < 0) {
         return WH_ERROR_ABORTED;
     }
 
     /* Lock mutex */
-    pthread_mutex_lock(&context->mutex);
+    if (pthread_mutex_lock(&ctx->mutex) != 0) {
+        return WH_ERROR_ABORTED;
+    }
 
     /* Format log entry: TIMESTAMP|LEVEL|FILE:LINE|FUNCTION|MESSAGE\n */
     len = snprintf(buffer, sizeof(buffer), "%llu|%s|%s:%u|%s|%.*s\n",
@@ -137,15 +139,15 @@ int posixLogFile_AddEntry(void* c, const whLogEntry* entry)
                    entry->msg);
 
     if (len < 0 || (size_t)len >= sizeof(buffer)) {
-        pthread_mutex_unlock(&context->mutex);
+        (void)pthread_mutex_unlock(&ctx->mutex);
         return WH_ERROR_ABORTED;
     }
 
     /* Write to file */
-    bytes_written = write(context->fd, buffer, len);
+    bytes_written = write(ctx->fd, buffer, len);
 
     /* Unlock mutex */
-    pthread_mutex_unlock(&context->mutex);
+    (void)pthread_mutex_unlock(&ctx->mutex);
 
     if (bytes_written != len) {
         return WH_ERROR_ABORTED;
@@ -154,19 +156,19 @@ int posixLogFile_AddEntry(void* c, const whLogEntry* entry)
     return WH_ERROR_OK;
 }
 
-int posixLogFile_Export(void* c, void* export_arg)
+int posixLogFile_Export(void* context, void* export_arg)
 {
-    posixLogFileContext* context = c;
+    posixLogFileContext* ctx = context;
     FILE*                out_fp  = (FILE*)export_arg;
     FILE*                in_fp   = NULL;
     char                 line[2048];
     int                  ret = 0;
 
-    if (context == NULL) {
+    if (ctx == NULL) {
         return WH_ERROR_BADARGS;
     }
 
-    if (!context->initialized || context->fd < 0) {
+    if (!ctx->initialized || ctx->fd < 0) {
         return WH_ERROR_ABORTED;
     }
 
@@ -176,18 +178,20 @@ int posixLogFile_Export(void* c, void* export_arg)
     }
 
     /* Lock mutex */
-    pthread_mutex_lock(&context->mutex);
+    if (pthread_mutex_lock(&ctx->mutex) != 0) {
+        return WH_ERROR_ABORTED;
+    }
 
     /* Flush any pending writes */
-    if (fsync(context->fd) != 0) {
-        pthread_mutex_unlock(&context->mutex);
+    if (fsync(ctx->fd) != 0) {
+        (void)pthread_mutex_unlock(&ctx->mutex);
         return WH_ERROR_ABORTED;
     }
 
     /* Open file for reading (using fdopen with dup'd fd) */
-    int fd_dup = dup(context->fd);
+    int fd_dup = dup(ctx->fd);
     if (fd_dup < 0) {
-        pthread_mutex_unlock(&context->mutex);
+        (void)pthread_mutex_unlock(&ctx->mutex);
         return WH_ERROR_ABORTED;
     }
 
@@ -197,7 +201,7 @@ int posixLogFile_Export(void* c, void* export_arg)
     in_fp = fdopen(fd_dup, "r");
     if (in_fp == NULL) {
         close(fd_dup);
-        pthread_mutex_unlock(&context->mutex);
+        (void)pthread_mutex_unlock(&ctx->mutex);
         return WH_ERROR_ABORTED;
     }
 
@@ -212,39 +216,42 @@ int posixLogFile_Export(void* c, void* export_arg)
     fclose(in_fp); /* Also closes fd_dup */
 
     /* Unlock mutex */
-    pthread_mutex_unlock(&context->mutex);
+    (void)pthread_mutex_unlock(&ctx->mutex);
 
     return ret;
 }
 
-int posixLogFile_Iterate(void* c, whLogIterateCb iterate_cb, void* iterate_arg)
+int posixLogFile_Iterate(void* context, whLogIterateCb iterate_cb,
+                         void* iterate_arg)
 {
-    posixLogFileContext* context = c;
+    posixLogFileContext* ctx = context;
     FILE*                fp      = NULL;
     char                 line[2048];
     int                  ret = 0;
 
-    if ((context == NULL) || (iterate_cb == NULL)) {
+    if ((ctx == NULL) || (iterate_cb == NULL)) {
         return WH_ERROR_BADARGS;
     }
 
-    if (!context->initialized || context->fd < 0) {
+    if (!ctx->initialized || ctx->fd < 0) {
         return WH_ERROR_ABORTED;
     }
 
     /* Lock mutex */
-    pthread_mutex_lock(&context->mutex);
+    if (pthread_mutex_lock(&ctx->mutex) != 0) {
+        return WH_ERROR_ABORTED;
+    }
 
     /* Flush any pending writes */
-    if (fsync(context->fd) != 0) {
-        pthread_mutex_unlock(&context->mutex);
+    if (fsync(ctx->fd) != 0) {
+        (void)pthread_mutex_unlock(&ctx->mutex);
         return WH_ERROR_ABORTED;
     }
 
     /* Open file for reading (using fdopen with dup'd fd) */
-    int fd_dup = dup(context->fd);
+    int fd_dup = dup(ctx->fd);
     if (fd_dup < 0) {
-        pthread_mutex_unlock(&context->mutex);
+        (void)pthread_mutex_unlock(&ctx->mutex);
         return WH_ERROR_ABORTED;
     }
 
@@ -254,7 +261,7 @@ int posixLogFile_Iterate(void* c, whLogIterateCb iterate_cb, void* iterate_arg)
     fp = fdopen(fd_dup, "r");
     if (fp == NULL) {
         close(fd_dup);
-        pthread_mutex_unlock(&context->mutex);
+        (void)pthread_mutex_unlock(&ctx->mutex);
         return WH_ERROR_ABORTED;
     }
 
@@ -300,41 +307,43 @@ int posixLogFile_Iterate(void* c, whLogIterateCb iterate_cb, void* iterate_arg)
     fclose(fp); /* Also closes fd_dup */
 
     /* Unlock mutex */
-    pthread_mutex_unlock(&context->mutex);
+    (void)pthread_mutex_unlock(&ctx->mutex);
 
     return ret;
 }
 
-int posixLogFile_Clear(void* c)
+int posixLogFile_Clear(void* context)
 {
-    posixLogFileContext* context = c;
+    posixLogFileContext* ctx = context;
     int                  ret     = 0;
 
-    if (context == NULL) {
+    if (ctx == NULL) {
         return WH_ERROR_BADARGS;
     }
 
-    if (!context->initialized || context->fd < 0) {
+    if (!ctx->initialized || ctx->fd < 0) {
         return WH_ERROR_ABORTED;
     }
 
     /* Lock mutex */
-    pthread_mutex_lock(&context->mutex);
+    if (pthread_mutex_lock(&ctx->mutex) != 0) {
+        return WH_ERROR_ABORTED;
+    }
 
     /* Truncate file to zero length */
-    if (ftruncate(context->fd, 0) != 0) {
+    if (ftruncate(ctx->fd, 0) != 0) {
         ret = WH_ERROR_ABORTED;
     }
 
     /* Seek to beginning */
     if (ret == 0) {
-        if (lseek(context->fd, 0, SEEK_SET) < 0) {
+        if (lseek(ctx->fd, 0, SEEK_SET) < 0) {
             ret = WH_ERROR_ABORTED;
         }
     }
 
     /* Unlock mutex */
-    pthread_mutex_unlock(&context->mutex);
+    (void)pthread_mutex_unlock(&ctx->mutex);
 
     return ret;
 }

--- a/port/posix/posix_transport_shm.c
+++ b/port/posix/posix_transport_shm.c
@@ -400,7 +400,7 @@ int posixTransportShm_ServerInit(void* c, const void* cf,
 
     if (ret == WH_ERROR_OK) {
         memset(ctx, 0, sizeof(*ctx));
-        snprintf(ctx->name, sizeof(ctx->name), "%s", config->name);
+        (void)snprintf(ctx->name, sizeof(ctx->name), "%s", config->name);
         ctx->connectcb     = connectcb;
         ctx->connectcb_arg = connectcb_arg;
 
@@ -446,7 +446,7 @@ int posixTransportShm_ClientInit(void* c, const void* cf,
     }
 
     memset(ctx, 0, sizeof(*ctx));
-    snprintf(ctx->name, sizeof(ctx->name), "%s", config->name);
+    (void)snprintf(ctx->name, sizeof(ctx->name), "%s", config->name);
     ctx->connectcb     = connectcb;
     ctx->connectcb_arg = connectcb_arg;
 

--- a/src/wh_client_keywrap.c
+++ b/src/wh_client_keywrap.c
@@ -100,12 +100,12 @@ int wh_Client_KeyWrapResponse(whClientContext*   ctx,
 int wh_Client_KeyWrap(whClientContext* ctx, enum wc_CipherType cipherType,
                       uint16_t serverKeyId, void* keyIn, uint16_t keySz,
                       whNvmMetadata* metadataIn, void* wrappedKeyOut,
-                      uint16_t* wrappedKeySz)
+                      uint16_t* wrappedKeyInOutSz)
 {
     int ret = WH_ERROR_OK;
 
     if (ctx == NULL || keyIn == NULL || metadataIn == NULL ||
-        wrappedKeyOut == NULL || wrappedKeySz == NULL) {
+        wrappedKeyOut == NULL || wrappedKeyInOutSz == NULL) {
         return WH_ERROR_BADARGS;
     }
 
@@ -117,7 +117,7 @@ int wh_Client_KeyWrap(whClientContext* ctx, enum wc_CipherType cipherType,
 
     do {
         ret = wh_Client_KeyWrapResponse(ctx, cipherType, wrappedKeyOut,
-                                        wrappedKeySz);
+                                        wrappedKeyInOutSz);
     } while (ret == WH_ERROR_NOTREADY);
 
     return ret;

--- a/src/wh_log.c
+++ b/src/wh_log.c
@@ -51,13 +51,13 @@ const char* wh_Log_LevelToString(whLogLevel level)
 }
 
 void wh_Log_AddMsg(whLogContext* ctx, whLogLevel level, const char* file,
-                   const char* function, uint32_t line, const char* src,
-                   size_t src_len)
+                   const char* function, uint32_t line, const char* msg,
+                   size_t msg_len)
 {
     uint64_t timestamp = WH_GETTIME_US();
     size_t   max_len =
         (WOLFHSM_CFG_LOG_MSG_MAX > 0) ? (WOLFHSM_CFG_LOG_MSG_MAX - 1) : 0;
-    size_t     copy_len = (src_len < max_len) ? src_len : max_len;
+    size_t     copy_len = (msg_len < max_len) ? msg_len : max_len;
     whLogEntry entry    = {.timestamp = timestamp,
                            .level     = level,
                            .file      = file,
@@ -65,8 +65,8 @@ void wh_Log_AddMsg(whLogContext* ctx, whLogLevel level, const char* file,
                            .line      = line,
                            .msg_len   = (uint32_t)copy_len};
 
-    if ((src != NULL) && (copy_len > 0)) {
-        memcpy(entry.msg, src, copy_len);
+    if ((msg != NULL) && (copy_len > 0)) {
+        memcpy(entry.msg, msg, copy_len);
     }
     /* Zero-pad remainder of message buffer to prevent information leakage */
     memset(&entry.msg[copy_len], 0, WOLFHSM_CFG_LOG_MSG_MAX - copy_len);

--- a/src/wh_log_printf.c
+++ b/src/wh_log_printf.c
@@ -33,41 +33,41 @@
 
 #ifdef WOLFHSM_CFG_LOGGING
 
-int whLogPrintf_Init(void* c, const void* cf)
+int whLogPrintf_Init(void* context, const void* config)
 {
-    whLogPrintfContext*      context = (whLogPrintfContext*)c;
-    const whLogPrintfConfig* config  = (const whLogPrintfConfig*)cf;
+    whLogPrintfContext*      ctx = (whLogPrintfContext*)context;
+    const whLogPrintfConfig* cfg  = (const whLogPrintfConfig*)config;
 
-    if (context == NULL) {
+    if (ctx == NULL) {
         return WH_ERROR_BADARGS;
     }
 
     /* Initialize context */
-    memset(context, 0, sizeof(*context));
+    memset(ctx, 0, sizeof(*ctx));
 
     /* Copy config if provided, otherwise use defaults */
-    if (config != NULL) {
-        context->logIfNotDebug = config->logIfNotDebug;
+    if (cfg != NULL) {
+        ctx->logIfNotDebug = cfg->logIfNotDebug;
     }
     else {
-        context->logIfNotDebug = 0;
+        ctx->logIfNotDebug = 0;
     }
 
-    context->initialized = 1;
+    ctx->initialized = 1;
 
     return WH_ERROR_OK;
 }
 
 
-int whLogPrintf_AddEntry(void* c, const whLogEntry* entry)
+int whLogPrintf_AddEntry(void* context, const whLogEntry* entry)
 {
-    whLogPrintfContext* context = (whLogPrintfContext*)c;
+    whLogPrintfContext* ctx = (whLogPrintfContext*)context;
 
-    if ((context == NULL) || (entry == NULL)) {
+    if ((ctx == NULL) || (entry == NULL)) {
         return WH_ERROR_BADARGS;
     }
 
-    if (!context->initialized) {
+    if (!ctx->initialized) {
         return WH_ERROR_ABORTED;
     }
 
@@ -76,7 +76,7 @@ int whLogPrintf_AddEntry(void* c, const whLogEntry* entry)
      * - If logIfNotDebug is false: only log if WOLFHSM_CFG_DEBUG is defined
      */
 #ifndef WOLFHSM_CFG_DEBUG
-    if (!context->logIfNotDebug) {
+    if (!ctx->logIfNotDebug) {
         return WH_ERROR_OK;
     }
 #endif

--- a/src/wh_log_ringbuf.c
+++ b/src/wh_log_ringbuf.c
@@ -31,19 +31,19 @@
 
 #ifdef WOLFHSM_CFG_LOGGING
 
-int whLogRingbuf_Init(void* c, const void* cf)
+int whLogRingbuf_Init(void* context, const void* config)
 {
-    whLogRingbufContext*      context = (whLogRingbufContext*)c;
-    const whLogRingbufConfig* config  = (const whLogRingbufConfig*)cf;
+    whLogRingbufContext*      ctx = (whLogRingbufContext*)context;
+    const whLogRingbufConfig* cfg  = (const whLogRingbufConfig*)config;
     size_t                    capacity;
 
-    if (context == NULL || config == NULL || config->buffer == NULL ||
-        config->buffer_size < sizeof(whLogEntry)) {
+    if (ctx == NULL || cfg == NULL || cfg->buffer == NULL ||
+        cfg->buffer_size < sizeof(whLogEntry)) {
         return WH_ERROR_BADARGS;
     }
 
     /* Calculate capacity (number of complete entries that fit in buffer) */
-    capacity = config->buffer_size / sizeof(whLogEntry);
+    capacity = cfg->buffer_size / sizeof(whLogEntry);
     /* Capacity must be able to hold at least one log entry, specifically to
      * prevent divide-by-zeros in the rollover logic */
     if (capacity == 0) {
@@ -51,106 +51,107 @@ int whLogRingbuf_Init(void* c, const void* cf)
     }
 
     /* Initialize context */
-    memset(context, 0, sizeof(*context));
-    context->entries     = (whLogEntry*)config->buffer;
-    context->capacity    = capacity;
-    context->count       = 0;
-    context->initialized = 1;
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->entries     = (whLogEntry*)cfg->buffer;
+    ctx->capacity    = capacity;
+    ctx->count       = 0;
+    ctx->initialized = 1;
 
     return WH_ERROR_OK;
 }
 
-int whLogRingbuf_Cleanup(void* c)
+int whLogRingbuf_Cleanup(void* context)
 {
-    whLogRingbufContext* context = (whLogRingbufContext*)c;
+    whLogRingbufContext* ctx = (whLogRingbufContext*)context;
 
-    if (context == NULL) {
+    if (ctx == NULL) {
         return WH_ERROR_BADARGS;
     }
 
-    if (context->initialized) {
-        (void)whLogRingbuf_Clear(context);
-        context->initialized = 0;
+    if (ctx->initialized) {
+        (void)whLogRingbuf_Clear(ctx);
+        ctx->initialized = 0;
     }
 
     return WH_ERROR_OK;
 }
 
-int whLogRingbuf_AddEntry(void* c, const whLogEntry* entry)
+int whLogRingbuf_AddEntry(void* context, const whLogEntry* entry)
 {
-    whLogRingbufContext* context = (whLogRingbufContext*)c;
+    whLogRingbufContext* ctx = (whLogRingbufContext*)context;
     size_t               head;
 
-    if ((context == NULL) || (entry == NULL)) {
+    if ((ctx == NULL) || (entry == NULL)) {
         return WH_ERROR_BADARGS;
     }
 
-    if (!context->initialized) {
+    if (!ctx->initialized) {
         return WH_ERROR_ABORTED;
     }
 
     /* Calculate head position from count */
-    head = context->count % context->capacity;
+    head = ctx->count % ctx->capacity;
 
     /* Copy entry to ring buffer at head position */
-    memcpy(&context->entries[head], entry, sizeof(whLogEntry));
+    memcpy(&ctx->entries[head], entry, sizeof(whLogEntry));
 
     /* Increment count freely to track total messages written */
-    context->count++;
+    ctx->count++;
 
     return WH_ERROR_OK;
 }
 
-int whLogRingbuf_Export(void* c, void* export_arg)
+int whLogRingbuf_Export(void* context, void* export_arg)
 {
-    (void)c;
+    (void)context;
     (void)export_arg;
     return WH_ERROR_OK;
 }
 
-int whLogRingbuf_Iterate(void* c, whLogIterateCb iterate_cb, void* iterate_arg)
+int whLogRingbuf_Iterate(void* context, whLogIterateCb iterate_cb,
+                         void* iterate_arg)
 {
-    whLogRingbufContext* context = (whLogRingbufContext*)c;
+    whLogRingbufContext* ctx = (whLogRingbufContext*)context;
     size_t               capacity;
     size_t               num_entries;
     size_t               start_idx;
     size_t               i;
     int                  ret = 0;
 
-    if ((context == NULL) || (iterate_cb == NULL)) {
+    if ((ctx == NULL) || (iterate_cb == NULL)) {
         return WH_ERROR_BADARGS;
     }
 
-    if (!context->initialized) {
+    if (!ctx->initialized) {
         return WH_ERROR_ABORTED;
     }
 
     /* If buffer is empty, nothing to iterate */
-    if (context->count == 0) {
+    if (ctx->count == 0) {
         return WH_ERROR_OK;
     }
 
-    capacity = context->capacity;
+    capacity = ctx->capacity;
 
     /* Calculate actual number of entries in buffer (capped at capacity) */
-    num_entries = (context->count < capacity) ? context->count : capacity;
+    num_entries = (ctx->count < capacity) ? ctx->count : capacity;
 
     /* Determine starting index for iteration:
      * - If not full: start at 0 (oldest entry)
      * - If full: start at head (oldest entry, about to be overwritten)
      *   head = count % capacity
      */
-    if (context->count < capacity) {
+    if (ctx->count < capacity) {
         start_idx = 0;
     }
     else {
-        start_idx = context->count % capacity;
+        start_idx = ctx->count % capacity;
     }
 
     /* Iterate through entries in chronological order */
     for (i = 0; i < num_entries; i++) {
         size_t idx = (start_idx + i) % capacity;
-        ret        = iterate_cb(iterate_arg, &context->entries[idx]);
+        ret        = iterate_cb(iterate_arg, &ctx->entries[idx]);
         if (ret != 0) {
             /* User callback requested early termination */
             break;
@@ -160,19 +161,19 @@ int whLogRingbuf_Iterate(void* c, whLogIterateCb iterate_cb, void* iterate_arg)
     return ret;
 }
 
-int whLogRingbuf_Clear(void* c)
+int whLogRingbuf_Clear(void* context)
 {
-    whLogRingbufContext* context = (whLogRingbufContext*)c;
+    whLogRingbufContext* ctx = (whLogRingbufContext*)context;
 
-    if (context == NULL) {
+    if (ctx == NULL) {
         return WH_ERROR_BADARGS;
     }
 
     /* Reset ring buffer state */
-    context->count = 0;
+    ctx->count = 0;
 
     /* Zero the log entries */
-    memset(context->entries, 0, context->capacity * sizeof(whLogEntry));
+    memset(ctx->entries, 0, ctx->capacity * sizeof(whLogEntry));
 
     return WH_ERROR_OK;
 }

--- a/src/wh_nvm_flash.c
+++ b/src/wh_nvm_flash.c
@@ -45,7 +45,7 @@ enum {
 /* MSW of state variables (nfState) must be set to this pattern when written
  * to flash to prevent hardware on certain chipsets from confusing zero values
  * with erased flash */
-static const whFlashUnit BASE_STATE = 0x1234567800000000ull;
+static const whFlashUnit BASE_STATE = 0x1234567800000000ULL;
 
 /* On-flash layout of the state of an Object or Directory*/
 typedef struct {
@@ -79,7 +79,7 @@ typedef struct {
 #define NF_UNITS_PER_DIRECTORY WHFU_BYTES2UNITS(sizeof(nfDirectory))
 #define NF_DIRECTORY_OBJECTS_OFFSET WHFU_BYTES2UNITS(offsetof(nfDirectory, objects))
 #define NF_DIRECTORY_OBJECT_OFFSET(_n) \
-                    (NF_DIRECTORY_OBJECTS_OFFSET + (NF_UNITS_PER_OBJECT * _n))
+                    (NF_DIRECTORY_OBJECTS_OFFSET + (NF_UNITS_PER_OBJECT * (_n)))
 
 /* On-flash layout of a Partition */
 typedef struct {

--- a/src/wh_nvm_flash_log.c
+++ b/src/wh_nvm_flash_log.c
@@ -507,7 +507,8 @@ int wh_NvmFlashLog_Cleanup(void* c)
 
 /* List objects */
 int wh_NvmFlashLog_List(void* c, whNvmAccess access, whNvmFlags flags,
-                        whNvmId start_id, whNvmId* out_count, whNvmId* out_id)
+                        whNvmId start_id, whNvmId* out_avail_objects,
+                        whNvmId* out_id)
 {
     whNvmFlashLogContext*  ctx      = (whNvmFlashLogContext*)c;
     whNvmFlashLogMetadata *next_obj = NULL, *start_obj = NULL;
@@ -531,16 +532,16 @@ int wh_NvmFlashLog_List(void* c, whNvmAccess access, whNvmFlags flags,
     }
 
     if (next_obj == NULL || next_obj->meta.id == WH_NVM_ID_INVALID) {
-        if (out_count != NULL)
-            *out_count = 0;
+        if (out_avail_objects != NULL)
+            *out_avail_objects = 0;
         if (out_id != NULL)
             *out_id = WH_NVM_ID_INVALID;
         return WH_ERROR_OK;
     }
 
     count = nfl_ObjectCount(ctx, next_obj);
-    if (out_count != NULL)
-        *out_count = count;
+    if (out_avail_objects != NULL)
+        *out_avail_objects = count;
     if (out_id != NULL)
         *out_id = next_obj->meta.id;
 

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -557,7 +557,7 @@ int wh_Server_EccKeyCacheImport(whServerContext* ctx, ecc_key* key,
     uint8_t* cacheBuf;
     whNvmMetadata* cacheMeta;
     /* Maximum size of an ecc key der file */
-    uint16_t max_size = ECC_BUFSIZE;;
+    uint16_t max_size = ECC_BUFSIZE;
     uint16_t der_size;
 
     if (    (ctx == NULL) ||
@@ -3497,7 +3497,7 @@ static int _HandleAesGcmDma(whServerContext* ctx, uint16_t magic, int devId,
 #if defined(WOLFSSL_CMAC) && !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT)
 
 /* Resolve CMAC key from request (inline key or keystore ID).
- * outKey must be at least AES_MAX_KEY_SIZE bytes. */
+ * outKey must be at least AES_256_KEY_SIZE bytes. */
 static int _CmacResolveKey(whServerContext* ctx, const uint8_t* requestKey,
                            uint32_t requestKeySz, whKeyId clientKeyId,
                            uint8_t* outKey, uint32_t* outKeyLen)
@@ -3574,7 +3574,7 @@ static int _HandleCmac(whServerContext* ctx, uint16_t magic, int devId,
     if (req.keySz > available) {
         return WH_ERROR_BADARGS;
     }
-    if (req.keySz > AES_MAX_KEY_SIZE) {
+    if (req.keySz > AES_256_KEY_SIZE) {
         return WH_ERROR_BADARGS;
     }
 
@@ -3588,7 +3588,7 @@ static int _HandleCmac(whServerContext* ctx, uint16_t magic, int devId,
 
     memset(&res, 0, sizeof(res));
 
-    uint8_t tmpKey[AES_MAX_KEY_SIZE];
+    uint8_t tmpKey[AES_256_KEY_SIZE];
     uint32_t tmpKeyLen = sizeof(tmpKey);
     Cmac    cmac[1];
 
@@ -5735,7 +5735,7 @@ static int _HandleCmacDma(whServerContext* ctx, uint16_t magic, int devId,
     if (req.keySz > available) {
         return WH_ERROR_BADARGS;
     }
-    if (req.keySz > AES_MAX_KEY_SIZE) {
+    if (req.keySz > AES_256_KEY_SIZE) {
         return WH_ERROR_BADARGS;
     }
 
@@ -5752,7 +5752,7 @@ static int _HandleCmacDma(whServerContext* ctx, uint16_t magic, int devId,
     /* DMA translated address for input */
     void* inAddr = NULL;
 
-    uint8_t tmpKey[AES_MAX_KEY_SIZE];
+    uint8_t tmpKey[AES_256_KEY_SIZE];
     uint32_t tmpKeyLen = sizeof(tmpKey);
     Cmac    cmac[1];
 

--- a/src/wh_utils.c
+++ b/src/wh_utils.c
@@ -42,22 +42,22 @@ uint16_t wh_Utils_Swap16(uint16_t val)
 
 uint32_t wh_Utils_Swap32(uint32_t val)
 {
-    return  ((val & 0xFF000000ul) >> 24) |
-            ((val & 0x00FF0000ul) >> 8) |
-            ((val & 0x0000FF00ul) << 8) |
-            ((val & 0x000000FFul) << 24);
+    return  ((val & 0xFF000000UL) >> 24) |
+            ((val & 0x00FF0000UL) >> 8) |
+            ((val & 0x0000FF00UL) << 8) |
+            ((val & 0x000000FFUL) << 24);
 }
 
 uint64_t wh_Utils_Swap64(uint64_t val)
 {
-    return  ((val & 0xFF00000000000000ull) >> 56) |
-            ((val & 0xFF000000000000ull) >> 40) |
-            ((val & 0xFF0000000000ull) >> 24) |
-            ((val & 0xFF00000000ull) >> 8)|
-            ((val & 0xFF000000ull) << 8) |
-            ((val & 0xFF0000ull) << 24 ) |
-            ((val & 0xFF00ull) << 40) |
-            ((val & 0xFFull) << 56);
+    return  ((val & 0xFF00000000000000ULL) >> 56) |
+            ((val & 0xFF000000000000ULL) >> 40) |
+            ((val & 0xFF0000000000ULL) >> 24) |
+            ((val & 0xFF00000000ULL) >> 8)|
+            ((val & 0xFF000000ULL) << 8) |
+            ((val & 0xFF0000ULL) << 24 ) |
+            ((val & 0xFF00ULL) << 40) |
+            ((val & 0xFFULL) << 56);
 }
 
 static int isLittleEndian(void) {

--- a/test/wh_test_clientserver.c
+++ b/test/wh_test_clientserver.c
@@ -751,7 +751,7 @@ int whTest_ClientServerSequential(whTestNvmBackendType nvmType)
         /* Prepare echo test */
         send_len =
             snprintf(send_buffer, sizeof(send_buffer), "Request:%u", counter);
-        snprintf(recv_buffer, sizeof(recv_buffer), "NOTHING RECEIVED");
+        (void)snprintf(recv_buffer, sizeof(recv_buffer), "NOTHING RECEIVED");
         recv_len = 0;
 
         WH_TEST_RETURN_ON_FAIL(
@@ -1167,7 +1167,7 @@ int whTest_ClientServerClientConfig(whClientConfig* clientCfg)
         /* Prepare echo test */
         send_len =
             snprintf(send_buffer, sizeof(send_buffer), "Request:%u", counter);
-        snprintf(recv_buffer, sizeof(recv_buffer), "NOTHING RECEIVED");
+        (void)snprintf(recv_buffer, sizeof(recv_buffer), "NOTHING RECEIVED");
         recv_len = 0;
 
         WH_TEST_RETURN_ON_FAIL(ret = wh_Client_Echo(client, send_len, send_buffer, &recv_len, recv_buffer));
@@ -1549,13 +1549,11 @@ static void _whClientServerThreadTest(whClientConfig* c_conf,
         rc = pthread_create(&cthread, NULL, _whClientTask, c_conf);
         if (rc == 0) {
             /* All good. Block on joining */
-
-            pthread_join(cthread, &retval);
-            pthread_cancel(sthread);
+            (void)pthread_join(cthread, &retval);
+            (void)pthread_cancel(sthread);
         } else {
             /* Cancel the server thread */
-            pthread_cancel(sthread);
-
+            (void)pthread_cancel(sthread);
         }
     }
 }

--- a/test/wh_test_comm.c
+++ b/test/wh_test_comm.c
@@ -131,7 +131,7 @@ int whTest_CommMem(void)
                                                     &rx_req_len, rx_req));
 
     for (counter = 0; counter < REPEAT_COUNT; counter++) {
-        snprintf((char*)tx_req, sizeof(tx_req), "Request:%u", counter);
+        (void)snprintf((char*)tx_req, sizeof(tx_req), "Request:%u", counter);
         tx_req_len  = strlen((char*)tx_req);
         tx_req_type = counter * 2;
         WH_TEST_RETURN_ON_FAIL(
@@ -159,7 +159,7 @@ int whTest_CommMem(void)
         WH_TEST_DEBUG_PRINT("Server RecvRequest:%d, flags %x, type:%x, seq:%d, len:%d, %s\n",
                ret, rx_req_flags, rx_req_type, rx_req_seq, rx_req_len, rx_req);
 
-        snprintf((char*)tx_resp, sizeof(tx_resp), "Response:%s", rx_req);
+        (void)snprintf((char*)tx_resp, sizeof(tx_resp), "Response:%s", rx_req);
         tx_resp_len = strlen((char*)tx_resp);
         ret = wh_CommServer_SendResponse(server, rx_req_flags, rx_req_type,
                                          rx_req_seq, tx_resp_len, tx_resp);
@@ -218,7 +218,7 @@ static void* _whCommClientTask(void* cf)
     WH_TEST_ASSERT_MSG(0 == ret, "Client Init: ret=%d", ret);
 
     for (counter = 0; counter < REPEAT_COUNT; counter++) {
-        snprintf((char*)tx_req, sizeof(tx_req), "Request:%u", counter);
+        (void)snprintf((char*)tx_req, sizeof(tx_req), "Request:%u", counter);
         tx_req_len  = strlen((char*)tx_req);
         tx_req_type = counter * 2;
         do {
@@ -306,7 +306,7 @@ static void* _whCommServerTask(void* cf)
         }
 
         do {
-            snprintf((char*)tx_resp, sizeof(tx_resp), "Response:%s", rx_req);
+            (void)snprintf((char*)tx_resp, sizeof(tx_resp), "Response:%s", rx_req);
             tx_resp_len = strlen((char*)tx_resp);
             ret = wh_CommServer_SendResponse(server, rx_req_flags, rx_req_type,
                                              rx_req_seq, tx_resp_len, tx_resp);
@@ -354,14 +354,13 @@ static void _whCommClientServerThreadTest(whCommClientConfig* c_conf,
         WH_TEST_DEBUG_PRINT("Client thread create:%d\n", rc);
         if (rc == 0) {
             /* All good. Block on joining */
-
-            pthread_join(cthread, &retval);
-            pthread_join(sthread, &retval);
+            (void)pthread_join(cthread, &retval);
+            (void)pthread_join(sthread, &retval);
         }
         else {
             /* Cancel the server thread */
-            pthread_cancel(sthread);
-            pthread_join(sthread, &retval);
+            (void)pthread_cancel(sthread);
+            (void)pthread_join(sthread, &retval);
         }
     }
 }


### PR DESCRIPTION
These are the (imo) important fixes extracted from the closed #291  

* clang-tidy fixes
* Reduce temp key buffer on stack for CMAC operations
* Minor misc changes