### PR TITLE
add macro guard on SHA512 hashType

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,6 +45,11 @@ jobs:
     - name: Build and test DMA ASAN
       run: cd test && make clean && make -j DMA=1 ASAN=1 WOLFSSL_DIR=../wolfssl && make run
 
+    # Build and test with DMA, SHA-512 enabled in wolfSSL, but with
+    # WOLFSSL_SHA512_HASHTYPE disabled.
+    - name: Build and test DMA without WOLFSSL_SHA512_HASHTYPE
+      run: cd test && make clean && make -j DMA=1 NO_SHA512_HASHTYPE=1 WOLFSSL_DIR=../wolfssl && make run
+
     # Build and test ASAN build, with wolfCrypt tests enabled.
     - name: Build and test ASAN TESTWOLFCRYPT
       run: cd test && make clean && make -j ASAN=1 TESTWOLFCRYPT=1 WOLFSSL_DIR=../wolfssl && make run

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -5215,7 +5215,9 @@ static int _HandleSha512Dma(whServerContext* ctx, uint16_t magic, int devId,
     sha512->loLen    = req.resumeState.loLen;
     sha512->hiLen    = req.resumeState.hiLen;
     sha512->buffLen  = 0;
+#ifdef WOLFSSL_SHA512_HASHTYPE
     sha512->hashType = hashType;
+#endif
 
     if (ret == 0 && req.inSz > 0) {
         ret = wc_Sha512Update(sha512, inlineData, req.inSz);

--- a/test/Makefile
+++ b/test/Makefile
@@ -165,6 +165,13 @@ ifeq ($(AUTH),1)
 	DEF += -DWOLFHSM_CFG_ENABLE_AUTHENTICATION
 endif
 
+# Build wolfSSL without WOLFSSL_SHA512_HASHTYPE to verify the SHA-512 server
+# DMA path compiles when wolfSSL has SHA-512 enabled but does not track the
+# variant on the struct.
+ifeq ($(NO_SHA512_HASHTYPE),1)
+	DEF += -DWHTEST_NO_SHA512_HASHTYPE
+endif
+
 ## Project defines
 # Option to build wolfcrypt tests
 ifeq ($(TESTWOLFCRYPT),1)

--- a/test/config/user_settings.h
+++ b/test/config/user_settings.h
@@ -130,7 +130,9 @@
 #define WOLFSSL_SHA224
 #define WOLFSSL_SHA384
 #define WOLFSSL_SHA512
+#ifndef WHTEST_NO_SHA512_HASHTYPE
 #define WOLFSSL_SHA512_HASHTYPE
+#endif
 
 /* Dilithium Options */
 #define HAVE_DILITHIUM

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -5024,6 +5024,7 @@ static int whTest_CryptoSha512LargeInput(whClientContext* ctx, int devId,
     return ret;
 }
 
+#ifdef WOLFSSL_SHA512_HASHTYPE
 /* Direct exercise of the new async non-DMA SHA512 primitives. */
 static int whTest_CryptoSha512Async(whClientContext* ctx, int devId,
                                     WC_RNG* rng)
@@ -5278,6 +5279,7 @@ static int whTest_CryptoSha512DmaAsync(whClientContext* ctx, int devId,
     return ret;
 }
 #endif /* WOLFHSM_CFG_DMA */
+#endif /* WOLFSSL_SHA512_HASHTYPE */
 
 #endif /* WOLFSSL_SHA512 */
 
@@ -11296,18 +11298,20 @@ int whTest_CryptoClientConfig(whClientConfig* config)
             ret =
                 whTest_CryptoSha512LargeInput(client, WH_DEV_IDS_ARRAY[i], rng);
         }
+#ifdef WOLFSSL_SHA512_HASHTYPE
         if (ret == WH_ERROR_OK) {
             ret = whTest_CryptoSha512Async(client, WH_DEV_IDS_ARRAY[i], rng);
         }
+#endif /* WOLFSSL_SHA512_HASHTYPE */
         if (ret == WH_ERROR_OK) {
             i++;
         }
     }
-#ifdef WOLFHSM_CFG_DMA
+#if defined(WOLFHSM_CFG_DMA) && defined(WOLFSSL_SHA512_HASHTYPE)
     if (ret == WH_ERROR_OK) {
         ret = whTest_CryptoSha512DmaAsync(client, WH_DEV_ID_DMA, rng);
     }
-#endif /* WOLFHSM_CFG_DMA */
+#endif /* WOLFHSM_CFG_DMA && WOLFSSL_SHA512_HASHTYPE */
 #endif /* WOLFSSL_SHA512 */
 
 #ifdef HAVE_HKDF


### PR DESCRIPTION
This was found when developing and integrating wolfHSM into a project. The autoconf ./configure used to compile wolfSSL that wolfHSM was being linked to did not define WOLFSSL_SHA512_HASHTYPE. The changes in this PR allow for linking against wolfSSL compiled without WOLFSSL_SHA512_HASHTYPE and add a CI test case.