### PR TITLE
back out sha512 hash type tests and leave only single macro guard in …

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,11 +45,6 @@ jobs:
     - name: Build and test DMA ASAN
       run: cd test && make clean && make -j DMA=1 ASAN=1 WOLFSSL_DIR=../wolfssl && make run
 
-    # Build and test with DMA, SHA-512 enabled in wolfSSL, but with
-    # WOLFSSL_SHA512_HASHTYPE disabled.
-    - name: Build and test DMA without WOLFSSL_SHA512_HASHTYPE
-      run: cd test && make clean && make -j DMA=1 NO_SHA512_HASHTYPE=1 WOLFSSL_DIR=../wolfssl && make run
-
     # Build and test ASAN build, with wolfCrypt tests enabled.
     - name: Build and test ASAN TESTWOLFCRYPT
       run: cd test && make clean && make -j ASAN=1 TESTWOLFCRYPT=1 WOLFSSL_DIR=../wolfssl && make run

--- a/test/Makefile
+++ b/test/Makefile
@@ -165,13 +165,6 @@ ifeq ($(AUTH),1)
 	DEF += -DWOLFHSM_CFG_ENABLE_AUTHENTICATION
 endif
 
-# Build wolfSSL without WOLFSSL_SHA512_HASHTYPE to verify the SHA-512 server
-# DMA path compiles when wolfSSL has SHA-512 enabled but does not track the
-# variant on the struct.
-ifeq ($(NO_SHA512_HASHTYPE),1)
-	DEF += -DWHTEST_NO_SHA512_HASHTYPE
-endif
-
 ## Project defines
 # Option to build wolfcrypt tests
 ifeq ($(TESTWOLFCRYPT),1)

--- a/test/config/user_settings.h
+++ b/test/config/user_settings.h
@@ -130,9 +130,7 @@
 #define WOLFSSL_SHA224
 #define WOLFSSL_SHA384
 #define WOLFSSL_SHA512
-#ifndef WHTEST_NO_SHA512_HASHTYPE
 #define WOLFSSL_SHA512_HASHTYPE
-#endif
 
 /* Dilithium Options */
 #define HAVE_DILITHIUM

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -5024,7 +5024,6 @@ static int whTest_CryptoSha512LargeInput(whClientContext* ctx, int devId,
     return ret;
 }
 
-#ifdef WOLFSSL_SHA512_HASHTYPE
 /* Direct exercise of the new async non-DMA SHA512 primitives. */
 static int whTest_CryptoSha512Async(whClientContext* ctx, int devId,
                                     WC_RNG* rng)
@@ -5279,7 +5278,6 @@ static int whTest_CryptoSha512DmaAsync(whClientContext* ctx, int devId,
     return ret;
 }
 #endif /* WOLFHSM_CFG_DMA */
-#endif /* WOLFSSL_SHA512_HASHTYPE */
 
 #endif /* WOLFSSL_SHA512 */
 
@@ -11298,20 +11296,18 @@ int whTest_CryptoClientConfig(whClientConfig* config)
             ret =
                 whTest_CryptoSha512LargeInput(client, WH_DEV_IDS_ARRAY[i], rng);
         }
-#ifdef WOLFSSL_SHA512_HASHTYPE
         if (ret == WH_ERROR_OK) {
             ret = whTest_CryptoSha512Async(client, WH_DEV_IDS_ARRAY[i], rng);
         }
-#endif /* WOLFSSL_SHA512_HASHTYPE */
         if (ret == WH_ERROR_OK) {
             i++;
         }
     }
-#if defined(WOLFHSM_CFG_DMA) && defined(WOLFSSL_SHA512_HASHTYPE)
+#ifdef WOLFHSM_CFG_DMA
     if (ret == WH_ERROR_OK) {
         ret = whTest_CryptoSha512DmaAsync(client, WH_DEV_ID_DMA, rng);
     }
-#endif /* WOLFHSM_CFG_DMA && WOLFSSL_SHA512_HASHTYPE */
+#endif /* WOLFHSM_CFG_DMA */
 #endif /* WOLFSSL_SHA512 */
 
 #ifdef HAVE_HKDF


### PR DESCRIPTION
…DMA section

Reverts CI test from https://github.com/wolfSSL/wolfHSM/pull/357