### PR TITLE
f-2010 : Add bound check for aes-ctr

### DIFF
--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -2534,22 +2534,33 @@ static int _HandleAesCtr(whServerContext* ctx, uint16_t magic, int devId,
         ret = wc_AesSetKeyDirect(aes, (byte*)key, (word32)key_len, (byte*)iv,
                                  enc != 0 ? AES_ENCRYPTION : AES_DECRYPTION);
         if (ret == WH_ERROR_OK) {
-            /* do the crypto operation; also restore previous left */
-            aes->left = left;
-            memcpy(aes->tmp, tmp, sizeof(aes->tmp));
-            if (enc != 0) {
-                ret = wc_AesCtrEncrypt(aes, (byte*)out, (byte*)in, (word32)len);
-                if (ret == WH_ERROR_OK) {
-                    WH_DEBUG_VERBOSE_HEXDUMP("[AesCtr] Encrypted output",
-                                             out, len);
-                }
+            /* Reject client-supplied left values outside the valid range.
+             * wc_AesCtrEncrypt indexes aes->tmp via AES_BLOCK_SIZE - aes->left;
+             * an out-of-range value causes an out-of-bounds read that could
+             * disclose server-side memory across the HSM trust boundary. */
+            if (left > AES_BLOCK_SIZE) {
+                ret = WH_ERROR_BADARGS;
             }
             else {
-                /* CTR uses the same function for encrypt and decrypt */
-                ret = wc_AesCtrEncrypt(aes, (byte*)out, (byte*)in, (word32)len);
-                if (ret == WH_ERROR_OK) {
-                    WH_DEBUG_VERBOSE_HEXDUMP("[AesCtr] Decrypted output",
-                                             out, len);
+                /* Restore streaming CTR context from the previous call. */
+                aes->left = left;
+                memcpy(aes->tmp, tmp, sizeof(aes->tmp));
+                if (enc != 0) {
+                    ret = wc_AesCtrEncrypt(aes, (byte*)out, (byte*)in,
+                                           (word32)len);
+                    if (ret == WH_ERROR_OK) {
+                        WH_DEBUG_VERBOSE_HEXDUMP("[AesCtr] Encrypted output",
+                                                 out, len);
+                    }
+                }
+                else {
+                    /* CTR uses the same function for encrypt and decrypt */
+                    ret = wc_AesCtrEncrypt(aes, (byte*)out, (byte*)in,
+                                           (word32)len);
+                    if (ret == WH_ERROR_OK) {
+                        WH_DEBUG_VERBOSE_HEXDUMP("[AesCtr] Decrypted output",
+                                                 out, len);
+                    }
                 }
             }
         }
@@ -2695,32 +2706,40 @@ static int _HandleAesCtrDma(whServerContext* ctx, uint16_t magic, int devId,
         ret = wc_AesSetKeyDirect(aes, (byte*)key, (word32)keyLen, (byte*)iv,
                                  enc != 0 ? AES_ENCRYPTION : AES_DECRYPTION);
         if (ret == WH_ERROR_OK) {
-            /* do the crypto operation */
-            /* restore previous left */
-            aes->left = left;
-            memcpy(aes->tmp, tmp, sizeof(aes->tmp));
-            if (enc != 0) {
-                ret = wc_AesCtrEncrypt(aes, (byte*)outAddr, (byte*)inAddr,
-                                       (word32)len);
-                if (ret == WH_ERROR_OK) {
-                    WH_DEBUG_VERBOSE_HEXDUMP("[AesCtr] Encrypted output",
-                                             outAddr, len);
-                }
+            /* Reject client-supplied left values outside the valid range.
+             * wc_AesCtrEncrypt indexes aes->tmp via AES_BLOCK_SIZE - aes->left;
+             * an out-of-range value causes an out-of-bounds read that could
+             * disclose server-side memory across the HSM trust boundary. */
+            if (left > AES_BLOCK_SIZE) {
+                ret = WH_ERROR_BADARGS;
             }
             else {
-                /* CTR uses the same function for encrypt and decrypt */
-                ret = wc_AesCtrEncrypt(aes, (byte*)outAddr, (byte*)inAddr,
-                                       (word32)len);
-                if (ret == WH_ERROR_OK) {
-                    WH_DEBUG_VERBOSE_HEXDUMP("[AesCtr] Decrypted output",
-                                             outAddr, len);
+                /* Restore streaming CTR context from the previous call. */
+                aes->left = left;
+                memcpy(aes->tmp, tmp, sizeof(aes->tmp));
+                if (enc != 0) {
+                    ret = wc_AesCtrEncrypt(aes, (byte*)outAddr, (byte*)inAddr,
+                                           (word32)len);
+                    if (ret == WH_ERROR_OK) {
+                        WH_DEBUG_VERBOSE_HEXDUMP("[AesCtr] Encrypted output",
+                                                 outAddr, len);
+                    }
                 }
-            }
-            if (ret == WH_ERROR_OK) {
-                left = aes->left;
-                outSz = len;
-                memcpy(out_tmp, aes->tmp, AES_BLOCK_SIZE);
-                memcpy(out_iv, aes->reg, AES_IV_SIZE);
+                else {
+                    /* CTR uses the same function for encrypt and decrypt */
+                    ret = wc_AesCtrEncrypt(aes, (byte*)outAddr, (byte*)inAddr,
+                                           (word32)len);
+                    if (ret == WH_ERROR_OK) {
+                        WH_DEBUG_VERBOSE_HEXDUMP("[AesCtr] Decrypted output",
+                                                 outAddr, len);
+                    }
+                }
+                if (ret == WH_ERROR_OK) {
+                    left = aes->left;
+                    outSz = len;
+                    memcpy(out_tmp, aes->tmp, AES_BLOCK_SIZE);
+                    memcpy(out_iv, aes->reg, AES_IV_SIZE);
+                }
             }
         }
     }

--- a/test-refactor/client-server/wh_test_crypto_aes.c
+++ b/test-refactor/client-server/wh_test_crypto_aes.c
@@ -442,6 +442,91 @@ static int whTest_CryptoAesCbcStreaming(whClientContext* ctx)
 }
 #endif /* HAVE_AES_CBC */
 
+#ifdef WOLFSSL_AES_COUNTER
+/* Verifies that wh_Client_AesCtr (and wh_Client_AesCtrDma when DMA is
+ * enabled) reject aes->left > AES_BLOCK_SIZE with WH_ERROR_BADARGS.
+ * wc_AesCtrEncrypt indexes aes->tmp via AES_BLOCK_SIZE - aes->left; an
+ * oversized value would cause an out-of-bounds read disclosing server-side
+ * memory across the HSM trust boundary. */
+int whTest_CryptoAesCtrLeftOob(whClientContext* ctx)
+{
+    int           devId = WH_DEV_ID;
+    int           ret   = 0;
+    int           tmp;
+    Aes           aes[1];
+    uint8_t       cipher[AES_BLOCK_SIZE]  = {0};
+    const uint8_t key[]                   = {0x2b, 0x7e, 0x15, 0x16,
+                                              0x28, 0xae, 0xd2, 0xa6,
+                                              0xab, 0xf7, 0x15, 0x88,
+                                              0x09, 0xcf, 0x4f, 0x3c};
+    const uint8_t iv[AES_BLOCK_SIZE]      = {0x00, 0x01, 0x02, 0x03,
+                                             0x04, 0x05, 0x06, 0x07,
+                                             0x08, 0x09, 0x0a, 0x0b,
+                                             0x0c, 0x0d, 0x0e, 0x0f};
+    const uint8_t plainIn[AES_BLOCK_SIZE] = {0x6b, 0xc1, 0xbe, 0xe2,
+                                             0x2e, 0x40, 0x9f, 0x96,
+                                             0xe9, 0x3d, 0x7e, 0x11,
+                                             0x73, 0x93, 0x17, 0x2a};
+
+    ret = wc_AesInit(aes, NULL, devId);
+    if (ret != 0) {
+        WH_ERROR_PRINT("Failed to wc_AesInit %d\n", ret);
+    }
+    else {
+        ret = wc_AesSetKeyDirect(aes, key, sizeof(key), iv, AES_ENCRYPTION);
+        if (ret != 0) {
+            WH_ERROR_PRINT("Failed to wc_AesSetKeyDirect %d\n", ret);
+        }
+        else {
+            aes->left = AES_BLOCK_SIZE + 1;
+            tmp = wh_Client_AesCtr(ctx, aes, 1, plainIn, sizeof(plainIn),
+                                   cipher);
+            if (tmp != WH_ERROR_BADARGS) {
+                WH_ERROR_PRINT(
+                    "AES-CTR: left > AES_BLOCK_SIZE should be BADARGS, "
+                    "got %d\n",
+                    tmp);
+                ret = -1;
+            }
+        }
+        (void)wc_AesFree(aes);
+    }
+
+#ifdef WOLFHSM_CFG_DMA
+    if (ret == 0) {
+        ret = wc_AesInit(aes, NULL, devId);
+        if (ret != 0) {
+            WH_ERROR_PRINT("Failed to wc_AesInit %d\n", ret);
+        }
+        else {
+            ret = wc_AesSetKeyDirect(aes, key, sizeof(key), iv, AES_ENCRYPTION);
+            if (ret != 0) {
+                WH_ERROR_PRINT("Failed to wc_AesSetKeyDirect %d\n", ret);
+            }
+            else {
+                aes->left = AES_BLOCK_SIZE + 1;
+                tmp = wh_Client_AesCtrDma(ctx, aes, 1, plainIn,
+                                          sizeof(plainIn), cipher);
+                if (tmp != WH_ERROR_BADARGS) {
+                    WH_ERROR_PRINT(
+                        "AES-CTR DMA: left > AES_BLOCK_SIZE should be "
+                        "BADARGS, got %d\n",
+                        tmp);
+                    ret = -1;
+                }
+            }
+            (void)wc_AesFree(aes);
+        }
+    }
+#endif /* WOLFHSM_CFG_DMA */
+
+    if (ret == 0) {
+        WH_TEST_PRINT("AES CTR left OOB DEVID=0x%X SUCCESS\n", devId);
+    }
+    return ret;
+}
+#endif /* WOLFSSL_AES_COUNTER */
+
 int whTest_CryptoAesKeyUsagePolicies(whClientContext* ctx)
 {
     int      ret        = 0;

--- a/test-refactor/client-server/wh_test_crypto_aes.c
+++ b/test-refactor/client-server/wh_test_crypto_aes.c
@@ -448,7 +448,7 @@ static int whTest_CryptoAesCbcStreaming(whClientContext* ctx)
  * wc_AesCtrEncrypt indexes aes->tmp via AES_BLOCK_SIZE - aes->left; an
  * oversized value would cause an out-of-bounds read disclosing server-side
  * memory across the HSM trust boundary. */
-int whTest_CryptoAesCtrLeftOob(whClientContext* ctx)
+static int whTest_CryptoAesCtrLeftOob(whClientContext* ctx)
 {
     int           devId = WH_DEV_ID;
     int           ret   = 0;
@@ -1110,6 +1110,9 @@ int whTest_Crypto_Aes(whClientContext* ctx)
     /* CBC streaming drives the request/response API directly (INVALID_DEVID),
      * so it is not devId-routed -- run it once. */
     WH_TEST_RETURN_ON_FAIL(whTest_CryptoAesCbcStreaming(ctx));
+#endif
+#ifdef WOLFSSL_AES_COUNTER
+    WH_TEST_RETURN_ON_FAIL(whTest_CryptoAesCtrLeftOob(ctx));
 #endif
     /* TODO: port legacy AES async + DMA-async coverage (comm-buffer & DMA, round-trip & KAT) -- the only remaining legacy crypto parity gap; deferred to follow-up PR. */
     return 0;

--- a/test-refactor/wh_test_list.c
+++ b/test-refactor/wh_test_list.c
@@ -43,6 +43,7 @@ WH_TEST_DECL(whTest_CertVerify);
 WH_TEST_DECL(whTest_NvmOptional);
 WH_TEST_DECL(whTest_ClientCerts);
 WH_TEST_DECL(whTest_Crypto_Aes);
+WH_TEST_DECL(whTest_CryptoAesCtrLeftOob);
 WH_TEST_DECL(whTest_CryptoAesKeyUsagePolicies);
 WH_TEST_DECL(whTest_Crypto_Cmac);
 WH_TEST_DECL(whTest_Crypto_Curve25519);
@@ -74,6 +75,7 @@ const size_t whTestsServerCount = sizeof(whTestsServer) / sizeof(whTestsServer[0
 const whTestCase whTestsClient[] = {
     { "whTest_ClientCerts", whTest_ClientCerts },
     { "whTest_Crypto_Aes", whTest_Crypto_Aes },
+    { "whTest_CryptoAesCtrLeftOob", whTest_CryptoAesCtrLeftOob },
     { "whTest_CryptoAesKeyUsagePolicies", whTest_CryptoAesKeyUsagePolicies },
     { "whTest_Crypto_Cmac", whTest_Crypto_Cmac },
     { "whTest_Crypto_Curve25519", whTest_Crypto_Curve25519 },

--- a/test-refactor/wh_test_list.c
+++ b/test-refactor/wh_test_list.c
@@ -43,7 +43,6 @@ WH_TEST_DECL(whTest_CertVerify);
 WH_TEST_DECL(whTest_NvmOptional);
 WH_TEST_DECL(whTest_ClientCerts);
 WH_TEST_DECL(whTest_Crypto_Aes);
-WH_TEST_DECL(whTest_CryptoAesCtrLeftOob);
 WH_TEST_DECL(whTest_CryptoAesKeyUsagePolicies);
 WH_TEST_DECL(whTest_Crypto_Cmac);
 WH_TEST_DECL(whTest_Crypto_Curve25519);
@@ -75,7 +74,6 @@ const size_t whTestsServerCount = sizeof(whTestsServer) / sizeof(whTestsServer[0
 const whTestCase whTestsClient[] = {
     { "whTest_ClientCerts", whTest_ClientCerts },
     { "whTest_Crypto_Aes", whTest_Crypto_Aes },
-    { "whTest_CryptoAesCtrLeftOob", whTest_CryptoAesCtrLeftOob },
     { "whTest_CryptoAesKeyUsagePolicies", whTest_CryptoAesKeyUsagePolicies },
     { "whTest_Crypto_Cmac", whTest_Crypto_Cmac },
     { "whTest_Crypto_Curve25519", whTest_Crypto_Curve25519 },

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -8447,6 +8447,31 @@ static int whTest_CryptoAesAsync(whClientContext* ctx, int devId, WC_RNG* rng)
         }
         (void)wc_AesFree(aes);
     }
+
+    /* CTR: server must reject left > AES_BLOCK_SIZE.
+     * wc_AesCtrEncrypt indexes aes->tmp via AES_BLOCK_SIZE - aes->left;
+     * an oversized client-supplied value would cause an out-of-bounds read
+     * disclosing server-side memory across the HSM trust boundary. */
+    if (ret == 0) {
+        int tmp;
+        ret = wc_AesInit(aes, NULL, devId);
+        if (ret == 0) {
+            ret = wc_AesSetKeyDirect(aes, key, sizeof(key), iv, AES_ENCRYPTION);
+        }
+        if (ret == 0) {
+            aes->left = AES_BLOCK_SIZE + 1;
+            tmp = wh_Client_AesCtr(ctx, aes, 1, plainIn, sizeof(plainIn),
+                                   cipher);
+            if (tmp != WH_ERROR_BADARGS) {
+                WH_ERROR_PRINT(
+                    "AES-CTR async: left > AES_BLOCK_SIZE should be "
+                    "BADARGS, got %d\n",
+                    tmp);
+                ret = -1;
+            }
+        }
+        (void)wc_AesFree(aes);
+    }
     if (ret == 0) {
         WH_TEST_PRINT("AES CTR ASYNC DEVID=0x%X SUCCESS\n", devId);
     }
@@ -9445,6 +9470,28 @@ static int whTest_CryptoAesDmaAsync(whClientContext* ctx, int devId,
         (void)wc_AesFree(aes);
         memset(cipher, 0, sizeof(cipher));
         memset(plainOut, 0, sizeof(plainOut));
+    }
+
+    /* CTR DMA: same left > AES_BLOCK_SIZE rejection as the non-DMA path. */
+    if (ret == 0) {
+        int tmp;
+        ret = wc_AesInit(aes, NULL, devId);
+        if (ret == 0) {
+            ret = wc_AesSetKeyDirect(aes, key, sizeof(key), iv, AES_ENCRYPTION);
+        }
+        if (ret == 0) {
+            aes->left = AES_BLOCK_SIZE + 1;
+            tmp = wh_Client_AesCtrDma(ctx, aes, 1, plainIn, sizeof(plainIn),
+                                      cipher);
+            if (tmp != WH_ERROR_BADARGS) {
+                WH_ERROR_PRINT(
+                    "AES-CTR DMA async: left > AES_BLOCK_SIZE should be "
+                    "BADARGS, got %d\n",
+                    tmp);
+                ret = -1;
+            }
+        }
+        (void)wc_AesFree(aes);
     }
     if (ret == 0) {
         WH_TEST_PRINT("AES CTR DMA ASYNC DEVID=0x%X SUCCESS\n", devId);


### PR DESCRIPTION
# Fix: AES-CTR `left` field out-of-bounds read in `_HandleAesCtr` and `_HandleAesCtrDma`

## Background

wolfHSM's AES-CTR streaming API preserves keystream state across calls by round-tripping
`aes->left` and `aes->tmp` between the client and the HSM server.  The `left` field
indicates how many cached keystream bytes remain in `aes->tmp[AES_BLOCK_SIZE]`.

`wc_AesCtrEncrypt` internally indexes into `aes->tmp` as:

```c
aes->tmp[AES_BLOCK_SIZE - aes->left]
```

If `aes->left > AES_BLOCK_SIZE`, the subtraction wraps (unsigned underflow), producing a
very large index and reading beyond the end of `aes->tmp` into adjacent struct memory
(potentially including key material).  The XOR'd bytes from that out-of-bounds read are
written to the output buffer and returned to the caller.

## Problem

Both `_HandleAesCtr` and `_HandleAesCtrDma` restored the client-supplied `left` value
without bounds validation:

```c
// Before fix — in both handlers
if (left > AES_BLOCK_SIZE) {
    ret = WH_ERROR_BADARGS;   // sets ret …
}
aes->left = left;             // … but assignment executes unconditionally
if (enc != 0) {               // guard checks enc, not ret
    wc_AesCtrEncrypt(...);    // called even when left is out of range
}
```

The bounds check set `ret = WH_ERROR_BADARGS`, but `aes->left = left` and the subsequent
`wc_AesCtrEncrypt` call were **not** gated on `ret`.  Because the encrypt call used
`if (enc != 0)` (not `if (ret == WH_ERROR_OK)`), a compromised client core could send
`left > 16` and trigger the out-of-bounds read on every request, crossing the HSM trust
boundary.

## Fix

Wrap the context restoration and the encrypt call inside an `else` branch so they are
skipped entirely when `left > AES_BLOCK_SIZE`.

**`_HandleAesCtr` (`src/wh_server_crypto.c`)**

```c
if (left > AES_BLOCK_SIZE) {
    ret = WH_ERROR_BADARGS;
}
else {
    /* Restore streaming CTR context from the previous call. */
    aes->left = left;
    memcpy(aes->tmp, tmp, sizeof(aes->tmp));
    if (enc != 0) {
        ret = wc_AesCtrEncrypt(aes, out, in, len);
    }
    else {
        ret = wc_AesCtrEncrypt(aes, out, in, len);
    }
}
```

**`_HandleAesCtrDma` (`src/wh_server_crypto.c`)** — identical structure; the
post-encrypt metadata copies (`left`, `out_tmp`, `out_iv`) are also moved inside the
`else` branch so they are never reached with an invalid `left`.

## Tests Added

**`test/wh_test_crypto.c`**

| Function | Test description |
|---|---|
| `whTest_CryptoAesAsync` | Sets `aes->left = AES_BLOCK_SIZE + 1`, calls `wh_Client_AesCtr`, expects `WH_ERROR_BADARGS` |
| `whTest_CryptoAesDmaAsync` | Same check via `wh_Client_AesCtrDma` (active when built with `DMA=1`) |

Both tests verify that the server rejects the request before calling `wc_AesCtrEncrypt`,
confirming no out-of-bounds read can occur.

## Files Changed

| File | Change |
|---|---|
| `src/wh_server_crypto.c` | Add `else` guard in `_HandleAesCtr` and `_HandleAesCtrDma` |
| `test/wh_test_crypto.c` | Add bounds-check rejection tests for non-DMA and DMA paths |
