### PR TITLE
Dma fixes

### DIFF
--- a/src/wh_server_cert.c
+++ b/src/wh_server_cert.c
@@ -556,9 +556,10 @@ int wh_Server_HandleCertRequest(whServerContext* server, uint16_t magic,
 
 #ifdef WOLFHSM_CFG_DMA
         case WH_MESSAGE_CERT_ACTION_ADDTRUSTED_DMA: {
-            whMessageCert_AddTrustedDmaRequest req       = {0};
-            whMessageCert_SimpleResponse       resp      = {0};
-            void*                              cert_data = NULL;
+            whMessageCert_AddTrustedDmaRequest req              = {0};
+            whMessageCert_SimpleResponse       resp             = {0};
+            void*                              cert_data        = NULL;
+            int                                cert_dma_pre_ok  = 0;
 
             if (req_size != sizeof(req)) {
                 /* Request is malformed */
@@ -574,6 +575,9 @@ int wh_Server_HandleCertRequest(whServerContext* server, uint16_t magic,
                 resp.rc = wh_Server_DmaProcessClientAddress(
                     server, req.cert_addr, &cert_data, req.cert_len,
                     WH_DMA_OPER_CLIENT_READ_PRE, (whServerDmaFlags){0});
+                if (resp.rc == WH_ERROR_OK) {
+                    cert_dma_pre_ok = 1;
+                }
             }
             if (resp.rc == WH_ERROR_OK) {
                 /* Process the add trusted action */
@@ -586,9 +590,10 @@ int wh_Server_HandleCertRequest(whServerContext* server, uint16_t magic,
                     (void)WH_SERVER_NVM_UNLOCK(server);
                 } /* WH_SERVER_NVM_LOCK() */
             }
-            if (resp.rc == WH_ERROR_OK) {
-                /* Post-process client address */
-                resp.rc = wh_Server_DmaProcessClientAddress(
+            /* Always call POST for successful PRE, regardless of operation
+             * result */
+            if (cert_dma_pre_ok) {
+                (void)wh_Server_DmaProcessClientAddress(
                     server, req.cert_addr, &cert_data, req.cert_len,
                     WH_DMA_OPER_CLIENT_READ_POST, (whServerDmaFlags){0});
             }
@@ -600,11 +605,12 @@ int wh_Server_HandleCertRequest(whServerContext* server, uint16_t magic,
         }; break;
 
         case WH_MESSAGE_CERT_ACTION_READTRUSTED_DMA: {
-            whMessageCert_ReadTrustedDmaRequest req       = {0};
-            whMessageCert_SimpleResponse        resp      = {0};
-            void*                               cert_data = NULL;
+            whMessageCert_ReadTrustedDmaRequest req              = {0};
+            whMessageCert_SimpleResponse        resp             = {0};
+            void*                               cert_data        = NULL;
             uint32_t                            cert_len;
             whNvmMetadata                       meta;
+            int                                 cert_dma_pre_ok  = 0;
 
             if (req_size != sizeof(req)) {
                 /* Request is malformed */
@@ -620,6 +626,9 @@ int wh_Server_HandleCertRequest(whServerContext* server, uint16_t magic,
                 resp.rc = wh_Server_DmaProcessClientAddress(
                     server, req.cert_addr, &cert_data, req.cert_len,
                     WH_DMA_OPER_CLIENT_WRITE_PRE, (whServerDmaFlags){0});
+                if (resp.rc == WH_ERROR_OK) {
+                    cert_dma_pre_ok = 1;
+                }
             }
             if (resp.rc == WH_ERROR_OK) {
                 /* Check metadata to see if the certificate is non-exportable */
@@ -641,10 +650,11 @@ int wh_Server_HandleCertRequest(whServerContext* server, uint16_t magic,
                     (void)WH_SERVER_NVM_UNLOCK(server);
                 } /* WH_SERVER_NVM_LOCK() */
             }
-            if (resp.rc == WH_ERROR_OK) {
-                /* Post-process client address */
-                resp.rc = wh_Server_DmaProcessClientAddress(
-                    server, req.cert_addr, &cert_data, cert_len,
+            /* Always call POST for successful PRE, regardless of operation
+             * result */
+            if (cert_dma_pre_ok) {
+                (void)wh_Server_DmaProcessClientAddress(
+                    server, req.cert_addr, &cert_data, req.cert_len,
                     WH_DMA_OPER_CLIENT_WRITE_POST, (whServerDmaFlags){0});
             }
 
@@ -655,10 +665,11 @@ int wh_Server_HandleCertRequest(whServerContext* server, uint16_t magic,
         }; break;
 
         case WH_MESSAGE_CERT_ACTION_VERIFY_DMA: {
-            whMessageCert_VerifyDmaRequest  req       = {0};
-            whMessageCert_VerifyDmaResponse resp      = {0};
-            void*                           cert_data = NULL;
-            whKeyId                         keyId     = WH_KEYID_ERASED;
+            whMessageCert_VerifyDmaRequest  req              = {0};
+            whMessageCert_VerifyDmaResponse resp             = {0};
+            void*                           cert_data        = NULL;
+            whKeyId                         keyId            = WH_KEYID_ERASED;
+            int                             cert_dma_pre_ok  = 0;
 
             if (req_size != sizeof(req)) {
                 /* Request is malformed */
@@ -677,6 +688,9 @@ int wh_Server_HandleCertRequest(whServerContext* server, uint16_t magic,
                 resp.rc = wh_Server_DmaProcessClientAddress(
                     server, req.cert_addr, &cert_data, req.cert_len,
                     WH_DMA_OPER_CLIENT_READ_PRE, (whServerDmaFlags){0});
+                if (resp.rc == WH_ERROR_OK) {
+                    cert_dma_pre_ok = 1;
+                }
             }
             if (resp.rc == WH_ERROR_OK) {
                 resp.rc = WH_SERVER_NVM_LOCK(server);
@@ -693,9 +707,10 @@ int wh_Server_HandleCertRequest(whServerContext* server, uint16_t magic,
                     (void)WH_SERVER_NVM_UNLOCK(server);
                 } /* WH_SERVER_NVM_LOCK() */
             }
-            if (resp.rc == WH_ERROR_OK) {
-                /* Post-process client address */
-                resp.rc = wh_Server_DmaProcessClientAddress(
+            /* Always call POST for successful PRE, regardless of operation
+             * result */
+            if (cert_dma_pre_ok) {
+                (void)wh_Server_DmaProcessClientAddress(
                     server, req.cert_addr, &cert_data, req.cert_len,
                     WH_DMA_OPER_CLIENT_READ_POST, (whServerDmaFlags){0});
             }
@@ -766,9 +781,10 @@ int wh_Server_HandleCertRequest(whServerContext* server, uint16_t magic,
 #if defined(WOLFHSM_CFG_DMA)
         case WH_MESSAGE_CERT_ACTION_VERIFY_ACERT_DMA: {
             /* Acert verify request uses standard cert verify request struct */
-            whMessageCert_VerifyDmaRequest req       = {0};
-            whMessageCert_SimpleResponse   resp      = {0};
-            void*                          cert_data = NULL;
+            whMessageCert_VerifyDmaRequest req              = {0};
+            whMessageCert_SimpleResponse   resp             = {0};
+            void*                          cert_data        = NULL;
+            int                            cert_dma_pre_ok  = 0;
 
             if (req_size != sizeof(req)) {
                 /* Request is malformed */
@@ -783,6 +799,9 @@ int wh_Server_HandleCertRequest(whServerContext* server, uint16_t magic,
                 rc = wh_Server_DmaProcessClientAddress(
                     server, req.cert_addr, &cert_data, req.cert_len,
                     WH_DMA_OPER_CLIENT_READ_PRE, (whServerDmaFlags){0});
+                if (rc == WH_ERROR_OK) {
+                    cert_dma_pre_ok = 1;
+                }
             }
             if (rc == WH_ERROR_OK) {
                 /* Process the verify action */
@@ -805,9 +824,10 @@ int wh_Server_HandleCertRequest(whServerContext* server, uint16_t magic,
                     resp.rc = rc;
                 }
             }
-            if (rc == WH_ERROR_OK) {
-                /* Post-process client address */
-                rc = wh_Server_DmaProcessClientAddress(
+            /* Always call POST for successful PRE, regardless of operation
+             * result */
+            if (cert_dma_pre_ok) {
+                (void)wh_Server_DmaProcessClientAddress(
                     server, req.cert_addr, &cert_data, req.cert_len,
                     WH_DMA_OPER_CLIENT_READ_POST, (whServerDmaFlags){0});
             }

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -4784,11 +4784,17 @@ static int _HandleSha256Dma(whServerContext* ctx, uint16_t magic, int devId,
             res.dmaAddrStatus.badAddr = req.state;
         }
         else {
-            /* Save the client devId to be restored later, when the context is
-             * copied back into client memory. */
-            clientDevId = sha256->devId;
-            /* overwrite the devId to that of the server for local crypto */
-            sha256->devId = devId;
+            /* Validate buffLen from untrusted context */
+            if (sha256->buffLen >= WC_SHA256_BLOCK_SIZE) {
+                ret = WH_ERROR_BADARGS;
+            }
+            else {
+                /* Save the client devId to be restored later, when the context
+                 * is copied back into client memory. */
+                clientDevId = sha256->devId;
+                /* overwrite the devId to that of the server for local crypto */
+                sha256->devId = devId;
+            }
         }
     }
 
@@ -4906,11 +4912,17 @@ static int _HandleSha224Dma(whServerContext* ctx, uint16_t magic, int devId,
             res.dmaAddrStatus.badAddr = req.state;
         }
         else {
-            /* Save the client devId to be restored later, when the context is
-             * copied back into client memory. */
-            clientDevId = sha224->devId;
-            /* overwrite the devId to that of the server for local crypto */
-            sha224->devId = devId;
+            /* Validate buffLen from untrusted context */
+            if (sha224->buffLen >= WC_SHA224_BLOCK_SIZE) {
+                ret = WH_ERROR_BADARGS;
+            }
+            else {
+                /* Save the client devId to be restored later, when the context
+                 * is copied back into client memory. */
+                clientDevId = sha224->devId;
+                /* overwrite the devId to that of the server for local crypto */
+                sha224->devId = devId;
+            }
         }
     }
 
@@ -5028,11 +5040,17 @@ static int _HandleSha384Dma(whServerContext* ctx, uint16_t magic, int devId,
             res.dmaAddrStatus.badAddr = req.state;
         }
         else {
-            /* Save the client devId to be restored later, when the context is
-             * copied back into client memory. */
-            clientDevId = sha384->devId;
-            /* overwrite the devId to that of the server for local crypto */
-            sha384->devId = devId;
+            /* Validate buffLen from untrusted context */
+            if (sha384->buffLen >= WC_SHA384_BLOCK_SIZE) {
+                ret = WH_ERROR_BADARGS;
+            }
+            else {
+                /* Save the client devId to be restored later, when the context
+                 * is copied back into client memory. */
+                clientDevId = sha384->devId;
+                /* overwrite the devId to that of the server for local crypto */
+                sha384->devId = devId;
+            }
         }
     }
 
@@ -5150,13 +5168,25 @@ static int _HandleSha512Dma(whServerContext* ctx, uint16_t magic, int devId,
             res.dmaAddrStatus.badAddr = req.state;
         }
         else {
-            /* Save the client devId to be restored later, when the context is
-             * copied back into client memory. */
-            clientDevId = sha512->devId;
-            /* overwrite the devId to that of the server for local crypto */
-            sha512->devId = devId;
-            /* retrieve hash Type to handle 512, 512-224, or 512-256 */
-            hashType = sha512->hashType;
+            /* Validate buffLen from untrusted context */
+            if (sha512->buffLen >= WC_SHA512_BLOCK_SIZE) {
+                ret = WH_ERROR_BADARGS;
+            }
+            else {
+                /* Save the client devId to be restored later, when the context
+                 * is copied back into client memory. */
+                clientDevId = sha512->devId;
+                /* overwrite the devId to that of the server for local crypto */
+                sha512->devId = devId;
+                /* retrieve hash Type to handle 512, 512-224, or 512-256 */
+                hashType = sha512->hashType;
+                /* Validate hashType from untrusted context */
+                if (hashType != WC_HASH_TYPE_SHA512 &&
+                    hashType != WC_HASH_TYPE_SHA512_224 &&
+                    hashType != WC_HASH_TYPE_SHA512_256) {
+                    ret = WH_ERROR_BADARGS;
+                }
+            }
         }
     }
 

--- a/src/wh_server_dma.c
+++ b/src/wh_server_dma.c
@@ -131,15 +131,7 @@ int whServerDma_CopyFromClient(struct whServerContext_t* server,
         return WH_ERROR_BADARGS;
     }
 
-    /* Check the server address against the allow list */
-    rc = wh_Dma_CheckMemOperAgainstAllowList(server->dma.dmaAddrAllowList,
-                                             WH_DMA_OPER_CLIENT_READ_PRE,
-                                             serverPtr, len);
-    if (rc != WH_ERROR_OK) {
-        return rc;
-    }
-
-    /* Process the client address pre-read */
+    /* Process the client address pre-read (includes allow list check) */
     rc = wh_Server_DmaProcessClientAddress(
         server, clientAddr, &transformedAddr, len, WH_DMA_OPER_CLIENT_READ_PRE,
         flags);
@@ -185,15 +177,7 @@ int whServerDma_CopyToClient(struct whServerContext_t* server,
         return WH_ERROR_BADARGS;
     }
 
-    /* Check the server address against the allow list */
-    rc = wh_Dma_CheckMemOperAgainstAllowList(server->dma.dmaAddrAllowList,
-                                             WH_DMA_OPER_CLIENT_WRITE_PRE,
-                                             serverPtr, len);
-    if (rc != WH_ERROR_OK) {
-        return rc;
-    }
-
-    /* Process the client address pre-write */
+    /* Process the client address pre-write (includes allow list check) */
     rc = wh_Server_DmaProcessClientAddress(server, clientAddr, &transformedAddr,
                                            len, WH_DMA_OPER_CLIENT_WRITE_PRE,
                                            flags);

--- a/src/wh_server_nvm.c
+++ b/src/wh_server_nvm.c
@@ -349,6 +349,8 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
         whMessageNvm_SimpleResponse resp = {0};
         void* metadata = NULL;
         void* data = NULL;
+        int metadata_dma_pre_ok = 0;
+        int data_dma_pre_ok = 0;
 
         if (req_size != sizeof(req)) {
             /* Request is malformed */
@@ -363,11 +365,17 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
             resp.rc = wh_Server_DmaProcessClientAddress(
                 server, req.metadata_hostaddr, &metadata, sizeof(whNvmMetadata),
                 WH_DMA_OPER_CLIENT_READ_PRE, (whServerDmaFlags){0});
+            if (resp.rc == 0) {
+                metadata_dma_pre_ok = 1;
+            }
         }
         if (resp.rc == 0) {
             resp.rc = wh_Server_DmaProcessClientAddress(
                 server, req.data_hostaddr, &data, req.data_len,
                 WH_DMA_OPER_CLIENT_READ_PRE, (whServerDmaFlags){0});
+            if (resp.rc == 0) {
+                data_dma_pre_ok = 1;
+            }
         }
         if (resp.rc == 0) {
             rc = WH_SERVER_NVM_LOCK(server);
@@ -381,14 +389,15 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
             } /* WH_SERVER_NVM_LOCK() */
             resp.rc = rc;
         }
-        if (resp.rc == 0) {
-            /* perform platform-specific host address processing */
-            resp.rc = wh_Server_DmaProcessClientAddress(
+        /* Always call POST for successful PREs, regardless of operation
+         * result */
+        if (metadata_dma_pre_ok) {
+            (void)wh_Server_DmaProcessClientAddress(
                 server, req.metadata_hostaddr, &metadata, sizeof(whNvmMetadata),
                 WH_DMA_OPER_CLIENT_READ_POST, (whServerDmaFlags){0});
         }
-        if (resp.rc == 0) {
-            resp.rc = wh_Server_DmaProcessClientAddress(
+        if (data_dma_pre_ok) {
+            (void)wh_Server_DmaProcessClientAddress(
                 server, req.data_hostaddr, &data, req.data_len,
                 WH_DMA_OPER_CLIENT_READ_POST, (whServerDmaFlags){0});
         }
@@ -405,6 +414,7 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
         whNvmMetadata               meta = {0};
         whNvmSize                   read_len = 0;
         void*                       data = NULL;
+        int                         data_dma_pre_ok = 0;
 
         if (req_size != sizeof(req)) {
             /* Request is malformed */
@@ -441,15 +451,19 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
                     rc = wh_Server_DmaProcessClientAddress(
                         server, req.data_hostaddr, &data, req.data_len,
                         WH_DMA_OPER_CLIENT_WRITE_PRE, (whServerDmaFlags){0});
+                    if (rc == 0) {
+                        data_dma_pre_ok = 1;
+                    }
                 }
                 if (rc == 0) {
                     /* Process the Read action */
                     rc = wh_Nvm_ReadChecked(server->nvm, req.id, req.offset,
                                             read_len, (uint8_t*)data);
                 }
-                if (rc == 0) {
-                    /* perform platform-specific host address processing */
-                    rc = wh_Server_DmaProcessClientAddress(
+                /* Always call POST for successful PRE, regardless of read
+                 * result */
+                if (data_dma_pre_ok) {
+                    (void)wh_Server_DmaProcessClientAddress(
                         server, req.data_hostaddr, &data, req.data_len,
                         WH_DMA_OPER_CLIENT_WRITE_POST, (whServerDmaFlags){0});
                 }

--- a/test/wh_test_clientserver.c
+++ b/test/wh_test_clientserver.c
@@ -351,18 +351,6 @@ static int _testDma(whServerContext* server, whClientContext* client)
     WH_TEST_ASSERT_RETURN(0 == memcmp(testMem.srvBufAllow, testMem.cliBuf,
                                       sizeof(testMem.srvBufAllow)));
 
-    /* Now try and copy from the denylisted addresses */
-    WH_TEST_ASSERT_RETURN(WH_ERROR_ACCESS ==
-                          whServerDma_CopyFromClient(server, testMem.srvBufDeny,
-                                                     (uintptr_t)testMem.cliBuf,
-                                                     sizeof(testMem.cliBuf),
-                                                     (whServerDmaFlags){0}));
-    WH_TEST_ASSERT_RETURN(
-        WH_ERROR_ACCESS ==
-        whServerDma_CopyToClient(server, (uintptr_t)testMem.cliBuf,
-                                 testMem.srvBufDeny, sizeof(testMem.srvBufDeny),
-                                 (whServerDmaFlags){0}));
-
     /* Check that zero-sized copies fail, even from allowed addresses */
     WH_TEST_ASSERT_RETURN(WH_ERROR_BADARGS == whServerDma_CopyFromClient(
                                                   server, testMem.srvBufAllow,
@@ -396,6 +384,21 @@ static int _testDma(whServerContext* server, whClientContext* client)
     WH_TEST_ASSERT_RETURN(0 == memcmp(testMem.srvBufAllow,
                                       testMem.srvRemapBufAllow,
                                       sizeof(testMem.srvBufAllow)));
+
+    /* Check that out-of-allowlist client addresses are rejected (done after
+     * clearing the custom DMA callback to avoid the callback remapping the
+     * deny address out of bounds) */
+    WH_TEST_ASSERT_RETURN(WH_ERROR_ACCESS == whServerDma_CopyFromClient(
+                                                  server, testMem.srvBufAllow,
+                                                  (uintptr_t)testMem.srvBufDeny,
+                                                  sizeof(testMem.srvBufAllow),
+                                                  (whServerDmaFlags){0}));
+    WH_TEST_ASSERT_RETURN(WH_ERROR_ACCESS ==
+                          whServerDma_CopyToClient(
+                              server, (uintptr_t)testMem.srvBufDeny,
+                              testMem.srvBufAllow,
+                              sizeof(testMem.srvBufAllow),
+                              (whServerDmaFlags){0}));
 
     return rc;
 }


### PR DESCRIPTION
This pull request introduces several important improvements to DMA (Direct Memory Access) handling and validation in the server codebase, focusing on stricter memory operation checks, safer handling of client requests, and enhanced security for cryptographic operations. The changes ensure that DMA operations are validated more rigorously, and post-processing steps are always executed after successful pre-processing, regardless of the main operation's outcome.

**Key changes include:**

### DMA Allowlist and Memory Operation Handling

* Added a strict mode to `_checkMemOperAgainstAllowList` in `wh_dma.c`, which enforces a fail-closed policy when no allowlist is registered if `WOLFHSM_CFG_DMA_STRICT_ALLOWLIST` is defined. This increases the security posture by denying all DMA operations unless explicitly allowed.
* Simplified `whServerDma_CopyFromClient` and `whServerDma_CopyToClient` to rely on `wh_Server_DmaProcessClientAddress` for allowlist checking, reducing duplicate checks and centralizing validation logic. [[1]](diffhunk://#diff-91e3b16b805ab1dfc36c63424cef9bed53ce2b1594a01f59af0a1fd0fe57a810L134-R134) [[2]](diffhunk://#diff-91e3b16b805ab1dfc36c63424cef9bed53ce2b1594a01f59af0a1fd0fe57a810L188-R180)

### Consistent POST DMA Processing

* Refactored certificate and NVM request handlers (`wh_Server_HandleCertRequest` and `wh_Server_HandleNvmRequest`) to always perform POST DMA processing if the corresponding PRE step succeeded, regardless of the main operation's result. This ensures resource cleanup and consistent state, improving reliability and security. [[1]](diffhunk://#diff-d925822a2849c51d736b25bb5d9f1b889cf214469c725d798aa6b91df90754a5R578-R580) [[2]](diffhunk://#diff-d925822a2849c51d736b25bb5d9f1b889cf214469c725d798aa6b91df90754a5L589-R596) [[3]](diffhunk://#diff-d925822a2849c51d736b25bb5d9f1b889cf214469c725d798aa6b91df90754a5R629-R631) [[4]](diffhunk://#diff-d925822a2849c51d736b25bb5d9f1b889cf214469c725d798aa6b91df90754a5L644-R657) [[5]](diffhunk://#diff-d925822a2849c51d736b25bb5d9f1b889cf214469c725d798aa6b91df90754a5R691-R693) [[6]](diffhunk://#diff-d925822a2849c51d736b25bb5d9f1b889cf214469c725d798aa6b91df90754a5L696-R713) [[7]](diffhunk://#diff-d925822a2849c51d736b25bb5d9f1b889cf214469c725d798aa6b91df90754a5R802-R804) [[8]](diffhunk://#diff-d925822a2849c51d736b25bb5d9f1b889cf214469c725d798aa6b91df90754a5L808-R830) [[9]](diffhunk://#diff-bd36888ecd0187f58cfdb463e4f506f57ed24462472884908632afa975dccffdR352-R353) [[10]](diffhunk://#diff-bd36888ecd0187f58cfdb463e4f506f57ed24462472884908632afa975dccffdR368-R378) [[11]](diffhunk://#diff-bd36888ecd0187f58cfdb463e4f506f57ed24462472884908632afa975dccffdL384-R400) [[12]](diffhunk://#diff-bd36888ecd0187f58cfdb463e4f506f57ed24462472884908632afa975dccffdR417) [[13]](diffhunk://#diff-bd36888ecd0187f58cfdb463e4f506f57ed24462472884908632afa975dccffdR454-R466)

### Enhanced Validation of Untrusted Input

* Added validation for buffer length and hash type fields sourced from untrusted client contexts in SHA-2 DMA handlers (`_HandleSha256Dma`, `_HandleSha224Dma`, `_HandleSha384Dma`, `_HandleSha512Dma`). This prevents buffer overflows and invalid hash type usage, further hardening the cryptographic operations against malformed or malicious input. [[1]](diffhunk://#diff-446b88572bf243d9336b5ea249b53061536fe2c9d006f36fde4e1b7abdb1c015L4787-R4799) [[2]](diffhunk://#diff-446b88572bf243d9336b5ea249b53061536fe2c9d006f36fde4e1b7abdb1c015L4909-R4927) [[3]](diffhunk://#diff-446b88572bf243d9336b5ea249b53061536fe2c9d006f36fde4e1b7abdb1c015L5031-R5055) [[4]](diffhunk://#diff-446b88572bf243d9336b5ea249b53061536fe2c9d006f36fde4e1b7abdb1c015L5153-R5189)

These changes collectively improve the robustness, maintainability, and security of DMA and cryptographic operations in the server codebase.