### PR TITLE
ML-DSA rename

### DIFF
--- a/benchmark/bench_modules/wh_bench_mod_mldsa.c
+++ b/benchmark/bench_modules/wh_bench_mod_mldsa.c
@@ -23,15 +23,15 @@
 
 
 #if !defined(WOLFHSM_CFG_NO_CRYPTO) && defined(WOLFHSM_CFG_BENCH_ENABLE)
-#include "wolfssl/wolfcrypt/dilithium.h"
+#include "wolfssl/wolfcrypt/wc_mldsa.h"
 #include "wolfssl/wolfcrypt/random.h"
 
-#if defined(HAVE_DILITHIUM)
+#if defined(WOLFSSL_HAVE_MLDSA)
 
-#if !defined(WOLFSSL_DILITHIUM_NO_SIGN)
+#if !defined(WOLFSSL_MLDSA_NO_SIGN)
 /* raw private key without ASN1 syntax from
  * ./certs/dilithium/bench_dilithium_level2_key.der */
-static const unsigned char bench_dilithium_level2_key[] = {
+static const unsigned char bench_mldsa_44_key[] = {
     0xea, 0x05, 0x24, 0x0d, 0x80, 0x72, 0x25, 0x55, 0xf4, 0x5b, 0xc2, 0x13,
     0x8b, 0x87, 0x5d, 0x31, 0x99, 0x2f, 0x1d, 0xa9, 0x41, 0x09, 0x05, 0x76,
     0xa7, 0xb7, 0x5e, 0x8c, 0x44, 0xe2, 0x64, 0x79, 0xd8, 0x79, 0x4c, 0xee,
@@ -247,9 +247,9 @@ static const unsigned char bench_dilithium_level2_key[] = {
     0x37, 0xa0, 0x11, 0xff, 0xb2, 0xa4, 0xc3, 0x61, 0xf2, 0xa3, 0x49, 0xbe,
     0xe7, 0xb6, 0x96, 0x2f,
 };
-#endif /* !WOLFSSL_DILITHIUM_NO_SIGN */
+#endif /* !WOLFSSL_MLDSA_NO_SIGN */
 
-#if !defined(WOLFSSL_DILITHIUM_NO_VERIFY)
+#if !defined(WOLFSSL_MLDSA_NO_VERIFY)
 const byte ml_dsa_44_pub_key[] = {
     0xd8, 0xac, 0xaf, 0xd8, 0x2e, 0x14, 0x23, 0x78, 0xf7, 0x0d, 0x9a, 0x04,
     0x2b, 0x92, 0x48, 0x67, 0x60, 0x55, 0x34, 0xd9, 0xac, 0x0b, 0xc4, 0x1f,
@@ -610,24 +610,24 @@ static byte test_msg[512] = {
     0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff};
 /* raw public key without ASN1 syntax from
  * ./certs/dilithium/bench_dilithium_level2_key.der */
-#endif /* !(WOLFSSL_DILITHIUM_NO_VERIFY) */
+#endif /* !(WOLFSSL_MLDSA_NO_VERIFY) */
 
-#if !defined(WOLFSSL_DILITHIUM_NO_SIGN)
+#if !defined(WOLFSSL_MLDSA_NO_SIGN)
 /* Helper function for ML-DSA sign benchmark */
 static int _benchMlDsaSign(whClientContext* client, whBenchOpContext* ctx,
-                           int id, int securityLevel, int devId)
+                           int id, int paramSet, int devId)
 {
-    int      ret = 0;
-    MlDsaKey key;
-    WC_RNG   rng[1] = {0};
-    byte     msg[]  = "Test message for ML DSA signing";
-    byte*    sig    = NULL;
-    word32   sigSz  = 0;
-    int      i;
-    int      initialized_rng = 0;
-    int      initialized_key = 0;
-    whKeyId  keyId           = WH_KEYID_ERASED;
-    char     keyLabel[]      = "bench-mldsa-key";
+    int         ret = 0;
+    wc_MlDsaKey key;
+    WC_RNG      rng[1] = {0};
+    byte        msg[]  = "Test message for ML DSA signing";
+    byte*       sig    = NULL;
+    word32      sigSz  = 0;
+    int         i;
+    int         initialized_rng = 0;
+    int         initialized_key = 0;
+    whKeyId     keyId           = WH_KEYID_ERASED;
+    char        keyLabel[]      = "bench-mldsa-key";
 
     /* Initialize the RNG */
     ret = wc_InitRng_ex(rng, NULL, devId);
@@ -645,8 +645,8 @@ static int _benchMlDsaSign(whClientContext* client, whBenchOpContext* ctx,
     }
     initialized_key = 1;
 
-    /* Set security level */
-    ret = wc_MlDsaKey_SetParams(&key, securityLevel);
+    /* Set ML-DSA parameter set */
+    ret = wc_MlDsaKey_SetParams(&key, paramSet);
     if (ret != 0) {
         WH_BENCH_PRINTF("Failed to wc_MlDsaKey_SetParams %d\n", ret);
         goto exit;
@@ -654,8 +654,8 @@ static int _benchMlDsaSign(whClientContext* client, whBenchOpContext* ctx,
 
     /* Import the raw public key into the wolfCrypt structure */
     if (ret == 0) {
-        ret = wc_MlDsaKey_ImportPrivRaw(&key, bench_dilithium_level2_key,
-                                        sizeof(bench_dilithium_level2_key));
+        ret = wc_MlDsaKey_ImportPrivRaw(&key, bench_mldsa_44_key,
+                                        sizeof(bench_mldsa_44_key));
         if (ret != 0) {
             WH_BENCH_PRINTF("Failed to import ML-DSA public key: %d\n", ret);
         }
@@ -761,24 +761,23 @@ exit:
 
     return ret;
 }
-#endif /* !defined(WOLFSSL_DILITHIUM_NO_SIGN) */
+#endif /* !defined(WOLFSSL_MLDSA_NO_SIGN) */
 
-#if !defined(WOLFSSL_DILITHIUM_NO_VERIFY)
+#if !defined(WOLFSSL_MLDSA_NO_VERIFY)
 /* Helper function for ML-DSA verify benchmark */
 static int _benchMlDsaVerify(whClientContext* client, whBenchOpContext* ctx,
-                             int id, int securityLevel, int devId)
+                             int id, int paramSet, int devId)
 {
-    int      ret = 0;
-    MlDsaKey key;
-    WC_RNG   rng[1] = {0};
-    byte*    sig    = NULL;
-    /*word32   sigSz  = 0; */
-    int     i;
-    int     verified        = 0;
-    int     initialized_rng = 0;
-    int     initialized_key = 0;
-    whKeyId keyId           = WH_KEYID_ERASED;
-    char    keyLabel[]      = "bench-mldsa-key";
+    int         ret = 0;
+    wc_MlDsaKey key;
+    WC_RNG      rng[1] = {0};
+    byte*       sig    = NULL;
+    int         i;
+    int         verified        = 0;
+    int         initialized_rng = 0;
+    int         initialized_key = 0;
+    whKeyId     keyId           = WH_KEYID_ERASED;
+    char        keyLabel[]      = "bench-mldsa-key";
 
     /* Initialize the RNG */
     ret = wc_InitRng_ex(rng, NULL, devId);
@@ -796,8 +795,8 @@ static int _benchMlDsaVerify(whClientContext* client, whBenchOpContext* ctx,
     }
     initialized_key = 1;
 
-    /* Set security level */
-    ret = wc_MlDsaKey_SetParams(&key, securityLevel);
+    /* Set ML-DSA parameter set */
+    ret = wc_MlDsaKey_SetParams(&key, paramSet);
     if (ret != 0) {
         WH_BENCH_PRINTF("Failed to wc_MlDsaKey_SetParams %d\n", ret);
         goto exit;
@@ -893,21 +892,21 @@ exit:
 
     return ret;
 }
-#endif /* !defined(WOLFSSL_DILITHIUM_NO_VERIFY) */
+#endif /* !defined(WOLFSSL_MLDSA_NO_VERIFY) */
 
-#if !defined(WOLFSSL_DILITHIUM_NO_MAKE_KEY)
+#if !defined(WOLFSSL_MLDSA_NO_MAKE_KEY)
 /* Helper function for ML-DSA key generation benchmark */
 static int _benchMlDsaKeyGen(whClientContext* client, whBenchOpContext* ctx,
-                             int id, int securityLevel, int devId)
+                             int id, int paramSet, int devId)
 {
     (void)client;
 
-    int      ret = 0;
-    MlDsaKey key;
-    WC_RNG   rng[1] = {0};
-    int      i;
-    int      initialized_rng = 0;
-    int      initialized_key = 0;
+    int         ret = 0;
+    wc_MlDsaKey key;
+    WC_RNG      rng[1] = {0};
+    int         i;
+    int         initialized_rng = 0;
+    int         initialized_key = 0;
 
     /* Initialize the RNG */
     ret = wc_InitRng_ex(rng, NULL, devId);
@@ -930,8 +929,8 @@ static int _benchMlDsaKeyGen(whClientContext* client, whBenchOpContext* ctx,
         }
         initialized_key = 1;
 
-        /* Set security level */
-        ret = wc_MlDsaKey_SetParams(&key, securityLevel);
+        /* Set ML-DSA parameter set */
+        ret = wc_MlDsaKey_SetParams(&key, paramSet);
         if (ret != 0) {
             WH_BENCH_PRINTF("Failed to wc_MlDsaKey_SetParams %d\n", ret);
             break;
@@ -973,14 +972,14 @@ static int _benchMlDsaKeyGen(whClientContext* client, whBenchOpContext* ctx,
 
     return ret;
 }
-#endif /* !defined(WOLFSSL_DILITHIUM_NO_MAKE_KEY) */
+#endif /* !defined(WOLFSSL_MLDSA_NO_MAKE_KEY) */
 
-/* Benchmark functions for ML-DSA with security level 44 */
+/* Benchmark functions for ML-DSA 44 */
 #if !defined(WOLFSSL_NO_ML_DSA_44)
 int wh_Bench_Mod_MlDsa44Sign(whClientContext* client, whBenchOpContext* ctx,
                              int id, void* params)
 {
-#if !defined(WOLFSSL_DILITHIUM_NO_SIGN) && \
+#if !defined(WOLFSSL_MLDSA_NO_SIGN) && \
     !defined(WOLFHSM_CFG_TEST_CLIENT_LARGE_DATA_DMA_ONLY)
     (void)params;
     return _benchMlDsaSign(client, ctx, id, WC_ML_DSA_44, WH_DEV_ID);
@@ -996,7 +995,7 @@ int wh_Bench_Mod_MlDsa44Sign(whClientContext* client, whBenchOpContext* ctx,
 int wh_Bench_Mod_MlDsa44SignDma(whClientContext* client, whBenchOpContext* ctx,
                                 int id, void* params)
 {
-#if defined(WOLFHSM_CFG_DMA) && !defined(WOLFSSL_DILITHIUM_NO_SIGN)
+#if defined(WOLFHSM_CFG_DMA) && !defined(WOLFSSL_MLDSA_NO_SIGN)
     (void)params;
     return _benchMlDsaSign(client, ctx, id, WC_ML_DSA_44, WH_DEV_ID_DMA);
 #else
@@ -1011,7 +1010,7 @@ int wh_Bench_Mod_MlDsa44SignDma(whClientContext* client, whBenchOpContext* ctx,
 int wh_Bench_Mod_MlDsa44Verify(whClientContext* client, whBenchOpContext* ctx,
                                int id, void* params)
 {
-#if !defined(WOLFSSL_DILITHIUM_NO_VERIFY) && \
+#if !defined(WOLFSSL_MLDSA_NO_VERIFY) && \
     !defined(WOLFHSM_CFG_TEST_CLIENT_LARGE_DATA_DMA_ONLY)
     (void)params;
     return _benchMlDsaVerify(client, ctx, id, WC_ML_DSA_44, WH_DEV_ID);
@@ -1027,7 +1026,7 @@ int wh_Bench_Mod_MlDsa44Verify(whClientContext* client, whBenchOpContext* ctx,
 int wh_Bench_Mod_MlDsa44VerifyDma(whClientContext*  client,
                                   whBenchOpContext* ctx, int id, void* params)
 {
-#if defined(WOLFHSM_CFG_DMA) && !defined(WOLFSSL_DILITHIUM_NO_VERIFY)
+#if defined(WOLFHSM_CFG_DMA) && !defined(WOLFSSL_MLDSA_NO_VERIFY)
     (void)params;
     return _benchMlDsaVerify(client, ctx, id, WC_ML_DSA_44, WH_DEV_ID_DMA);
 #else
@@ -1042,7 +1041,7 @@ int wh_Bench_Mod_MlDsa44VerifyDma(whClientContext*  client,
 int wh_Bench_Mod_MlDsa44KeyGen(whClientContext* client, whBenchOpContext* ctx,
                                int id, void* params)
 {
-#if !defined(WOLFSSL_DILITHIUM_NO_MAKE_KEY) && \
+#if !defined(WOLFSSL_MLDSA_NO_MAKE_KEY) && \
     !defined(WOLFHSM_CFG_TEST_CLIENT_LARGE_DATA_DMA_ONLY)
     (void)params;
     return _benchMlDsaKeyGen(client, ctx, id, WC_ML_DSA_44, WH_DEV_ID);
@@ -1058,7 +1057,7 @@ int wh_Bench_Mod_MlDsa44KeyGen(whClientContext* client, whBenchOpContext* ctx,
 int wh_Bench_Mod_MlDsa44KeyGenDma(whClientContext*  client,
                                   whBenchOpContext* ctx, int id, void* params)
 {
-#if defined(WOLFHSM_CFG_DMA) && !defined(WOLFSSL_DILITHIUM_NO_MAKE_KEY)
+#if defined(WOLFHSM_CFG_DMA) && !defined(WOLFSSL_MLDSA_NO_MAKE_KEY)
     (void)params;
     return _benchMlDsaKeyGen(client, ctx, id, WC_ML_DSA_44, WH_DEV_ID_DMA);
 #else
@@ -1071,7 +1070,7 @@ int wh_Bench_Mod_MlDsa44KeyGenDma(whClientContext*  client,
 }
 #endif /* !defined(WOLFSSL_NO_ML_DSA_44) */
 
-/* Benchmark functions for ML-DSA with security level 65 */
+/* Benchmark functions for ML-DSA 65 */
 #if !defined(WOLFSSL_NO_ML_DSA_65)
 int wh_Bench_Mod_MlDsa65Sign(whClientContext* client, whBenchOpContext* ctx,
                              int id, void* params)
@@ -1134,8 +1133,8 @@ int wh_Bench_Mod_MlDsa65KeyGenDma(whClientContext*  client,
 }
 #endif /* !defined(WOLFSSL_NO_ML_DSA_65) */
 
-/* Benchmark functions for ML-DSA with security level 87 */
-#if !defined(WOLFSSL_DILITHIUM_NO_SIGN)
+/* Benchmark functions for ML-DSA 87 */
+#if !defined(WOLFSSL_MLDSA_NO_SIGN)
 int wh_Bench_Mod_MlDsa87Sign(whClientContext* client, whBenchOpContext* ctx,
                              int id, void* params)
 {
@@ -1197,6 +1196,6 @@ int wh_Bench_Mod_MlDsa87KeyGenDma(whClientContext*  client,
 }
 #endif /* !defined(WOLFSSL_NO_ML_DSA_87) */
 
-#endif /* HAVE_DILITHIUM */
+#endif /* WOLFSSL_HAVE_MLDSA */
 
 #endif /* !WOLFHSM_CFG_NO_CRYPTO && WOLFHSM_CFG_BENCH_ENABLE */

--- a/benchmark/config/user_settings.h
+++ b/benchmark/config/user_settings.h
@@ -133,9 +133,8 @@ extern "C" {
 #define WOLFSSL_SHA512
 #define WOLFSSL_SHA512_HASHTYPE
 
-/* Dilithium Options */
-#define HAVE_DILITHIUM
-#define WOLFSSL_WC_DILITHIUM /* use wolfCrypt implementation, not libOQS */
+/* ML-DSA Options */
+#define WOLFSSL_HAVE_MLDSA
 #define WOLFSSL_SHA3
 #define WOLFSSL_SHAKE128
 #define WOLFSSL_SHAKE256
@@ -143,16 +142,16 @@ extern "C" {
 /* The following options can be individually controlled to customize the
  * ML-DSA configuration */
 #if 0
-#define WOLFSSL_DILITHIUM_VERIFY_ONLY
+#define WOLFSSL_MLDSA_VERIFY_ONLY
 #endif
 #if 0
-#define WOLFSSL_DILITHIUM_NO_VERIFY
+#define WOLFSSL_MLDSA_NO_VERIFY
 #endif
 #if 0
-#define WOLFSSL_DILITHIUM_NO_SIGN
+#define WOLFSSL_MLDSA_NO_SIGN
 #endif
 #if 0
-#define WOLFSSL_DILITHIUM_NO_MAKE_KEY
+#define WOLFSSL_MLDSA_NO_MAKE_KEY
 #endif
 
 /** Composite features */

--- a/benchmark/wh_bench.c
+++ b/benchmark/wh_bench.c
@@ -228,7 +228,7 @@ typedef enum BenchModuleIdx {
 #endif /* HAVE_CURVE25519 */
 
 /* ML-DSA */
-#if defined(HAVE_DILITHIUM)
+#if defined(WOLFSSL_HAVE_MLDSA)
 #if !defined(WOLFSSL_NO_ML_DSA_44)
     BENCH_MODULE_IDX_ML_DSA_44_SIGN,
     BENCH_MODULE_IDX_ML_DSA_44_SIGN_DMA,
@@ -253,7 +253,7 @@ typedef enum BenchModuleIdx {
     BENCH_MODULE_IDX_ML_DSA_87_KEY_GEN,
     BENCH_MODULE_IDX_ML_DSA_87_KEY_GEN_DMA,
 #endif /* !(WOLFSSL_NO_ML_DSA_87) */
-#endif /* HAVE_DILITHIUM */
+#endif /* WOLFSSL_HAVE_MLDSA */
 #endif /* !(WOLFHSM_CFG_NO_CRYPTO) */
     /* number of modules. This must be the last entry and will be used as the
      * size of the global modules array */
@@ -414,7 +414,7 @@ static BenchModule g_benchModules[] = {
 #endif /* HAVE_CURVE25519 */
 
     /* ML-DSA */
-#if defined(HAVE_DILITHIUM)
+#if defined(WOLFSSL_HAVE_MLDSA)
 #if !defined(WOLFSSL_NO_ML_DSA_44)
     [BENCH_MODULE_IDX_ML_DSA_44_SIGN]          = {"ML-DSA-44-SIGN",               wh_Bench_Mod_MlDsa44Sign,             BENCH_THROUGHPUT_OPS, 0, NULL},
     [BENCH_MODULE_IDX_ML_DSA_44_SIGN_DMA]      = {"ML-DSA-44-SIGN-DMA",           wh_Bench_Mod_MlDsa44SignDma,          BENCH_THROUGHPUT_OPS, 0, NULL},
@@ -439,7 +439,7 @@ static BenchModule g_benchModules[] = {
     [BENCH_MODULE_IDX_ML_DSA_87_KEY_GEN]       = {"ML-DSA-87-KEY-GEN",            wh_Bench_Mod_MlDsa87KeyGen,           BENCH_THROUGHPUT_OPS, 0, NULL},
     [BENCH_MODULE_IDX_ML_DSA_87_KEY_GEN_DMA]   = {"ML-DSA-87-KEY-GEN-DMA",        wh_Bench_Mod_MlDsa87KeyGenDma,        BENCH_THROUGHPUT_OPS, 0, NULL},
 #endif /* !(WOLFSSL_NO_ML_DSA_87) */
-#endif /* HAVE_DILITHIUM */
+#endif /* WOLFSSL_HAVE_MLDSA */
 #endif /* !(WOLFHSM_CFG_NO_CRYPTO) */
 };
 /* clang-format on */

--- a/docs/src-ja/chapter05.md
+++ b/docs/src-ja/chapter05.md
@@ -319,7 +319,7 @@ int wh_Client_Ed25519ExportPublicKey(whClientContext* ctx, whKeyId keyId,
 int wh_Client_Curve25519ExportPublicKey(whClientContext* ctx, whKeyId keyId,
         curve25519_key* key, uint16_t label_len, uint8_t* label);
 int wh_Client_MlDsaExportPublicKey(whClientContext* ctx, whKeyId keyId,
-        MlDsaKey* key, uint16_t label_len, uint8_t* label);
+        wc_MlDsaKey* key, uint16_t label_len, uint8_t* label);
 ```
 
 例: HSM上でRSAの鍵ペアを生成し秘密鍵を`NONEXPORTABLE`でマークしたうえで、クライアント側で公開鍵を取得し、HSMがキャッシュされた秘密鍵で生成した署名を検証する。
@@ -353,7 +353,7 @@ int wh_Client_KeyExportPublicDma(whClientContext* c, whKeyId keyId,
         uint8_t* label, uint16_t labelSz, uint16_t* outSz);
 
 int wh_Client_MlDsaExportPublicKeyDma(whClientContext* ctx, whKeyId keyId,
-        MlDsaKey* key, uint16_t label_len, uint8_t* label);
+        wc_MlDsaKey* key, uint16_t label_len, uint8_t* label);
 ```
 
 `wh_Client_KeyExportPublicDma`は汎用トランスポートで、呼び出し側は生の公開鍵DERを受け取って自身でデシリアライズします。`wh_Client_MlDsaExportPublicKeyDma`は既存の`wh_Client_MlDsaExportKeyDma`に対応するML-DSA専用ヘルパーで、ML-DSAの大きな公開鍵DERを通信バッファにコピーせずに済ませたい場合に使用できます。

--- a/docs/src/chapter05.md
+++ b/docs/src/chapter05.md
@@ -312,7 +312,7 @@ int wh_Client_Ed25519ExportPublicKey(whClientContext* ctx, whKeyId keyId,
 int wh_Client_Curve25519ExportPublicKey(whClientContext* ctx, whKeyId keyId,
         curve25519_key* key, uint16_t label_len, uint8_t* label);
 int wh_Client_MlDsaExportPublicKey(whClientContext* ctx, whKeyId keyId,
-        MlDsaKey* key, uint16_t label_len, uint8_t* label);
+        wc_MlDsaKey* key, uint16_t label_len, uint8_t* label);
 ```
 
 Example: generate an RSA keypair on the HSM with the private key marked
@@ -358,7 +358,7 @@ int wh_Client_KeyExportPublicDma(whClientContext* c, whKeyId keyId,
         uint8_t* label, uint16_t labelSz, uint16_t* outSz);
 
 int wh_Client_MlDsaExportPublicKeyDma(whClientContext* ctx, whKeyId keyId,
-        MlDsaKey* key, uint16_t label_len, uint8_t* label);
+        wc_MlDsaKey* key, uint16_t label_len, uint8_t* label);
 ```
 
 `wh_Client_KeyExportPublicDma` is the generic transport — callers receive

--- a/examples/posix/wh_posix_server/user_settings.h
+++ b/examples/posix/wh_posix_server/user_settings.h
@@ -129,9 +129,8 @@ extern "C" {
 #define WOLFSSL_SHA512
 #define WOLFSSL_SHA512_HASHTYPE
 
-/* Dilithium Options */
-#define HAVE_DILITHIUM
-#define WOLFSSL_WC_DILITHIUM /* use wolfCrypt implementation, not libOQS */
+/* ML-DSA Options */
+#define WOLFSSL_HAVE_MLDSA
 #define WOLFSSL_SHA3
 #define WOLFSSL_SHAKE128
 #define WOLFSSL_SHAKE256
@@ -139,16 +138,16 @@ extern "C" {
 /* The following options can be individually controlled to customize the
  * ML-DSA configuration */
 #if 0
-#define WOLFSSL_DILITHIUM_VERIFY_ONLY
+#define WOLFSSL_MLDSA_VERIFY_ONLY
 #endif
 #if 0
-#define WOLFSSL_DILITHIUM_NO_VERIFY
+#define WOLFSSL_MLDSA_NO_VERIFY
 #endif
 #if 0
-#define WOLFSSL_DILITHIUM_NO_SIGN
+#define WOLFSSL_MLDSA_NO_SIGN
 #endif
 #if 0
-#define WOLFSSL_DILITHIUM_NO_MAKE_KEY
+#define WOLFSSL_MLDSA_NO_MAKE_KEY
 #endif
 
 /** Composite features */

--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -54,7 +54,7 @@
 #include "wolfssl/wolfcrypt/ecc.h"
 #include "wolfssl/wolfcrypt/curve25519.h"
 #include "wolfssl/wolfcrypt/ed25519.h"
-#include "wolfssl/wolfcrypt/dilithium.h"
+#include "wolfssl/wolfcrypt/wc_mldsa.h"
 #include "wolfssl/wolfcrypt/sha256.h"
 #include "wolfssl/wolfcrypt/sha512.h"
 #endif
@@ -114,18 +114,18 @@ static int _CmacKdfMakeKey(whClientContext* ctx, whKeyId saltKeyId,
                            uint8_t* out, uint32_t outSz);
 #endif
 
-#ifdef HAVE_DILITHIUM
+#ifdef WOLFSSL_HAVE_MLDSA
 /* Make a ML-DSA key on the server based on the flags */
 static int _MlDsaMakeKey(whClientContext* ctx, int size, int level,
                          whKeyId* inout_key_id, whNvmFlags flags,
-                         uint16_t label_len, uint8_t* label, MlDsaKey* key);
+                         uint16_t label_len, uint8_t* label, wc_MlDsaKey* key);
 
 #ifdef WOLFHSM_CFG_DMA
 static int _MlDsaMakeKeyDma(whClientContext* ctx, int level,
                             whKeyId* inout_key_id, whNvmFlags flags,
-                            uint16_t label_len, uint8_t* label, MlDsaKey* key);
+                            uint16_t label_len, uint8_t* label, wc_MlDsaKey* key);
 #endif /* WOLFHSM_CFG_DMA */
-#endif /* HAVE_DILITHIUM */
+#endif /* WOLFSSL_HAVE_MLDSA */
 
 static uint8_t* _createCryptoRequest(uint8_t* reqBuf, uint16_t type,
                                      uint32_t affinity);
@@ -3069,7 +3069,7 @@ int wh_Client_Curve25519SharedSecret(whClientContext* ctx,
                             ret = WH_ERROR_ABORTED;
                         }
                         if (out_size != NULL) {
-                            if ((ret >= 0) && 
+                            if ((ret >= 0) &&
                                 (out != NULL) && (res->sz > *out_size)) {
                                 /* Output buffer too small. Report required size
                                 * and fail rather than silently truncating
@@ -7318,9 +7318,9 @@ int wh_Client_Sha512Dma(whClientContext* ctx, wc_Sha512* sha, const uint8_t* in,
 #endif /* WOLFHSM_CFG_DMA  */
 #endif /* WOLFSSL_SHA512 */
 
-#ifdef HAVE_DILITHIUM
+#ifdef WOLFSSL_HAVE_MLDSA
 
-int wh_Client_MlDsaSetKeyId(MlDsaKey* key, whKeyId keyId)
+int wh_Client_MlDsaSetKeyId(wc_MlDsaKey* key, whKeyId keyId)
 {
     if (key == NULL) {
         return WH_ERROR_BADARGS;
@@ -7331,7 +7331,7 @@ int wh_Client_MlDsaSetKeyId(MlDsaKey* key, whKeyId keyId)
     return WH_ERROR_OK;
 }
 
-int wh_Client_MlDsaGetKeyId(MlDsaKey* key, whKeyId* outId)
+int wh_Client_MlDsaGetKeyId(wc_MlDsaKey* key, whKeyId* outId)
 {
     if (key == NULL || outId == NULL) {
         return WH_ERROR_BADARGS;
@@ -7342,13 +7342,13 @@ int wh_Client_MlDsaGetKeyId(MlDsaKey* key, whKeyId* outId)
     return WH_ERROR_OK;
 }
 
-int wh_Client_MlDsaImportKey(whClientContext* ctx, MlDsaKey* key,
+int wh_Client_MlDsaImportKey(whClientContext* ctx, wc_MlDsaKey* key,
                              whKeyId* inout_keyId, whNvmFlags flags,
                              uint16_t label_len, uint8_t* label)
 {
     int      ret    = WH_ERROR_OK;
     whKeyId  key_id = WH_KEYID_ERASED;
-    byte     buffer[DILITHIUM_MAX_BOTH_KEY_DER_SIZE];
+    byte     buffer[MLDSA_MAX_BOTH_KEY_DER_SIZE];
     uint16_t buffer_len = 0;
 
     if ((ctx == NULL) || (key == NULL) ||
@@ -7380,12 +7380,12 @@ int wh_Client_MlDsaImportKey(whClientContext* ctx, MlDsaKey* key,
     return ret;
 }
 
-int wh_Client_MlDsaExportKey(whClientContext* ctx, whKeyId keyId, MlDsaKey* key,
+int wh_Client_MlDsaExportKey(whClientContext* ctx, whKeyId keyId, wc_MlDsaKey* key,
                              uint16_t label_len, uint8_t* label)
 {
     int ret = WH_ERROR_OK;
     /* buffer cannot be larger than MTU */
-    byte     buffer[DILITHIUM_MAX_BOTH_KEY_DER_SIZE];
+    byte     buffer[MLDSA_MAX_BOTH_KEY_DER_SIZE];
     uint16_t buffer_len = sizeof(buffer);
 
     if ((ctx == NULL) || WH_KEYID_ISERASED(keyId) || (key == NULL)) {
@@ -7406,7 +7406,7 @@ int wh_Client_MlDsaExportKey(whClientContext* ctx, whKeyId keyId, MlDsaKey* key,
 }
 
 int wh_Client_MlDsaExportPublicKey(whClientContext* ctx, whKeyId keyId,
-                                   MlDsaKey* key, uint16_t label_len,
+                                   wc_MlDsaKey* key, uint16_t label_len,
                                    uint8_t* label)
 {
     int      ret;
@@ -7427,7 +7427,7 @@ int wh_Client_MlDsaExportPublicKey(whClientContext* ctx, whKeyId keyId,
 
 static int _MlDsaMakeKey(whClientContext* ctx, int size, int level,
                          whKeyId* inout_key_id, whNvmFlags flags,
-                         uint16_t label_len, uint8_t* label, MlDsaKey* key)
+                         uint16_t label_len, uint8_t* label, wc_MlDsaKey* key)
 {
     int                                  ret     = WH_ERROR_OK;
     whKeyId                              key_id  = WH_KEYID_ERASED;
@@ -7447,7 +7447,7 @@ static int _MlDsaMakeKey(whClientContext* ctx, int size, int level,
 
     /* Setup generic header and get pointer to request data */
     req = (whMessageCrypto_MlDsaKeyGenRequest*)_createCryptoRequestWithSubtype(
-        dataPtr, WC_PK_TYPE_PQC_SIG_KEYGEN, WC_PQC_SIG_TYPE_DILITHIUM,
+        dataPtr, WC_PK_TYPE_PQC_SIG_KEYGEN, WC_PQC_SIG_TYPE_MLDSA,
         ctx->cryptoAffinity);
 
     /* Use the supplied key id if provided */
@@ -7548,7 +7548,7 @@ int wh_Client_MlDsaMakeCacheKey(whClientContext* ctx, int size, int level,
 }
 
 int wh_Client_MlDsaMakeExportKey(whClientContext* ctx, int level, int size,
-                                 MlDsaKey* key)
+                                 wc_MlDsaKey* key)
 {
     if (key == NULL) {
         return WH_ERROR_BADARGS;
@@ -7560,7 +7560,7 @@ int wh_Client_MlDsaMakeExportKey(whClientContext* ctx, int level, int size,
 
 
 int wh_Client_MlDsaSign(whClientContext* ctx, const byte* in, word32 in_len,
-                      byte* out, word32* inout_len, MlDsaKey* key,
+                      byte* out, word32* inout_len, wc_MlDsaKey* key,
                       const byte* context, byte contextLen,
                       word32 preHashType)
 {
@@ -7618,7 +7618,7 @@ int wh_Client_MlDsaSign(whClientContext* ctx, const byte* in, word32 in_len,
         /* Setup generic header and get pointer to request data */
         req =
             (whMessageCrypto_MlDsaSignRequest*)_createCryptoRequestWithSubtype(
-                dataPtr, WC_PK_TYPE_PQC_SIG_SIGN, WC_PQC_SIG_TYPE_DILITHIUM,
+                dataPtr, WC_PK_TYPE_PQC_SIG_SIGN, WC_PQC_SIG_TYPE_MLDSA,
                 ctx->cryptoAffinity);
 
         if (total_len <= WOLFHSM_CFG_COMM_DATA_LEN) {
@@ -7697,7 +7697,7 @@ int wh_Client_MlDsaSign(whClientContext* ctx, const byte* in, word32 in_len,
 
 int wh_Client_MlDsaVerify(whClientContext* ctx, const byte* sig, word32 sig_len,
                          const byte* msg, word32 msg_len, int* out_res,
-                         MlDsaKey* key, const byte* context, byte contextLen,
+                         wc_MlDsaKey* key, const byte* context, byte contextLen,
                          word32 preHashType)
 {
     int                                  ret     = WH_ERROR_OK;
@@ -7754,7 +7754,7 @@ int wh_Client_MlDsaVerify(whClientContext* ctx, const byte* sig, word32 sig_len,
         /* Setup generic header and get pointer to request data */
         req = (whMessageCrypto_MlDsaVerifyRequest*)
             _createCryptoRequestWithSubtype(dataPtr, WC_PK_TYPE_PQC_SIG_VERIFY,
-                                            WC_PQC_SIG_TYPE_DILITHIUM,
+                                            WC_PQC_SIG_TYPE_MLDSA,
                                             ctx->cryptoAffinity);
 
         if (total_len <= WOLFHSM_CFG_COMM_DATA_LEN) {
@@ -7826,7 +7826,7 @@ int wh_Client_MlDsaVerify(whClientContext* ctx, const byte* sig, word32 sig_len,
     return ret;
 }
 
-int wh_Client_MlDsaCheckPrivKey(whClientContext* ctx, MlDsaKey* key,
+int wh_Client_MlDsaCheckPrivKey(whClientContext* ctx, wc_MlDsaKey* key,
                                 const byte* pubKey, word32 pubKeySz)
 {
     /* TODO */
@@ -7840,13 +7840,13 @@ int wh_Client_MlDsaCheckPrivKey(whClientContext* ctx, MlDsaKey* key,
 
 #ifdef WOLFHSM_CFG_DMA
 
-int wh_Client_MlDsaImportKeyDma(whClientContext* ctx, MlDsaKey* key,
+int wh_Client_MlDsaImportKeyDma(whClientContext* ctx, wc_MlDsaKey* key,
                                 whKeyId* inout_keyId, whNvmFlags flags,
                                 uint16_t label_len, uint8_t* label)
 {
     int      ret    = WH_ERROR_OK;
     whKeyId  key_id = WH_KEYID_ERASED;
-    byte     buffer[DILITHIUM_MAX_BOTH_KEY_DER_SIZE];
+    byte     buffer[MLDSA_MAX_BOTH_KEY_DER_SIZE];
     uint16_t buffer_len = 0;
 
     if ((ctx == NULL) || (key == NULL) ||
@@ -7874,11 +7874,11 @@ int wh_Client_MlDsaImportKeyDma(whClientContext* ctx, MlDsaKey* key,
 }
 
 int wh_Client_MlDsaExportKeyDma(whClientContext* ctx, whKeyId keyId,
-                                MlDsaKey* key, uint16_t label_len,
+                                wc_MlDsaKey* key, uint16_t label_len,
                                 uint8_t* label)
 {
     int      ret                                = WH_ERROR_OK;
-    byte     buffer[DILITHIUM_MAX_BOTH_KEY_DER_SIZE] = {0};
+    byte     buffer[MLDSA_MAX_BOTH_KEY_DER_SIZE] = {0};
     uint16_t buffer_len                         = sizeof(buffer);
 
     if ((ctx == NULL) || WH_KEYID_ISERASED(keyId) || (key == NULL)) {
@@ -7897,11 +7897,11 @@ int wh_Client_MlDsaExportKeyDma(whClientContext* ctx, whKeyId keyId,
 }
 
 int wh_Client_MlDsaExportPublicKeyDma(whClientContext* ctx, whKeyId keyId,
-                                      MlDsaKey* key, uint16_t label_len,
+                                      wc_MlDsaKey* key, uint16_t label_len,
                                       uint8_t* label)
 {
     int      ret;
-    byte     buffer[DILITHIUM_MAX_BOTH_KEY_DER_SIZE] = {0};
+    byte     buffer[MLDSA_MAX_BOTH_KEY_DER_SIZE] = {0};
     uint16_t buffer_len                              = sizeof(buffer);
 
     if ((ctx == NULL) || WH_KEYID_ISERASED(keyId) || (key == NULL)) {
@@ -7919,11 +7919,11 @@ int wh_Client_MlDsaExportPublicKeyDma(whClientContext* ctx, whKeyId keyId,
 
 static int _MlDsaMakeKeyDma(whClientContext* ctx, int level,
                             whKeyId* inout_key_id, whNvmFlags flags,
-                            uint16_t label_len, uint8_t* label, MlDsaKey* key)
+                            uint16_t label_len, uint8_t* label, wc_MlDsaKey* key)
 {
     int                                     ret    = WH_ERROR_OK;
     whKeyId                                 key_id = WH_KEYID_ERASED;
-    byte                                    buffer[DILITHIUM_MAX_BOTH_KEY_DER_SIZE];
+    byte                                    buffer[MLDSA_MAX_BOTH_KEY_DER_SIZE];
     uint8_t*                                dataPtr = NULL;
     whMessageCrypto_MlDsaKeyGenDmaRequest*  req     = NULL;
     whMessageCrypto_MlDsaKeyGenDmaResponse* res     = NULL;
@@ -7943,7 +7943,7 @@ static int _MlDsaMakeKeyDma(whClientContext* ctx, int level,
     /* Setup generic header and get pointer to request data */
     req =
         (whMessageCrypto_MlDsaKeyGenDmaRequest*)_createCryptoRequestWithSubtype(
-            dataPtr, WC_PK_TYPE_PQC_SIG_KEYGEN, WC_PQC_SIG_TYPE_DILITHIUM,
+            dataPtr, WC_PK_TYPE_PQC_SIG_KEYGEN, WC_PQC_SIG_TYPE_MLDSA,
             ctx->cryptoAffinity);
 
     /* Use the supplied key id if provided */
@@ -8034,7 +8034,7 @@ static int _MlDsaMakeKeyDma(whClientContext* ctx, int level,
 
 
 int wh_Client_MlDsaMakeExportKeyDma(whClientContext* ctx, int level,
-                                    MlDsaKey* key)
+                                    wc_MlDsaKey* key)
 {
     if (key == NULL) {
         return WH_ERROR_BADARGS;
@@ -8046,7 +8046,7 @@ int wh_Client_MlDsaMakeExportKeyDma(whClientContext* ctx, int level,
 
 
 int wh_Client_MlDsaSignDma(whClientContext* ctx, const byte* in, word32 in_len,
-                         byte* out, word32* out_len, MlDsaKey* key,
+                         byte* out, word32* out_len, wc_MlDsaKey* key,
                          const byte* context, byte contextLen,
                          word32 preHashType)
 {
@@ -8104,7 +8104,7 @@ int wh_Client_MlDsaSignDma(whClientContext* ctx, const byte* in, word32 in_len,
         /* Setup generic header and get pointer to request data */
         req = (whMessageCrypto_MlDsaSignDmaRequest*)
             _createCryptoRequestWithSubtype(dataPtr, WC_PK_TYPE_PQC_SIG_SIGN,
-                                            WC_PQC_SIG_TYPE_DILITHIUM,
+                                            WC_PQC_SIG_TYPE_MLDSA,
                                             ctx->cryptoAffinity);
 
         if (req_len <= WOLFHSM_CFG_COMM_DATA_LEN) {
@@ -8194,7 +8194,7 @@ int wh_Client_MlDsaSignDma(whClientContext* ctx, const byte* in, word32 in_len,
 
 int wh_Client_MlDsaVerifyDma(whClientContext* ctx, const byte* sig,
                             word32 sig_len, const byte* msg, word32 msg_len,
-                            int* out_res, MlDsaKey* key, const byte* context,
+                            int* out_res, wc_MlDsaKey* key, const byte* context,
                             byte contextLen, word32 preHashType)
 {
     int                                     ret     = 0;
@@ -8248,7 +8248,7 @@ int wh_Client_MlDsaVerifyDma(whClientContext* ctx, const byte* sig,
         /* Setup generic header and get pointer to request data */
         req = (whMessageCrypto_MlDsaVerifyDmaRequest*)
             _createCryptoRequestWithSubtype(dataPtr, WC_PK_TYPE_PQC_SIG_VERIFY,
-                                            WC_PQC_SIG_TYPE_DILITHIUM,
+                                            WC_PQC_SIG_TYPE_MLDSA,
                                             ctx->cryptoAffinity);
 
         if (req_len <= WOLFHSM_CFG_COMM_DATA_LEN) {
@@ -8337,7 +8337,7 @@ int wh_Client_MlDsaVerifyDma(whClientContext* ctx, const byte* sig,
 }
 
 
-int wh_Client_MlDsaCheckPrivKeyDma(whClientContext* ctx, MlDsaKey* key,
+int wh_Client_MlDsaCheckPrivKeyDma(whClientContext* ctx, wc_MlDsaKey* key,
                                    const byte* pubKey, word32 pubKeySz)
 {
     /* TODO */
@@ -8350,6 +8350,6 @@ int wh_Client_MlDsaCheckPrivKeyDma(whClientContext* ctx, MlDsaKey* key,
 
 
 #endif /* WOLFHSM_CFG_DMA */
-#endif /* HAVE_DILITHIUM */
+#endif /* WOLFSSL_HAVE_MLDSA */
 
 #endif /* !WOLFHSM_CFG_NO_CRYPTO && WOLFHSM_CFG_ENABLE_CLIENT */

--- a/src/wh_client_cryptocb.c
+++ b/src/wh_client_cryptocb.c
@@ -54,7 +54,7 @@
 #include "wolfhsm/wh_message_crypto.h"
 
 
-#if defined(HAVE_DILITHIUM) || defined(HAVE_FALCON)
+#if defined(WOLFSSL_HAVE_MLDSA) || defined(HAVE_FALCON)
 static int _handlePqcSigKeyGen(whClientContext* ctx, wc_CryptoInfo* info,
                                int useDma);
 static int _handlePqcSign(whClientContext* ctx, wc_CryptoInfo* info,
@@ -63,7 +63,7 @@ static int _handlePqcVerify(whClientContext* ctx, wc_CryptoInfo* info,
                             int useDma);
 static int _handlePqcSigCheckPrivKey(whClientContext* ctx, wc_CryptoInfo* info,
                                      int useDma);
-#endif /* HAVE_DILITHIUM || HAVE_FALCON */
+#endif /* WOLFSSL_HAVE_MLDSA || HAVE_FALCON */
 
 int wh_Client_CryptoCb(int devId, wc_CryptoInfo* info, void* inCtx)
 {
@@ -422,7 +422,7 @@ int wh_Client_CryptoCb(int devId, wc_CryptoInfo* info, void* inCtx)
 #endif /* HAVE_ED25519 */
 #endif /* HAVE_CURVE25519 */
 
-#if defined(HAVE_DILITHIUM) || defined(HAVE_FALCON)
+#if defined(WOLFSSL_HAVE_MLDSA) || defined(HAVE_FALCON)
         case WC_PK_TYPE_PQC_SIG_KEYGEN:
             ret = _handlePqcSigKeyGen(ctx, info, 0);
             break;
@@ -439,7 +439,7 @@ int wh_Client_CryptoCb(int devId, wc_CryptoInfo* info, void* inCtx)
             ret = _handlePqcSigCheckPrivKey(ctx, info, 0);
             break;
 
-#endif /* HAVE_DILITHIUM || HAVE_FALCON */
+#endif /* WOLFSSL_HAVE_MLDSA || HAVE_FALCON */
 
         case WC_PK_TYPE_NONE:
         default:
@@ -600,7 +600,7 @@ int wh_Client_CryptoCb(int devId, wc_CryptoInfo* info, void* inCtx)
     return ret;
 }
 
-#if defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
+#if defined(HAVE_FALCON) || defined(WOLFSSL_HAVE_MLDSA)
 static int _handlePqcSigKeyGen(whClientContext* ctx, wc_CryptoInfo* info,
                                int useDma)
 {
@@ -619,9 +619,9 @@ static int _handlePqcSigKeyGen(whClientContext* ctx, wc_CryptoInfo* info,
 #endif
 
     switch (type) {
-#ifdef HAVE_DILITHIUM
-        case WC_PQC_SIG_TYPE_DILITHIUM: {
-            int level = ((MlDsaKey*)key)->level;
+#ifdef WOLFSSL_HAVE_MLDSA
+        case WC_PQC_SIG_TYPE_MLDSA: {
+            int level = ((wc_MlDsaKey*)key)->level;
 #ifdef WOLFHSM_CFG_DMA
             if (useDma) {
                 ret = wh_Client_MlDsaMakeExportKeyDma(ctx, level, key);
@@ -632,7 +632,7 @@ static int _handlePqcSigKeyGen(whClientContext* ctx, wc_CryptoInfo* info,
                 ret = wh_Client_MlDsaMakeExportKey(ctx, level, size, key);
             }
         } break;
-#endif /* HAVE_DILITHIUM */
+#endif /* WOLFSSL_HAVE_MLDSA */
 
         /* Support for additional PQC algorithms should be added here */
 
@@ -667,8 +667,8 @@ static int _handlePqcSign(whClientContext* ctx, wc_CryptoInfo* info, int useDma)
 #endif
 
     switch (type) {
-#ifdef HAVE_DILITHIUM
-        case WC_PQC_SIG_TYPE_DILITHIUM:
+#ifdef WOLFSSL_HAVE_MLDSA
+        case WC_PQC_SIG_TYPE_MLDSA:
 #ifdef WOLFHSM_CFG_DMA
             if (useDma) {
                 ret = wh_Client_MlDsaSignDma(ctx, in, in_len, out, out_len,
@@ -682,7 +682,7 @@ static int _handlePqcSign(whClientContext* ctx, wc_CryptoInfo* info, int useDma)
                                              context, contextLen, preHashType);
             }
             break;
-#endif /* HAVE_DILITHIUM */
+#endif /* WOLFSSL_HAVE_MLDSA */
 
         /* Support for additional PQC algorithms should be added here */
 
@@ -719,8 +719,8 @@ static int _handlePqcVerify(whClientContext* ctx, wc_CryptoInfo* info,
 #endif
 
     switch (type) {
-#ifdef HAVE_DILITHIUM
-        case WC_PQC_SIG_TYPE_DILITHIUM:
+#ifdef WOLFSSL_HAVE_MLDSA
+        case WC_PQC_SIG_TYPE_MLDSA:
 #ifdef WOLFHSM_CFG_DMA
             if (useDma) {
                 ret = wh_Client_MlDsaVerifyDma(ctx, sig, sig_len, msg, msg_len,
@@ -735,7 +735,7 @@ static int _handlePqcVerify(whClientContext* ctx, wc_CryptoInfo* info,
                                                preHashType);
             }
             break;
-#endif /* HAVE_DILITHIUM */
+#endif /* WOLFSSL_HAVE_MLDSA */
 
         /* Support for additional PQC algorithms should be added here */
 
@@ -766,8 +766,8 @@ static int _handlePqcSigCheckPrivKey(whClientContext* ctx, wc_CryptoInfo* info,
 #endif
 
     switch (type) {
-#ifdef HAVE_DILITHIUM
-        case WC_PQC_SIG_TYPE_DILITHIUM:
+#ifdef WOLFSSL_HAVE_MLDSA
+        case WC_PQC_SIG_TYPE_MLDSA:
 #ifdef WOLFHSM_CFG_DMA
             if (useDma) {
                 ret =
@@ -779,7 +779,7 @@ static int _handlePqcSigCheckPrivKey(whClientContext* ctx, wc_CryptoInfo* info,
                 ret = wh_Client_MlDsaCheckPrivKey(ctx, key, pubKey, pubKeySz);
             }
             break;
-#endif /* HAVE_DILITHIUM */
+#endif /* WOLFSSL_HAVE_MLDSA */
 
             /* Support for additional PQC algorithms should be added here */
 
@@ -790,7 +790,7 @@ static int _handlePqcSigCheckPrivKey(whClientContext* ctx, wc_CryptoInfo* info,
 
     return ret;
 }
-#endif /* HAVE_FALCON || HAVE_DILITHIUM */
+#endif /* HAVE_FALCON || WOLFSSL_HAVE_MLDSA */
 
 
 #ifdef WOLFHSM_CFG_DMA
@@ -864,7 +864,7 @@ int wh_Client_CryptoCbDma(int devId, wc_CryptoInfo* info, void* inCtx)
 
     case WC_ALGO_TYPE_PK: {
         switch (info->pk.type) {
-#if defined(HAVE_DILITHIUM) || defined(HAVE_FALCON)
+#if defined(WOLFSSL_HAVE_MLDSA) || defined(HAVE_FALCON)
             case WC_PK_TYPE_PQC_SIG_KEYGEN:
                 ret = _handlePqcSigKeyGen(ctx, info, 1);
                 break;
@@ -877,7 +877,7 @@ int wh_Client_CryptoCbDma(int devId, wc_CryptoInfo* info, void* inCtx)
             case WC_PK_TYPE_PQC_SIG_CHECK_PRIV_KEY:
                 ret = _handlePqcSigCheckPrivKey(ctx, info, 1);
                 break;
-#endif /* HAVE_DILITHIUM || HAVE_FALCON */
+#endif /* WOLFSSL_HAVE_MLDSA || HAVE_FALCON */
 #ifdef HAVE_ED25519
             case WC_PK_TYPE_ED25519_KEYGEN: {
                 ed25519_key* key = info->pk.ed25519kg.key;

--- a/src/wh_crypto.c
+++ b/src/wh_crypto.c
@@ -43,7 +43,7 @@
 #include "wolfssl/wolfcrypt/curve25519.h"
 #include "wolfssl/wolfcrypt/ecc.h"
 #include "wolfssl/wolfcrypt/ed25519.h"
-#include "wolfssl/wolfcrypt/dilithium.h"
+#include "wolfssl/wolfcrypt/wc_mldsa.h"
 
 #include "wolfhsm/wh_error.h"
 #include "wolfhsm/wh_utils.h"
@@ -300,8 +300,8 @@ int wh_Crypto_Ed25519DeserializeKeyDer(const uint8_t* buffer, uint16_t size,
 }
 #endif /* HAVE_ED25519 */
 
-#ifdef HAVE_DILITHIUM
-int wh_Crypto_MlDsaSerializeKeyDer(MlDsaKey* key, uint16_t max_size,
+#ifdef WOLFSSL_HAVE_MLDSA
+int wh_Crypto_MlDsaSerializeKeyDer(wc_MlDsaKey* key, uint16_t max_size,
                                    uint8_t* buffer, uint16_t* out_size)
 {
     int ret = 0;
@@ -312,26 +312,26 @@ int wh_Crypto_MlDsaSerializeKeyDer(MlDsaKey* key, uint16_t max_size,
 
     /* Choose appropriate serialization based on key flags */
     if (key->prvKeySet && key->pubKeySet) {
-#if defined(WOLFSSL_DILITHIUM_PRIVATE_KEY) && \
-    defined(WOLFSSL_DILITHIUM_PUBLIC_KEY)
+#if defined(WOLFSSL_MLDSA_PRIVATE_KEY) && \
+    defined(WOLFSSL_MLDSA_PUBLIC_KEY)
         /* Full keypair - use KeyToDer */
-        ret = wc_Dilithium_KeyToDer(key, buffer, max_size);
+        ret = wc_MlDsaKey_KeyToDer(key, buffer, max_size);
 #else
         ret = WH_ERROR_BADARGS;
 #endif
     }
     else if (key->pubKeySet) {
-#ifdef WOLFSSL_DILITHIUM_PUBLIC_KEY
+#ifdef WOLFSSL_MLDSA_PUBLIC_KEY
         /* Public key only - use PublicKeyToDer with SPKI format */
-        ret = wc_Dilithium_PublicKeyToDer(key, buffer, max_size, 1);
+        ret = wc_MlDsaKey_PublicKeyToDer(key, buffer, max_size, 1);
 #else
         ret = WH_ERROR_BADARGS;
 #endif
     }
     else if (key->prvKeySet) {
-#ifdef WOLFSSL_DILITHIUM_PRIVATE_KEY
+#ifdef WOLFSSL_MLDSA_PRIVATE_KEY
         /* Private key only */
-        ret = wc_Dilithium_PrivateKeyToDer(key, buffer, max_size);
+        ret = wc_MlDsaKey_PrivateKeyToDer(key, buffer, max_size);
 #else
         ret = WH_ERROR_BADARGS;
 #endif
@@ -350,7 +350,7 @@ int wh_Crypto_MlDsaSerializeKeyDer(MlDsaKey* key, uint16_t max_size,
 }
 
 int wh_Crypto_MlDsaDeserializeKeyDer(const uint8_t* buffer, uint16_t size,
-        MlDsaKey* key)
+        wc_MlDsaKey* key)
 {
     word32 idx = 0;
     int ret;
@@ -359,25 +359,25 @@ int wh_Crypto_MlDsaDeserializeKeyDer(const uint8_t* buffer, uint16_t size,
         return WH_ERROR_BADARGS;
     }
 
-#if defined(WOLFSSL_DILITHIUM_PRIVATE_KEY) && \
-    defined(WOLFSSL_DILITHIUM_PUBLIC_KEY)
+#if defined(WOLFSSL_MLDSA_PRIVATE_KEY) && \
+    defined(WOLFSSL_MLDSA_PUBLIC_KEY)
     /* Try private key first, if that fails try public key */
-    ret = wc_Dilithium_PrivateKeyDecode(buffer, &idx, key, size);
+    ret = wc_MlDsaKey_PrivateKeyDecode(key, buffer, size, &idx);
     if (ret != 0) {
         /* Reset index before trying public key */
         idx = 0;
-        ret = wc_Dilithium_PublicKeyDecode(buffer, &idx, key, size);
+        ret = wc_MlDsaKey_PublicKeyDecode(key, buffer, size, &idx);
     }
-#elif defined(WOLFSSL_DILITHIUM_PUBLIC_KEY)
-    ret = wc_Dilithium_PublicKeyDecode(buffer, &idx, key, size);
-#elif defined(WOLFSSL_DILITHIUM_PRIVATE_KEY)
-    ret = wc_Dilithium_PrivateKeyDecode(buffer, &idx, key, size);
+#elif defined(WOLFSSL_MLDSA_PUBLIC_KEY)
+    ret = wc_MlDsaKey_PublicKeyDecode(key, buffer, size, &idx);
+#elif defined(WOLFSSL_MLDSA_PRIVATE_KEY)
+    ret = wc_MlDsaKey_PrivateKeyDecode(key, buffer, size, &idx);
 #else
     ret = WH_ERROR_BADARGS;
 #endif
     return ret;
 }
-#endif /* HAVE_DILITHIUM */
+#endif /* WOLFSSL_HAVE_MLDSA */
 
 #ifdef WOLFSSL_CMAC
 void wh_Crypto_CmacAesSaveStateToMsg(whMessageCrypto_CmacAesState* state,

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -43,7 +43,7 @@
 #include "wolfssl/wolfcrypt/sha256.h"
 #include "wolfssl/wolfcrypt/sha512.h"
 #include "wolfssl/wolfcrypt/cmac.h"
-#include "wolfssl/wolfcrypt/dilithium.h"
+#include "wolfssl/wolfcrypt/wc_mldsa.h"
 #include "wolfssl/wolfcrypt/hmac.h"
 #include "wolfssl/wolfcrypt/kdf.h"
 
@@ -173,26 +173,26 @@ static int _HandleEd25519VerifyDma(whServerContext* ctx, uint16_t magic,
 #endif /* WOLFHSM_CFG_DMA */
 #endif /* HAVE_ED25519 */
 
-#ifdef HAVE_DILITHIUM
-/* Process a Dilithium KeyGen request packet and produce a response packet */
+#ifdef WOLFSSL_HAVE_MLDSA
+/* Process an ML-DSA KeyGen request packet and produce a response packet */
 static int _HandleMlDsaKeyGen(whServerContext* ctx, uint16_t magic, int devId,
                               const void* cryptoDataIn, uint16_t inSize,
                               void* cryptoDataOut, uint16_t* outSize);
-/* Process a Dilithium Sign request packet and produce a response packet */
+/* Process an ML-DSA Sign request packet and produce a response packet */
 static int _HandleMlDsaSign(whServerContext* ctx, uint16_t magic, int devId,
                             const void* cryptoDataIn, uint16_t inSize,
                             void* cryptoDataOut, uint16_t* outSize);
-/* Process a Dilithium Verify request packet and produce a response packet */
+/* Process an ML-DSA Verify request packet and produce a response packet */
 static int _HandleMlDsaVerify(whServerContext* ctx, uint16_t magic, int devId,
                               const void* cryptoDataIn, uint16_t inSize,
                               void* cryptoDataOut, uint16_t* outSize);
-/* Process a Dilithium Check PrivKey request packet and produce a response
+/* Process an ML-DSA Check PrivKey request packet and produce a response
  * packet */
 static int _HandleMlDsaCheckPrivKey(whServerContext* ctx, uint16_t magic,
                                     int devId, const void* cryptoDataIn,
                                     uint16_t inSize, void* cryptoDataOut,
                                     uint16_t* outSize);
-#endif /* HAVE_DILITHIUM */
+#endif /* WOLFSSL_HAVE_MLDSA */
 
 /** Public server crypto functions */
 
@@ -731,8 +731,8 @@ int wh_Server_CacheExportCurve25519Key(whServerContext* server, whKeyId keyId,
 }
 #endif /* HAVE_CURVE25519 */
 
-#ifdef HAVE_DILITHIUM
-int wh_Server_MlDsaKeyCacheImport(whServerContext* ctx, MlDsaKey* key,
+#ifdef WOLFSSL_HAVE_MLDSA
+int wh_Server_MlDsaKeyCacheImport(whServerContext* ctx, wc_MlDsaKey* key,
                                   whKeyId keyId, whNvmFlags flags,
                                   uint16_t label_len, uint8_t* label)
 {
@@ -743,11 +743,11 @@ int wh_Server_MlDsaKeyCacheImport(whServerContext* ctx, MlDsaKey* key,
 
     const uint16_t MAX_MLDSA_DER_SIZE =
 #if !defined(WOLFSSL_NO_ML_DSA_87)
-        ML_DSA_LEVEL5_PRV_KEY_DER_SIZE;
+        WC_MLDSA_87_PRV_KEY_DER_SIZE;
 #elif !defined(WOLFSSL_NO_ML_DSA_65)
-        ML_DSA_LEVEL3_PRV_KEY_DER_SIZE;
+        WC_MLDSA_65_PRV_KEY_DER_SIZE;
 #else
-        ML_DSA_LEVEL2_PRV_KEY_DER_SIZE;
+        WC_MLDSA_44_PRV_KEY_DER_SIZE;
 #endif
 
     if ((ctx == NULL) || (key == NULL) || (WH_KEYID_ISERASED(keyId)) ||
@@ -778,7 +778,7 @@ int wh_Server_MlDsaKeyCacheImport(whServerContext* ctx, MlDsaKey* key,
 }
 
 int wh_Server_MlDsaKeyCacheExport(whServerContext* ctx, whKeyId keyId,
-                                  MlDsaKey* key)
+                                  wc_MlDsaKey* key)
 {
     uint8_t*       cacheBuf;
     whNvmMetadata* cacheMeta;
@@ -796,7 +796,7 @@ int wh_Server_MlDsaKeyCacheExport(whServerContext* ctx, whKeyId keyId,
     }
     return ret;
 }
-#endif /* HAVE_DILITHIUM */
+#endif /* WOLFSSL_HAVE_MLDSA */
 
 
 /** Request/Response Handling functions */
@@ -4066,9 +4066,9 @@ static int _HandleSha512(whServerContext* ctx, uint16_t magic, int devId,
     return ret;
 }
 #endif /* WOLFSSL_SHA512 */
-#ifdef HAVE_DILITHIUM
+#ifdef WOLFSSL_HAVE_MLDSA
 
-#ifndef WOLFSSL_DILITHIUM_NO_MAKE_KEY
+#ifndef WOLFSSL_MLDSA_NO_MAKE_KEY
 /* Check if the ML-DSA security level is supported
  * returns 1 if supported, 0 otherwise */
 static int _IsMlDsaLevelSupported(int level)
@@ -4098,13 +4098,13 @@ static int _IsMlDsaLevelSupported(int level)
 
     return ret;
 }
-#endif /* WOLFSSL_DILITHIUM_NO_MAKE_KEY */
+#endif /* WOLFSSL_MLDSA_NO_MAKE_KEY */
 
 static int _HandleMlDsaKeyGen(whServerContext* ctx, uint16_t magic, int devId,
                               const void* cryptoDataIn, uint16_t inSize,
                               void* cryptoDataOut, uint16_t* outSize)
 {
-#ifdef WOLFSSL_DILITHIUM_NO_MAKE_KEY
+#ifdef WOLFSSL_MLDSA_NO_MAKE_KEY
     (void)ctx;
     (void)magic;
     (void)cryptoDataIn;
@@ -4116,7 +4116,7 @@ static int _HandleMlDsaKeyGen(whServerContext* ctx, uint16_t magic, int devId,
     (void)inSize;
 
     int                                 ret = WH_ERROR_OK;
-    MlDsaKey                            key[1];
+    wc_MlDsaKey                         key[1];
     whMessageCrypto_MlDsaKeyGenRequest  req;
     whMessageCrypto_MlDsaKeyGenResponse res;
 
@@ -4207,14 +4207,14 @@ static int _HandleMlDsaKeyGen(whServerContext* ctx, uint16_t magic, int devId,
         }
     }
     return ret;
-#endif /* WOLFSSL_DILITHIUM_NO_MAKE_KEY */
+#endif /* WOLFSSL_MLDSA_NO_MAKE_KEY */
 }
 
 static int _HandleMlDsaSign(whServerContext* ctx, uint16_t magic, int devId,
                             const void* cryptoDataIn, uint16_t inSize,
                             void* cryptoDataOut, uint16_t* outSize)
 {
-#ifdef WOLFSSL_DILITHIUM_NO_SIGN
+#ifdef WOLFSSL_MLDSA_NO_SIGN
     (void)ctx;
     (void)magic;
     (void)cryptoDataIn;
@@ -4226,7 +4226,7 @@ static int _HandleMlDsaSign(whServerContext* ctx, uint16_t magic, int devId,
     (void)inSize;
 
     int                                 ret;
-    MlDsaKey                            key[1];
+    wc_MlDsaKey                         key[1];
     whMessageCrypto_MlDsaSignRequest    req;
     whMessageCrypto_MlDsaSignResponse   res;
 
@@ -4314,14 +4314,14 @@ cleanup:
         *outSize = sizeof(whMessageCrypto_MlDsaSignResponse) + res_len;
     }
     return ret;
-#endif /* WOLFSSL_DILITHIUM_NO_SIGN */
+#endif /* WOLFSSL_MLDSA_NO_SIGN */
 }
 
 static int _HandleMlDsaVerify(whServerContext* ctx, uint16_t magic, int devId,
                               const void* cryptoDataIn, uint16_t inSize,
                               void* cryptoDataOut, uint16_t* outSize)
 {
-#ifdef WOLFSSL_DILITHIUM_NO_VERIFY
+#ifdef WOLFSSL_MLDSA_NO_VERIFY
     (void)ctx;
     (void)magic;
     (void)cryptoDataIn;
@@ -4331,7 +4331,7 @@ static int _HandleMlDsaVerify(whServerContext* ctx, uint16_t magic, int devId,
     return WH_ERROR_NOHANDLER;
 #else
     int                                 ret;
-    MlDsaKey                            key[1];
+    wc_MlDsaKey                         key[1];
     whMessageCrypto_MlDsaVerifyRequest  req;
     whMessageCrypto_MlDsaVerifyResponse res;
 
@@ -4419,7 +4419,7 @@ cleanup:
         *outSize = sizeof(whMessageCrypto_MlDsaVerifyResponse);
     }
     return ret;
-#endif /* WOLFSSL_DILITHIUM_NO_VERIFY */
+#endif /* WOLFSSL_MLDSA_NO_VERIFY */
 }
 
 static int _HandleMlDsaCheckPrivKey(whServerContext* ctx, uint16_t magic,
@@ -4436,9 +4436,9 @@ static int _HandleMlDsaCheckPrivKey(whServerContext* ctx, uint16_t magic,
     (void)outSize;
     return WH_ERROR_NOHANDLER;
 }
-#endif /* HAVE_DILITHIUM */
+#endif /* WOLFSSL_HAVE_MLDSA */
 
-#if defined(HAVE_DILITHIUM) || defined(HAVE_FALCON)
+#if defined(WOLFSSL_HAVE_MLDSA) || defined(HAVE_FALCON)
 static int _HandlePqcSigAlgorithm(whServerContext* ctx, uint16_t magic,
                                   int devId, const void* cryptoDataIn,
                                   uint16_t cryptoInSize, void* cryptoDataOut,
@@ -4450,8 +4450,8 @@ static int _HandlePqcSigAlgorithm(whServerContext* ctx, uint16_t magic,
     /* Dispatch the appropriate algorithm handler based on the requested PK type
      * and the algorithm type. */
     switch (pqAlgoType) {
-#ifdef HAVE_DILITHIUM
-        case WC_PQC_SIG_TYPE_DILITHIUM: {
+#ifdef WOLFSSL_HAVE_MLDSA
+        case WC_PQC_SIG_TYPE_MLDSA: {
             switch (pkAlgoType) {
                 case WC_PK_TYPE_PQC_SIG_KEYGEN:
                     ret = _HandleMlDsaKeyGen(ctx, magic, devId, cryptoDataIn,
@@ -4478,7 +4478,7 @@ static int _HandlePqcSigAlgorithm(whServerContext* ctx, uint16_t magic,
                     break;
             }
         } break;
-#endif /* HAVE_DILITHIUM */
+#endif /* WOLFSSL_HAVE_MLDSA */
         default:
             ret = WH_ERROR_NOHANDLER;
             break;
@@ -4672,7 +4672,7 @@ int wh_Server_HandleCryptoRequest(whServerContext* ctx, uint16_t magic,
                     break;
 #endif /* HAVE_ED25519 */
 
-#if defined(HAVE_DILITHIUM) || defined(HAVE_FALCON)
+#if defined(WOLFSSL_HAVE_MLDSA) || defined(HAVE_FALCON)
                 case WC_PK_TYPE_PQC_SIG_KEYGEN:
                 case WC_PK_TYPE_PQC_SIG_SIGN:
                 case WC_PK_TYPE_PQC_SIG_VERIFY:
@@ -5279,14 +5279,14 @@ static int _HandleSha512Dma(whServerContext* ctx, uint16_t magic, int devId,
 }
 #endif /* WOLFSSL_SHA512 */
 
-#if defined(HAVE_DILITHIUM)
+#if defined(WOLFSSL_HAVE_MLDSA)
 
 static int _HandleMlDsaKeyGenDma(whServerContext* ctx, uint16_t magic,
                                  int devId, const void* cryptoDataIn,
                                  uint16_t inSize, void* cryptoDataOut,
                                  uint16_t* outSize)
 {
-#ifdef WOLFSSL_DILITHIUM_NO_MAKE_KEY
+#ifdef WOLFSSL_MLDSA_NO_MAKE_KEY
     (void)ctx;
     (void)magic;
     (void)cryptoDataIn;
@@ -5295,10 +5295,10 @@ static int _HandleMlDsaKeyGenDma(whServerContext* ctx, uint16_t magic,
     (void)outSize;
     return WH_ERROR_NOHANDLER;
 #else
-    int      ret = WH_ERROR_OK;
-    MlDsaKey key[1];
-    void*    clientOutAddr = NULL;
-    uint16_t keySize       = 0;
+    int         ret = WH_ERROR_OK;
+    wc_MlDsaKey key[1];
+    void*       clientOutAddr = NULL;
+    uint16_t    keySize       = 0;
 
     whMessageCrypto_MlDsaKeyGenDmaRequest req;
     whMessageCrypto_MlDsaKeyGenDmaResponse res;
@@ -5400,14 +5400,14 @@ static int _HandleMlDsaKeyGenDma(whServerContext* ctx, uint16_t magic,
     *outSize = sizeof(res);
 
     return ret;
-#endif /* WOLFSSL_DILITHIUM_NO_MAKE_KEY */
+#endif /* WOLFSSL_MLDSA_NO_MAKE_KEY */
 }
 
 static int _HandleMlDsaSignDma(whServerContext* ctx, uint16_t magic, int devId,
                                const void* cryptoDataIn, uint16_t inSize,
                                void* cryptoDataOut, uint16_t* outSize)
 {
-#ifdef WOLFSSL_DILITHIUM_NO_SIGN
+#ifdef WOLFSSL_MLDSA_NO_SIGN
     (void)ctx;
     (void)magic;
     (void)cryptoDataIn;
@@ -5416,11 +5416,11 @@ static int _HandleMlDsaSignDma(whServerContext* ctx, uint16_t magic, int devId,
     (void)outSize;
     return WH_ERROR_NOHANDLER;
 #else
-    int      ret = 0;
-    MlDsaKey key[1];
-    void*    msgAddr = NULL;
-    void*    sigAddr = NULL;
-    word32   sigLen   = 0;
+    int         ret = 0;
+    wc_MlDsaKey key[1];
+    void*       msgAddr = NULL;
+    void*       sigAddr = NULL;
+    word32      sigLen   = 0;
 
     whMessageCrypto_MlDsaSignDmaRequest req;
     whMessageCrypto_MlDsaSignDmaResponse res;
@@ -5533,7 +5533,7 @@ static int _HandleMlDsaSignDma(whServerContext* ctx, uint16_t magic, int devId,
     }
 
     return ret;
-#endif /* WOLFSSL_DILITHIUM_NO_SIGN */
+#endif /* WOLFSSL_MLDSA_NO_SIGN */
 }
 
 static int _HandleMlDsaVerifyDma(whServerContext* ctx, uint16_t magic,
@@ -5541,7 +5541,7 @@ static int _HandleMlDsaVerifyDma(whServerContext* ctx, uint16_t magic,
                                  uint16_t inSize, void* cryptoDataOut,
                                  uint16_t* outSize)
 {
-#ifdef WOLFSSL_DILITHIUM_NO_VERIFY
+#ifdef WOLFSSL_MLDSA_NO_VERIFY
     (void)ctx;
     (void)magic;
     (void)cryptoDataIn;
@@ -5550,11 +5550,11 @@ static int _HandleMlDsaVerifyDma(whServerContext* ctx, uint16_t magic,
     (void)outSize;
     return WH_ERROR_NOHANDLER;
 #else
-    int      ret = 0;
-    MlDsaKey key[1];
-    void*    msgAddr  = NULL;
-    void*    sigAddr  = NULL;
-    int      verified = 0;
+    int         ret = 0;
+    wc_MlDsaKey key[1];
+    void*       msgAddr  = NULL;
+    void*       sigAddr  = NULL;
+    int         verified = 0;
 
     whMessageCrypto_MlDsaVerifyDmaRequest req;
     whMessageCrypto_MlDsaVerifyDmaResponse res;
@@ -5665,7 +5665,7 @@ static int _HandleMlDsaVerifyDma(whServerContext* ctx, uint16_t magic,
 
     wc_MlDsaKey_Free(key);
     return ret;
-#endif /* WOLFSSL_DILITHIUM_NO_VERIFY */
+#endif /* WOLFSSL_MLDSA_NO_VERIFY */
 }
 
 static int _HandleMlDsaCheckPrivKeyDma(whServerContext* ctx, uint16_t magic,
@@ -5682,9 +5682,9 @@ static int _HandleMlDsaCheckPrivKeyDma(whServerContext* ctx, uint16_t magic,
     (void)outSize;
     return WH_ERROR_NOHANDLER;
 }
-#endif /* HAVE_DILITHIUM */
+#endif /* WOLFSSL_HAVE_MLDSA */
 
-#if defined(HAVE_DILITHIUM) || defined(HAVE_FALCON)
+#if defined(WOLFSSL_HAVE_MLDSA) || defined(HAVE_FALCON)
 static int _HandlePqcSigAlgorithmDma(whServerContext* ctx, uint16_t magic,
                                      int devId, const void* cryptoDataIn,
                                      uint16_t cryptoInSize, void* cryptoDataOut,
@@ -5696,8 +5696,8 @@ static int _HandlePqcSigAlgorithmDma(whServerContext* ctx, uint16_t magic,
     /* Dispatch the appropriate algorithm handler based on the requested PK type
      * and the algorithm type. */
     switch (pqAlgoType) {
-#ifdef HAVE_DILITHIUM
-        case WC_PQC_SIG_TYPE_DILITHIUM: {
+#ifdef WOLFSSL_HAVE_MLDSA
+        case WC_PQC_SIG_TYPE_MLDSA: {
             switch (pkAlgoType) {
                 case WC_PK_TYPE_PQC_SIG_KEYGEN:
                     ret = _HandleMlDsaKeyGenDma(ctx, magic, devId, cryptoDataIn,
@@ -5724,7 +5724,7 @@ static int _HandlePqcSigAlgorithmDma(whServerContext* ctx, uint16_t magic,
                     break;
             }
         } break;
-#endif /* HAVE_DILITHIUM */
+#endif /* WOLFSSL_HAVE_MLDSA */
         default:
             ret = WH_ERROR_NOHANDLER;
             break;
@@ -5732,7 +5732,7 @@ static int _HandlePqcSigAlgorithmDma(whServerContext* ctx, uint16_t magic,
 
     return ret;
 }
-#endif /* HAVE_DILITHIUM || HAVE_FALCON */
+#endif /* WOLFSSL_HAVE_MLDSA || HAVE_FALCON */
 
 #if defined(WOLFSSL_CMAC) && !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT)
 static int _HandleCmacDma(whServerContext* ctx, uint16_t magic, int devId,
@@ -6094,7 +6094,7 @@ int wh_Server_HandleCryptoDmaRequest(whServerContext* ctx, uint16_t magic,
 
         case WC_ALGO_TYPE_PK:
             switch (rqstHeader.algoType) {
-#if defined(HAVE_DILITHIUM) || defined(HAVE_FALCON)
+#if defined(WOLFSSL_HAVE_MLDSA) || defined(HAVE_FALCON)
                 case WC_PK_TYPE_PQC_SIG_KEYGEN:
                 case WC_PK_TYPE_PQC_SIG_SIGN:
                 case WC_PK_TYPE_PQC_SIG_VERIFY:
@@ -6104,7 +6104,7 @@ int wh_Server_HandleCryptoDmaRequest(whServerContext* ctx, uint16_t magic,
                         cryptoDataOut, &cryptoOutSize, rqstHeader.algoType,
                         rqstHeader.algoSubType);
                     break;
-#endif /* HAVE_DILITHIUM || HAVE_FALCON */
+#endif /* WOLFSSL_HAVE_MLDSA || HAVE_FALCON */
 #ifdef HAVE_ED25519
                 case WC_PK_TYPE_ED25519_SIGN:
                     ret = _HandleEd25519SignDma(ctx, magic, devId, cryptoDataIn,

--- a/src/wh_server_keystore.c
+++ b/src/wh_server_keystore.c
@@ -64,8 +64,8 @@
 #ifdef HAVE_CURVE25519
 #include "wolfssl/wolfcrypt/curve25519.h"
 #endif
-#ifdef HAVE_DILITHIUM
-#include "wolfssl/wolfcrypt/dilithium.h"
+#ifdef WOLFSSL_HAVE_MLDSA
+#include "wolfssl/wolfcrypt/wc_mldsa.h"
 #endif
 
 static int _FindInCache(whServerContext* server, whKeyId keyId, int* out_index,
@@ -489,13 +489,13 @@ static int _ExportEd25519PublicKey(whServerContext* server, whKeyId keyId,
 }
 #endif
 
-#if defined(HAVE_DILITHIUM) && defined(WOLFSSL_DILITHIUM_PUBLIC_KEY)
+#if defined(WOLFSSL_HAVE_MLDSA) && defined(WOLFSSL_MLDSA_PUBLIC_KEY)
 static int _ExportMldsaPublicKey(whServerContext* server, whKeyId keyId,
     uint8_t* out, uint16_t* outSz)
 {
-    int      ret = WH_ERROR_OK;
-    MlDsaKey key[1];
-    int      pub_ret;
+    int         ret = WH_ERROR_OK;
+    wc_MlDsaKey key[1];
+    int         pub_ret;
 
     ret = wc_MlDsaKey_Init(key, NULL, INVALID_DEVID);
     if (ret == 0) {
@@ -2076,12 +2076,12 @@ int wh_Server_HandleKeyRequest(whServerContext* server, uint16_t magic,
                                                       stage, &stageMax);
                             break;
                     #endif /* HAVE_ED25519 */
-                    #if defined(HAVE_DILITHIUM) && defined(WOLFSSL_DILITHIUM_PUBLIC_KEY)
+                    #if defined(WOLFSSL_HAVE_MLDSA) && defined(WOLFSSL_MLDSA_PUBLIC_KEY)
                         case WH_KEY_ALGO_MLDSA:
                             ret = _ExportMldsaPublicKey(server, serverKeyId,
                                                       stage, &stageMax);
                             break;
-                    #endif /* HAVE_DILITHIUM && WOLFSSL_DILITHIUM_PUBLIC_KEY */
+                    #endif /* WOLFSSL_HAVE_MLDSA && WOLFSSL_MLDSA_PUBLIC_KEY */
                     #ifdef HAVE_CURVE25519
                         case WH_KEY_ALGO_CURVE25519:
                             ret = _ExportCurve25519PublicKey(server, serverKeyId,
@@ -2272,13 +2272,13 @@ int wh_Server_HandleKeyRequest(whServerContext* server, uint16_t magic,
                                                       out, &max_der);
                             break;
                     #endif /* HAVE_ED25519 */
-                    #if defined(HAVE_DILITHIUM) && \
-                                           defined(WOLFSSL_DILITHIUM_PUBLIC_KEY)
+                    #if defined(WOLFSSL_HAVE_MLDSA) && \
+                                           defined(WOLFSSL_MLDSA_PUBLIC_KEY)
                         case WH_KEY_ALGO_MLDSA:
                             ret = _ExportMldsaPublicKey(server, serverKeyId,
                                                         out, &max_der);
                             break;
-                    #endif /* HAVE_DILITHIUM && WOLFSSL_DILITHIUM_PUBLIC_KEY */
+                    #endif /* WOLFSSL_HAVE_MLDSA && WOLFSSL_MLDSA_PUBLIC_KEY */
                     #ifdef HAVE_CURVE25519
                         case WH_KEY_ALGO_CURVE25519:
                             ret = _ExportCurve25519PublicKey(server,
@@ -2413,7 +2413,7 @@ int wh_Server_HandleKeyRequest(whServerContext* server, uint16_t magic,
 
             (void)wh_MessageKeystore_TranslateRevokeResponse(
                 magic, &resp, (whMessageKeystore_RevokeResponse*)resp_packet);
-            
+
             *out_resp_size = sizeof(resp);
         } break;
 

--- a/test/config/user_settings.h
+++ b/test/config/user_settings.h
@@ -132,9 +132,8 @@
 #define WOLFSSL_SHA512
 #define WOLFSSL_SHA512_HASHTYPE
 
-/* Dilithium Options */
-#define HAVE_DILITHIUM
-#define WOLFSSL_WC_DILITHIUM /* use wolfCrypt implementation, not libOQS */
+/* ML-DSA Options */
+#define WOLFSSL_HAVE_MLDSA
 #define WOLFSSL_SHA3
 #define WOLFSSL_SHAKE128
 #define WOLFSSL_SHAKE256
@@ -145,16 +144,16 @@
 /* The following options can be individually controlled to customize the
  * ML-DSA configuration */
 #if 0
-#define WOLFSSL_DILITHIUM_VERIFY_ONLY
+#define WOLFSSL_MLDSA_VERIFY_ONLY
 #endif
 #if 0
-#define WOLFSSL_DILITHIUM_NO_VERIFY
+#define WOLFSSL_MLDSA_NO_VERIFY
 #endif
 #if 0
-#define WOLFSSL_DILITHIUM_NO_SIGN
+#define WOLFSSL_MLDSA_NO_SIGN
 #endif
 #if 0
-#define WOLFSSL_DILITHIUM_NO_MAKE_KEY
+#define WOLFSSL_MLDSA_NO_MAKE_KEY
 #endif
 
 /** Composite features */

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -9265,11 +9265,11 @@ static int whTestCrypto_Cmac(whClientContext* ctx, int devId, WC_RNG* rng)
 }
 #endif /* WOLFSSL_CMAC && !NO_AES && WOLFSSL_AES_DIRECT */
 
-#ifdef HAVE_DILITHIUM
+#ifdef WOLFSSL_HAVE_MLDSA
 
-#if !defined(WOLFSSL_DILITHIUM_NO_VERIFY) && \
-    !defined(WOLFSSL_DILITHIUM_NO_SIGN) &&   \
-    !defined(WOLFSSL_DILITHIUM_NO_MAKE_KEY) && !defined(WOLFSSL_NO_ML_DSA_44)
+#if !defined(WOLFSSL_MLDSA_NO_VERIFY) && \
+    !defined(WOLFSSL_MLDSA_NO_SIGN) &&   \
+    !defined(WOLFSSL_MLDSA_NO_MAKE_KEY) && !defined(WOLFSSL_NO_ML_DSA_44)
 static int whTestCrypto_MlDsaWolfCrypt(whClientContext* ctx, int devId,
                                        WC_RNG* rng)
 {
@@ -9279,10 +9279,10 @@ static int whTestCrypto_MlDsaWolfCrypt(whClientContext* ctx, int devId,
     int verified = 0;
 
     /* Test ML DSA key generation, signing and verification */
-    MlDsaKey key;
-    byte     msg[] = "Test message for ML DSA signing";
-    byte     sig[DILITHIUM_ML_DSA_44_SIG_SIZE];
-    word32   sigSz = sizeof(sig);
+    wc_MlDsaKey key;
+    byte        msg[] = "Test message for ML DSA signing";
+    byte        sig[WC_MLDSA_44_SIG_SIZE];
+    word32      sigSz = sizeof(sig);
 
     /* Initialize key */
     ret = wc_MlDsaKey_Init(&key, NULL, devId);
@@ -9367,8 +9367,8 @@ static int whTestCrypto_MlDsaClient(whClientContext* ctx, int devId,
     (void)devId;
     (void)rng;
 
-    int      ret = 0;
-    MlDsaKey key[1];
+    int         ret = 0;
+    wc_MlDsaKey key[1];
 
     /* Initialize key */
     ret = wc_MlDsaKey_Init(key, NULL, devId);
@@ -9388,7 +9388,7 @@ static int whTestCrypto_MlDsaClient(whClientContext* ctx, int devId,
     /* Test basic sign/verify using the public API (no context) */
     if (ret == 0) {
         byte   msg[] = "Test message for non-DMA ML-DSA";
-        byte   sig[DILITHIUM_MAX_SIG_SIZE];
+        byte   sig[MLDSA_MAX_SIG_SIZE];
         word32 sigLen   = sizeof(sig);
         int    verified = 0;
 
@@ -9430,7 +9430,7 @@ static int whTestCrypto_MlDsaClient(whClientContext* ctx, int devId,
     /* Test sign/verify with FIPS 204 context string */
     if (ret == 0) {
         byte       msg[] = "Context test message non-DMA";
-        byte       sig[DILITHIUM_MAX_SIG_SIZE];
+        byte       sig[MLDSA_MAX_SIG_SIZE];
         word32     sigLen   = sizeof(sig);
         int        verified = 0;
         const byte ctx_str[] = "test-context";
@@ -9483,20 +9483,20 @@ static int whTestCrypto_MlDsaClient(whClientContext* ctx, int devId,
     return ret;
 }
 
-#if defined(WOLFSSL_DILITHIUM_PUBLIC_KEY) && \
-    !defined(WOLFSSL_DILITHIUM_NO_MAKE_KEY) && !defined(WOLFSSL_NO_ML_DSA_44)
+#if defined(WOLFSSL_MLDSA_PUBLIC_KEY) && \
+    !defined(WOLFSSL_MLDSA_NO_MAKE_KEY) && !defined(WOLFSSL_NO_ML_DSA_44)
 static int whTestCrypto_MlDsaExportPublic(whClientContext* ctx, int devId,
                                           WC_RNG* rng)
 {
     (void)rng;
 
-    int      ret    = 0;
-    whKeyId  keyId  = WH_KEYID_ERASED;
-    MlDsaKey pub[1] = {0};
+    int         ret    = 0;
+    whKeyId     keyId  = WH_KEYID_ERASED;
+    wc_MlDsaKey pub[1] = {0};
     /* Large enough to hold an ML-DSA key DER so the access-control assertion
      * doesn't get masked by a buffer-too-small failure. */
-    uint8_t  denyBuf[DILITHIUM_MAX_BOTH_KEY_DER_SIZE];
-    uint16_t denyLen = sizeof(denyBuf);
+    uint8_t     denyBuf[MLDSA_MAX_BOTH_KEY_DER_SIZE];
+    uint16_t    denyLen = sizeof(denyBuf);
     (void)devId;
 
     /* MakeCacheKey at the smallest supported level, with NONEXPORTABLE. */
@@ -9555,7 +9555,7 @@ static int whTestCrypto_MlDsaExportPublic(whClientContext* ctx, int devId,
     }
     return ret;
 }
-#endif /* WOLFSSL_DILITHIUM_PUBLIC_KEY && ML_DSA_44 available */
+#endif /* WOLFSSL_MLDSA_PUBLIC_KEY && ML_DSA_44 available */
 
 #ifdef WOLFHSM_CFG_DMA
 static int whTestCrypto_MlDsaDmaClient(whClientContext* ctx, int devId,
@@ -9563,16 +9563,16 @@ static int whTestCrypto_MlDsaDmaClient(whClientContext* ctx, int devId,
 {
     (void)rng;
 
-    int      ret = 0;
-    MlDsaKey key[1];
-    MlDsaKey imported_key[1];
-    whKeyId  keyId       = WH_KEYID_ERASED;
-    uint8_t  label[]     = "ML-DSA Test Key";
-    int      keyImported = 0;
+    int         ret = 0;
+    wc_MlDsaKey key[1];
+    wc_MlDsaKey imported_key[1];
+    whKeyId     keyId       = WH_KEYID_ERASED;
+    uint8_t     label[]     = "ML-DSA Test Key";
+    int         keyImported = 0;
 
     /* Buffers for comparing serialized keys */
-    byte   key_der1[DILITHIUM_MAX_PRV_KEY_SIZE];
-    byte   key_der2[DILITHIUM_MAX_PRV_KEY_SIZE];
+    byte   key_der1[MLDSA_MAX_PRV_KEY_SIZE];
+    byte   key_der2[MLDSA_MAX_PRV_KEY_SIZE];
     word32 key_der1_len = sizeof(key_der1);
     word32 key_der2_len = sizeof(key_der2);
 
@@ -9601,7 +9601,7 @@ static int whTestCrypto_MlDsaDmaClient(whClientContext* ctx, int devId,
 
     /* Serialize the generated key for comparison */
     if (ret == 0) {
-        ret = wc_Dilithium_PrivateKeyToDer(key, key_der1, key_der1_len);
+        ret = wc_MlDsaKey_PrivateKeyToDer(key, key_der1, key_der1_len);
         if (ret < 0) {
             WH_ERROR_PRINT("Failed to serialize generated key: %d\n", ret);
         }
@@ -9633,7 +9633,7 @@ static int whTestCrypto_MlDsaDmaClient(whClientContext* ctx, int devId,
     /* Serialize the exported key for comparison */
     if (ret == 0) {
         ret =
-            wc_Dilithium_PrivateKeyToDer(imported_key, key_der2, key_der2_len);
+            wc_MlDsaKey_PrivateKeyToDer(imported_key, key_der2, key_der2_len);
         if (ret < 0) {
             WH_ERROR_PRINT("Failed to serialize exported key: %d\n", ret);
         }
@@ -9654,7 +9654,7 @@ static int whTestCrypto_MlDsaDmaClient(whClientContext* ctx, int devId,
     /* Test signing and verification */
     if (ret == 0) {
         byte   msg[] = "Test message to sign";
-        byte   sig[DILITHIUM_MAX_SIG_SIZE];
+        byte   sig[MLDSA_MAX_SIG_SIZE];
         word32 sigLen   = sizeof(sig);
         int    verified = 0;
 
@@ -9705,7 +9705,7 @@ static int whTestCrypto_MlDsaDmaClient(whClientContext* ctx, int devId,
     /* Test signing and verification with a FIPS 204 context string */
     if (ret == 0) {
         byte   msg[] = "Context test message";
-        byte   sig[DILITHIUM_MAX_SIG_SIZE];
+        byte   sig[MLDSA_MAX_SIG_SIZE];
         word32 sigLen   = sizeof(sig);
         int    verified = 0;
         const byte ctx_str[] = "test-context";
@@ -9775,18 +9775,18 @@ static int whTestCrypto_MlDsaDmaClient(whClientContext* ctx, int devId,
     return ret;
 }
 
-#ifdef WOLFSSL_DILITHIUM_PUBLIC_KEY
+#ifdef WOLFSSL_MLDSA_PUBLIC_KEY
 static int whTestCrypto_MlDsaExportPublicDma(whClientContext* ctx, int devId,
                                              WC_RNG* rng)
 {
     (void)rng;
     (void)devId;
 
-    int      ret    = 0;
-    whKeyId  keyId  = WH_KEYID_ERASED;
-    MlDsaKey pub[1] = {0};
-    uint8_t  denyBuf[1];
-    uint16_t denyLen = sizeof(denyBuf);
+    int         ret    = 0;
+    whKeyId     keyId  = WH_KEYID_ERASED;
+    wc_MlDsaKey pub[1] = {0};
+    uint8_t     denyBuf[1];
+    uint16_t    denyLen = sizeof(denyBuf);
 
     /* Cache an ML-DSA-44 keypair NONEXPORTABLE on the HSM. */
     ret = wh_Client_MlDsaMakeCacheKey(
@@ -9803,7 +9803,7 @@ static int whTestCrypto_MlDsaExportPublicDma(whClientContext* ctx, int devId,
 
     /* Full DMA export must be denied */
     {
-        byte fullBuf[DILITHIUM_MAX_BOTH_KEY_DER_SIZE];
+        byte fullBuf[MLDSA_MAX_BOTH_KEY_DER_SIZE];
         uint16_t fullLen = sizeof(fullBuf);
         int denyRet = wh_Client_KeyExportDma(ctx, keyId, fullBuf, fullLen,
                                              NULL, 0, &denyLen);
@@ -9842,8 +9842,8 @@ static int whTestCrypto_MlDsaExportPublicDma(whClientContext* ctx, int devId,
      * key. This cross-validates that the DMA path isn't producing
      * subtly different output. */
     if (ret == 0) {
-        byte     dmaDer[DILITHIUM_MAX_PUB_KEY_DER_SIZE];
-        byte     nonDmaDer[DILITHIUM_MAX_PUB_KEY_DER_SIZE];
+        byte     dmaDer[MLDSA_MAX_PUB_KEY_DER_SIZE];
+        byte     nonDmaDer[MLDSA_MAX_PUB_KEY_DER_SIZE];
         uint16_t dmaSz    = sizeof(dmaDer);
         uint16_t nonDmaSz = sizeof(nonDmaDer);
 
@@ -9895,15 +9895,15 @@ static int whTestCrypto_MlDsaExportPublicDma(whClientContext* ctx, int devId,
     }
     return ret;
 }
-#endif /* WOLFSSL_DILITHIUM_PUBLIC_KEY */
+#endif /* WOLFSSL_MLDSA_PUBLIC_KEY */
 
 #endif /* WOLFHSM_CFG_DMA */
-#endif /* !defined(WOLFSSL_DILITHIUM_NO_VERIFY) &&   \
-          !defined(WOLFSSL_DILITHIUM_NO_SIGN) &&     \
-          !defined(WOLFSSL_DILITHIUM_NO_MAKE_KEY) && \
+#endif /* !defined(WOLFSSL_MLDSA_NO_VERIFY) &&   \
+          !defined(WOLFSSL_MLDSA_NO_SIGN) &&     \
+          !defined(WOLFSSL_MLDSA_NO_MAKE_KEY) && \
           !defined(WOLFSSL_NO_ML_DSA_44) */
 
-#if !defined(WOLFSSL_DILITHIUM_NO_VERIFY) && \
+#if !defined(WOLFSSL_MLDSA_NO_VERIFY) && \
     !defined(WOLFSSL_NO_ML_DSA_44) && \
     defined(WOLFHSM_CFG_DMA)
 int whTestCrypto_MlDsaVerifyOnlyDma(whClientContext* ctx, int devId,
@@ -10271,10 +10271,10 @@ int whTestCrypto_MlDsaVerifyOnlyDma(whClientContext* ctx, int devId,
         0xec, 0xed, 0xee, 0xef, 0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7,
         0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd, 0xfe, 0xff};
 
-    int      ret;
-    MlDsaKey key[1];
-    whNvmId  keyId    = WH_KEYID_ERASED;
-    int      evictKey = 0;
+    int         ret;
+    wc_MlDsaKey key[1];
+    whNvmId     keyId    = WH_KEYID_ERASED;
+    int         evictKey = 0;
 
     /* Initialize keys */
     ret = wc_MlDsaKey_Init(key, NULL, devId);
@@ -10283,7 +10283,7 @@ int whTestCrypto_MlDsaVerifyOnlyDma(whClientContext* ctx, int devId,
         return ret;
     }
     else {
-        ret = wc_dilithium_set_level(key, WC_ML_DSA_44);
+        ret = wc_MlDsaKey_SetParams(key, WC_ML_DSA_44);
         if (ret != 0) {
             WH_ERROR_PRINT("Failed to set ML-DSA level: %d\n", ret);
         }
@@ -10351,12 +10351,12 @@ int whTestCrypto_MlDsaVerifyOnlyDma(whClientContext* ctx, int devId,
 
     return ret;
 }
-#endif /* !defined(WOLFSSL_DILITHIUM_NO_VERIFY) && \
+#endif /* !defined(WOLFSSL_MLDSA_NO_VERIFY) && \
           !defined(WOLFSSL_NO_ML_DSA_44) && \
           defined(WOLFHSM_CFG_DMA) */
 
 
-#endif /* HAVE_DILITHIUM */
+#endif /* WOLFSSL_HAVE_MLDSA */
 
 /* Test key usage policy enforcement for various crypto operations */
 int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
@@ -11322,11 +11322,11 @@ int whTest_CryptoClientConfig(whClientConfig* config)
     }
 #endif /* HAVE_CMAC_KDF */
 
-#ifdef HAVE_DILITHIUM
+#ifdef WOLFSSL_HAVE_MLDSA
 
-#if !defined(WOLFSSL_DILITHIUM_NO_VERIFY) && \
-    !defined(WOLFSSL_DILITHIUM_NO_SIGN) && \
-    !defined(WOLFSSL_DILITHIUM_NO_MAKE_KEY) && \
+#if !defined(WOLFSSL_MLDSA_NO_VERIFY) && \
+    !defined(WOLFSSL_MLDSA_NO_SIGN) && \
+    !defined(WOLFSSL_MLDSA_NO_MAKE_KEY) && \
     !defined(WOLFSSL_NO_ML_DSA_44)
 
     i = 0;
@@ -11347,7 +11347,7 @@ int whTest_CryptoClientConfig(whClientConfig* config)
         ret = whTestCrypto_MlDsaClient(client, WH_DEV_ID, rng);
     }
 
-#ifdef WOLFSSL_DILITHIUM_PUBLIC_KEY
+#ifdef WOLFSSL_MLDSA_PUBLIC_KEY
     if (ret == 0) {
         ret = whTestCrypto_MlDsaExportPublic(client, WH_DEV_ID, rng);
         if (ret != 0) {
@@ -11360,7 +11360,7 @@ int whTest_CryptoClientConfig(whClientConfig* config)
     if (ret == 0) {
         ret = whTestCrypto_MlDsaDmaClient(client, WH_DEV_ID_DMA, rng);
     }
-#ifdef WOLFSSL_DILITHIUM_PUBLIC_KEY
+#ifdef WOLFSSL_MLDSA_PUBLIC_KEY
     if (ret == 0) {
         ret = whTestCrypto_MlDsaExportPublicDma(client, WH_DEV_ID_DMA, rng);
         if (ret != 0) {
@@ -11370,22 +11370,22 @@ int whTest_CryptoClientConfig(whClientConfig* config)
     }
 #endif
 #endif /* WOLFHSM_CFG_DMA*/
-#endif /* !defined(WOLFSSL_DILITHIUM_NO_VERIFY) && \
-          !defined(WOLFSSL_DILITHIUM_NO_SIGN) && \
-          !defined(WOLFSSL_DILITHIUM_NO_MAKE_KEY) && \
+#endif /* !defined(WOLFSSL_MLDSA_NO_VERIFY) && \
+          !defined(WOLFSSL_MLDSA_NO_SIGN) && \
+          !defined(WOLFSSL_MLDSA_NO_MAKE_KEY) && \
           !defined(WOLFSSL_NO_ML_DSA_44) */
 
-#if !defined(WOLFSSL_DILITHIUM_NO_VERIFY) && \
+#if !defined(WOLFSSL_MLDSA_NO_VERIFY) && \
     !defined(WOLFSSL_NO_ML_DSA_44) && \
     defined(WOLFHSM_CFG_DMA)
     if (ret == 0) {
         ret = whTestCrypto_MlDsaVerifyOnlyDma(client, WH_DEV_ID_DMA, rng);
     }
-#endif /* !defined(WOLFSSL_DILITHIUM_NO_VERIFY) && \
+#endif /* !defined(WOLFSSL_MLDSA_NO_VERIFY) && \
           !defined(WOLFSSL_NO_ML_DSA_44) && \
           defined(WOLFHSM_CFG_DMA) */
 
-#endif /* HAVE_DILITHIUM */
+#endif /* WOLFSSL_HAVE_MLDSA */
 
 #ifdef WOLFHSM_CFG_DEBUG_VERBOSE
     if (ret == 0) {

--- a/wolfhsm/wh_client_crypto.h
+++ b/wolfhsm/wh_client_crypto.h
@@ -50,7 +50,7 @@
 #include "wolfssl/wolfcrypt/rsa.h"
 #include "wolfssl/wolfcrypt/ecc.h"
 #include "wolfssl/wolfcrypt/ed25519.h"
-#include "wolfssl/wolfcrypt/dilithium.h"
+#include "wolfssl/wolfcrypt/wc_mldsa.h"
 #include "wolfssl/wolfcrypt/hmac.h"
 
 /**
@@ -2190,7 +2190,7 @@ int wh_Client_Sha512DmaFinalResponse(whClientContext* ctx, wc_Sha512* sha,
 
 #endif /* WOLFSSL_SHA512 */
 
-#ifdef HAVE_DILITHIUM
+#ifdef WOLFSSL_HAVE_MLDSA
 
 /**
  * @brief Associates a ML-DSA key with a specific key ID.
@@ -2203,7 +2203,7 @@ int wh_Client_Sha512DmaFinalResponse(whClientContext* ctx, wc_Sha512* sha,
  * @param[in] keyId Key ID to be associated with the ML-DSA key.
  * @return int Returns 0 on success or a negative error code on failure.
  */
-int wh_Client_MlDsaSetKeyId(MlDsaKey* key, whKeyId keyId);
+int wh_Client_MlDsaSetKeyId(wc_MlDsaKey* key, whKeyId keyId);
 
 /**
  * @brief Gets the wolfHSM keyId being used by the wolfCrypt struct.
@@ -2215,7 +2215,7 @@ int wh_Client_MlDsaSetKeyId(MlDsaKey* key, whKeyId keyId);
  * @param[out] outId Pointer to the key ID to return.
  * @return int Returns 0 on success or a negative error code on failure.
  */
-int wh_Client_MlDsaGetKeyId(MlDsaKey* key, whKeyId* outId);
+int wh_Client_MlDsaGetKeyId(wc_MlDsaKey* key, whKeyId* outId);
 
 /**
  * @brief Import a ML-DSA key to the server key cache.
@@ -2228,7 +2228,7 @@ int wh_Client_MlDsaGetKeyId(MlDsaKey* key, whKeyId* outId);
  * @param[in] label Optional label to associate with key
  * @return int Returns 0 on success or a negative error code on failure.
  */
-int wh_Client_MlDsaImportKey(whClientContext* ctx, MlDsaKey* key,
+int wh_Client_MlDsaImportKey(whClientContext* ctx, wc_MlDsaKey* key,
                              whKeyId* inout_keyId, whNvmFlags flags,
                              uint16_t label_len, uint8_t* label);
 
@@ -2242,7 +2242,7 @@ int wh_Client_MlDsaImportKey(whClientContext* ctx, MlDsaKey* key,
  * @param[in] label Optional buffer to receive key label
  * @return int Returns 0 on success or a negative error code on failure.
  */
-int wh_Client_MlDsaExportKey(whClientContext* ctx, whKeyId keyId, MlDsaKey* key,
+int wh_Client_MlDsaExportKey(whClientContext* ctx, whKeyId keyId, wc_MlDsaKey* key,
                              uint16_t label_len, uint8_t* label);
 
 /**
@@ -2260,7 +2260,7 @@ int wh_Client_MlDsaExportKey(whClientContext* ctx, whKeyId keyId, MlDsaKey* key,
  * @param[in] ctx Pointer to the wolfHSM client context.
  * @param[in] keyId Server key ID whose public key should be exported. Must
  *                  not be WH_KEYID_ERASED.
- * @param[in,out] key Pointer to a caller-initialized MlDsaKey. On success,
+ * @param[in,out] key Pointer to a caller-initialized wc_MlDsaKey. On success,
  *                    only the public half is populated
  *                    (pubKeySet == 1, prvKeySet == 0).
  * @param[in] label_len Size of the optional label buffer in bytes. Values
@@ -2271,7 +2271,7 @@ int wh_Client_MlDsaExportKey(whClientContext* ctx, whKeyId keyId, MlDsaKey* key,
  *             code on failure (e.g. WH_ERROR_NOTFOUND, WH_ERROR_BADARGS).
  */
 int wh_Client_MlDsaExportPublicKey(whClientContext* ctx, whKeyId keyId,
-                                   MlDsaKey* key, uint16_t label_len,
+                                   wc_MlDsaKey* key, uint16_t label_len,
                                    uint8_t* label);
 
 /**
@@ -2287,7 +2287,7 @@ int wh_Client_MlDsaExportPublicKey(whClientContext* ctx, whKeyId keyId,
  * @return int Returns 0 on success, or a negative error code on failure.
  */
 int wh_Client_MlDsaMakeExportKey(whClientContext* ctx, int level, int size,
-                                 MlDsaKey* key);
+                                 wc_MlDsaKey* key);
 /**
  * @brief Create and cache a new ML-DSA key on the server.
  *
@@ -2324,7 +2324,7 @@ int wh_Client_MlDsaMakeCacheKey(whClientContext* ctx, int size, int level,
  * @return int Returns 0 on success, or a negative error code on failure.
  */
 int wh_Client_MlDsaSign(whClientContext* ctx, const byte* in, word32 in_len,
-                            byte* out, word32* out_len, MlDsaKey* key,
+                            byte* out, word32* out_len, wc_MlDsaKey* key,
                             const byte* context, byte contextLen,
                             word32 preHashType);
 /**
@@ -2348,7 +2348,7 @@ int wh_Client_MlDsaSign(whClientContext* ctx, const byte* in, word32 in_len,
  */
 int wh_Client_MlDsaVerify(whClientContext* ctx, const byte* sig,
                               word32 sig_len, const byte* msg, word32 msg_len,
-                              int* res, MlDsaKey* key, const byte* context,
+                              int* res, wc_MlDsaKey* key, const byte* context,
                               byte contextLen, word32 preHashType);
 
 /**
@@ -2363,7 +2363,7 @@ int wh_Client_MlDsaVerify(whClientContext* ctx, const byte* sig,
  * @param[in] pubKeySz Size of the public key in bytes.
  * @return int Returns 0 on success, or a negative error code on failure.
  */
-int wh_Client_MlDsaCheckPrivKey(whClientContext* ctx, MlDsaKey* key,
+int wh_Client_MlDsaCheckPrivKey(whClientContext* ctx, wc_MlDsaKey* key,
                                 const byte* pubKey, word32 pubKeySz);
 
 
@@ -2382,7 +2382,7 @@ int wh_Client_MlDsaCheckPrivKey(whClientContext* ctx, MlDsaKey* key,
  * @param[in] label Pointer to the key label.
  * @return int Returns 0 on success, or a negative error code on failure.
  */
-int wh_Client_MlDsaImportKeyDma(whClientContext* ctx, MlDsaKey* key,
+int wh_Client_MlDsaImportKeyDma(whClientContext* ctx, wc_MlDsaKey* key,
                                 whKeyId* inout_keyId, whNvmFlags flags,
                                 uint16_t label_len, uint8_t* label);
 
@@ -2399,7 +2399,7 @@ int wh_Client_MlDsaImportKeyDma(whClientContext* ctx, MlDsaKey* key,
  * @return int Returns 0 on success, or a negative error code on failure.
  */
 int wh_Client_MlDsaExportKeyDma(whClientContext* ctx, whKeyId keyId,
-                                MlDsaKey* key, uint16_t label_len,
+                                wc_MlDsaKey* key, uint16_t label_len,
                                 uint8_t* label);
 
 /**
@@ -2407,7 +2407,7 @@ int wh_Client_MlDsaExportKeyDma(whClientContext* ctx, whKeyId keyId,
  *
  * DMA counterpart to wh_Client_MlDsaExportPublicKey. The server emits the
  * public-only DER and DMAs it directly into a client-side staging buffer;
- * the wrapper then deserializes it into the caller-provided MlDsaKey.
+ * the wrapper then deserializes it into the caller-provided wc_MlDsaKey.
  *
  * The NONEXPORTABLE key flag does NOT block this call because public
  * material is non-sensitive. The caller is responsible for initializing
@@ -2416,7 +2416,7 @@ int wh_Client_MlDsaExportKeyDma(whClientContext* ctx, whKeyId keyId,
  * @param[in] ctx Pointer to the wolfHSM client context.
  * @param[in] keyId Server key ID whose public key should be exported. Must
  *                  not be WH_KEYID_ERASED.
- * @param[in,out] key Pointer to a caller-initialized MlDsaKey. On success,
+ * @param[in,out] key Pointer to a caller-initialized wc_MlDsaKey. On success,
  *                    only the public half is populated
  *                    (pubKeySet == 1, prvKeySet == 0).
  * @param[in] label_len Size of the optional label buffer in bytes.
@@ -2424,7 +2424,7 @@ int wh_Client_MlDsaExportKeyDma(whClientContext* ctx, whKeyId keyId,
  * @return int Returns 0 on success, or a negative error code on failure.
  */
 int wh_Client_MlDsaExportPublicKeyDma(whClientContext* ctx, whKeyId keyId,
-                                      MlDsaKey* key, uint16_t label_len,
+                                      wc_MlDsaKey* key, uint16_t label_len,
                                       uint8_t* label);
 
 /**
@@ -2439,7 +2439,7 @@ int wh_Client_MlDsaExportPublicKeyDma(whClientContext* ctx, whKeyId keyId,
  * @return int Returns 0 on success, or a negative error code on failure.
  */
 int wh_Client_MlDsaMakeExportKeyDma(whClientContext* ctx, int level,
-                                    MlDsaKey* key);
+                                    wc_MlDsaKey* key);
 
 
 /**
@@ -2463,7 +2463,7 @@ int wh_Client_MlDsaMakeExportKeyDma(whClientContext* ctx, int level,
  */
 int wh_Client_MlDsaSignDma(whClientContext* ctx, const byte* in,
                                word32 in_len, byte* out, word32* out_len,
-                               MlDsaKey* key, const byte* context,
+                               wc_MlDsaKey* key, const byte* context,
                                byte contextLen, word32 preHashType);
 
 /**
@@ -2487,7 +2487,7 @@ int wh_Client_MlDsaSignDma(whClientContext* ctx, const byte* in,
  */
 int wh_Client_MlDsaVerifyDma(whClientContext* ctx, const byte* sig,
                                  word32 sig_len, const byte* msg,
-                                 word32 msg_len, int* res, MlDsaKey* key,
+                                 word32 msg_len, int* res, wc_MlDsaKey* key,
                                  const byte* context, byte contextLen,
                                  word32 preHashType);
 
@@ -2502,12 +2502,12 @@ int wh_Client_MlDsaVerifyDma(whClientContext* ctx, const byte* sig,
  * @param[in] pubKeySz Size of the public key in bytes.
  * @return int Returns 0 on success, or a negative error code on failure.
  */
-int wh_Client_MlDsaCheckPrivKeyDma(whClientContext* ctx, MlDsaKey* key,
+int wh_Client_MlDsaCheckPrivKeyDma(whClientContext* ctx, wc_MlDsaKey* key,
                                    const byte* pubKey, word32 pubKeySz);
 
 #endif /* WOLFHSM_CFG_DMA */
 
-#endif /* HAVE_DILITHIUM */
+#endif /* WOLFSSL_HAVE_MLDSA */
 
 #endif /* !WOLFHSM_CFG_NO_CRYPTO */
 #endif /* !WOLFHSM_WH_CLIENT_CRYPTO_H_ */

--- a/wolfhsm/wh_crypto.h
+++ b/wolfhsm/wh_crypto.h
@@ -42,7 +42,7 @@
 #include "wolfssl/wolfcrypt/curve25519.h"
 #include "wolfssl/wolfcrypt/ecc.h"
 #include "wolfssl/wolfcrypt/ed25519.h"
-#include "wolfssl/wolfcrypt/dilithium.h"
+#include "wolfssl/wolfcrypt/wc_mldsa.h"
 
 #include "wolfhsm/wh_message_crypto.h"
 
@@ -108,15 +108,15 @@ int wh_Crypto_Ed25519DeserializeKeyDer(const uint8_t* buffer, uint16_t size,
                                        ed25519_key* key);
 #endif /* HAVE_ED25519 */
 
-#ifdef HAVE_DILITHIUM
+#ifdef WOLFSSL_HAVE_MLDSA
 #define WH_CRYPTO_MLDSA_MAX_CTX_LEN (255U)
-/* Store a MlDsaKey to a byte sequence */
-int wh_Crypto_MlDsaSerializeKeyDer(MlDsaKey* key, uint16_t max_size,
+/* Store a wc_MlDsaKey to a byte sequence */
+int wh_Crypto_MlDsaSerializeKeyDer(wc_MlDsaKey* key, uint16_t max_size,
                                    uint8_t* buffer, uint16_t* out_size);
-/* Restore a MlDsaKey from a byte sequence */
+/* Restore a wc_MlDsaKey from a byte sequence */
 int wh_Crypto_MlDsaDeserializeKeyDer(const uint8_t* buffer, uint16_t size,
-                                     MlDsaKey* key);
-#endif /* HAVE_DILITHIUM */
+                                     wc_MlDsaKey* key);
+#endif /* WOLFSSL_HAVE_MLDSA */
 
 #endif  /* !WOLFHSM_CFG_NO_CRYPTO */
 

--- a/wolfhsm/wh_server_crypto.h
+++ b/wolfhsm/wh_server_crypto.h
@@ -93,15 +93,15 @@ int wh_Server_CacheExportCurve25519Key(whServerContext* server, whKeyId keyId,
         curve25519_key* key);
 #endif /* HAVE_CURVE25519 */
 
-#ifdef HAVE_DILITHIUM
-/* Store a MlDsaKey into a server key cache with optional metadata */
-int wh_Server_MlDsaKeyCacheImport(whServerContext* ctx, MlDsaKey* key,
+#ifdef WOLFSSL_HAVE_MLDSA
+/* Store a wc_MlDsaKey into a server key cache with optional metadata */
+int wh_Server_MlDsaKeyCacheImport(whServerContext* ctx, wc_MlDsaKey* key,
                                   whKeyId keyId, whNvmFlags flags,
                                   uint16_t label_len, uint8_t* label);
-/* Restore a MlDsaKey from a server key cache */
+/* Restore a wc_MlDsaKey from a server key cache */
 int wh_Server_MlDsaKeyCacheExport(whServerContext* ctx, whKeyId keyId,
-                                  MlDsaKey* key);
-#endif /* HAVE_DILITHIUM */
+                                  wc_MlDsaKey* key);
+#endif /* WOLFSSL_HAVE_MLDSA */
 
 #ifdef HAVE_HKDF
 /* Store HKDF output into a server key cache with optional metadata */


### PR DESCRIPTION
Move to the new `wc_MlDsaKey` API and get rid of all "Dilithium" naming.