### PR TITLE
Add callback for message poll loops

### DIFF
--- a/src/wh_client.c
+++ b/src/wh_client.c
@@ -77,6 +77,11 @@ int wh_Client_Init(whClientContext* c, const whClientConfig* config)
 
     memset(c, 0, sizeof(*c));
 
+#ifdef WOLFHSM_CFG_CLIENT_MSG_POLL_CB
+    c->msgPollCb     = config->msgPollCb;
+    c->msgPollCbData = config->msgPollCbData;
+#endif /* WOLFHSM_CFG_CLIENT_MSG_POLL_CB */
+
     rc = wh_CommClient_Init(c->comm, config->comm);
 
 #ifndef WOLFHSM_CFG_NO_CRYPTO
@@ -152,6 +157,16 @@ int wh_Client_SendRequest(whClientContext* c,
         c->last_req_kind = kind;
         c->last_req_id   = req_id;
     }
+
+#ifdef WOLFHSM_CFG_CLIENT_MSG_POLL_CB
+    if (rc == WH_ERROR_NOTREADY && c->msgPollCb != NULL) {
+        int cbrc = c->msgPollCb(c->msgPollCbData);
+        if (cbrc != 0) {
+            return cbrc;
+        }
+    }
+#endif /* WOLFHSM_CFG_CLIENT_MSG_POLL_CB */
+
     return rc;
 }
 
@@ -188,6 +203,16 @@ int wh_Client_RecvResponse(whClientContext *c,
             }
         }
     }
+
+#ifdef WOLFHSM_CFG_CLIENT_MSG_POLL_CB
+    if (rc == WH_ERROR_NOTREADY && c->msgPollCb != NULL) {
+        int cbrc = c->msgPollCb(c->msgPollCbData);
+        if (cbrc != 0) {
+            return cbrc;
+        }
+    }
+#endif /* WOLFHSM_CFG_CLIENT_MSG_POLL_CB */
+
     return rc;
 }
 

--- a/wolfhsm/wh_client.h
+++ b/wolfhsm/wh_client.h
@@ -135,6 +135,14 @@ typedef struct {
 } whClientDmaContext;
 #endif /* WOLFHSM_CFG_DMA */
 
+#ifdef WOLFHSM_CFG_CLIENT_MSG_POLL_CB
+/* Invoked once each time wh_Client_SendRequest or wh_Client_RecvResponse would
+ * return WH_ERROR_NOTREADY. When the callback returns 0, the caller's retry
+ * loop continues. If the callback returns non-zero, the caller's retry loop is
+ * aborted and the non-zero propagates internally. */
+typedef int (*whClientMsgPollCb)(void* cbData);
+#endif /* WOLFHSM_CFG_CLIENT_MSG_POLL_CB */
+
 /* Client context */
 struct whClientContext_t {
     uint16_t     last_req_id;
@@ -143,6 +151,10 @@ struct whClientContext_t {
 #ifdef WOLFHSM_CFG_DMA
     whClientDmaContext dma;
 #endif /* WOLFHSM_CFG_DMA */
+#ifdef WOLFHSM_CFG_CLIENT_MSG_POLL_CB
+    whClientMsgPollCb msgPollCb;
+    void*             msgPollCbData;
+#endif /* WOLFHSM_CFG_CLIENT_MSG_POLL_CB */
     whCommClient comm[1];
 };
 
@@ -151,6 +163,10 @@ struct whClientConfig_t {
 #ifdef WOLFHSM_CFG_DMA
     whClientDmaConfig* dmaConfig;
 #endif /* WOLFHSM_CFG_DMA */
+#ifdef WOLFHSM_CFG_CLIENT_MSG_POLL_CB
+    whClientMsgPollCb msgPollCb;
+    void*             msgPollCbData;
+#endif /* WOLFHSM_CFG_CLIENT_MSG_POLL_CB */
 };
 typedef struct whClientConfig_t whClientConfig;
 


### PR DESCRIPTION
This hook allows callers of the client library to `sleep()` or do other work while waiting for either the outbound message to enqueue or while waiting for an incoming response. 

The use case is initially to avoid a busy wait in the test refactor in #331, but can be useful as a general purpose addition.

No test cases yet -- will add after #331 is merged. 