### PR TITLE
f-2708: Add test cases for KeyUsage

### DIFF
--- a/test-refactor/README.md
+++ b/test-refactor/README.md
@@ -82,6 +82,7 @@ Translated tests:
 | `wh_test_keystore_reqsize.c::whTest_KeystoreReqSize` | `misc/wh_test_keystore_reqsize.c::whTest_KeystoreReqSize` | Misc | |
 | `wh_test_cert.c::whTest_CertRamSim` | `server/wh_test_cert.c::whTest_CertVerify` | Server | remove ramsim coupling and migrate to server group |
 | `wh_test_crypto.c::whTest_Crypto` | `client-server/wh_test_crypto_{aes,cmac,curve25519,ecc,ed25519,kdf,keypolicy,mldsa,rng,rsa,sha}.c::whTest_Crypto_*` | Client | Split into per-algorithm suites; key revocation is gated by `WOLFHSM_CFG_TEST_ALLOW_PERSISTENT_NVM_ARTIFACTS` |
+| `wh_test_crypto.c::whTest_CryptoKeyUsagePolicies` (AES CTR/ECB/GCM subset) | `client-server/wh_test_crypto_aes.c::whTest_CryptoAesKeyUsagePolicies` | Client | AES-CTR/ECB/GCM key usage enforcement (non-DMA and DMA variants) |
 | `wh_test_clientserver.c` (echo and server-info paths) | `client-server/wh_test_echo.c::whTest_Echo`, `client-server/wh_test_server_info.c::whTest_ServerInfo` | Client | pthread test ported, sequential test dropped |
 | `wh_test_wolfcrypt_test.c::whTest_WolfCryptTest` | `client-server/wh_test_wolfcrypt.c::whTest_WolfCryptTest` | Client | |
 | `wh_test_flash_ramsim.c::whTest_Flash_RamSim` | `posix/wh_test_flash_ramsim.c::{whTest_FlashWriteLock, whTest_FlashEraseProgramVerify, whTest_FlashUnitOps}` | POSIX port-specific (`whTestGroup_RunOne`) | remove ramsim coupling and migrate to server group |

--- a/test-refactor/client-server/wh_test_crypto_aes.c
+++ b/test-refactor/client-server/wh_test_crypto_aes.c
@@ -442,6 +442,566 @@ static int whTest_CryptoAesCbcStreaming(whClientContext* ctx)
 }
 #endif /* HAVE_AES_CBC */
 
+int whTest_CryptoAesKeyUsagePolicies(whClientContext* ctx)
+{
+    int      ret        = 0;
+    WC_RNG   rng[1];
+    uint8_t  plaintext[AES_BLOCK_SIZE]  = {0};
+    uint8_t  ciphertext[AES_BLOCK_SIZE] = {0};
+    uint8_t  key[32]                    = {0};
+    uint32_t keyLen                     = sizeof(key);
+    whKeyId  keyId                      = WH_KEYID_ERASED;
+
+    ret = wc_InitRng_ex(rng, NULL, WH_DEV_ID);
+    if (ret != 0) {
+        WH_ERROR_PRINT("Failed to wc_InitRng_ex %d\n", ret);
+        return ret;
+    }
+
+    ret = wc_RNG_GenerateBlock(rng, plaintext, sizeof(plaintext));
+    if (ret == 0)
+        ret = wc_RNG_GenerateBlock(rng, key, sizeof(key));
+    if (ret != 0) {
+        WH_ERROR_PRINT("Failed to generate random data: %d\n", ret);
+        goto done;
+    }
+
+#ifdef WOLFSSL_AES_COUNTER
+    /* AES-CTR: encrypt without ENCRYPT flag */
+    {
+        Aes     aes[1];
+        uint8_t iv[AES_BLOCK_SIZE] = {0};
+        uint8_t ctrCipher[AES_BLOCK_SIZE] = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(ctx, WH_NVM_FLAGS_NONE,
+                                   (uint8_t*)"ctr-no-enc", strlen("ctr-no-enc"),
+                                   key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0)
+                    ret = wc_AesSetIV(aes, iv);
+                if (ret == 0) {
+                    ret = wh_Client_AesCtr(ctx, aes, 1, plaintext,
+                                           sizeof(plaintext), ctrCipher);
+                    if (ret == WH_ERROR_USAGE)
+                        ret = 0;
+                    else {
+                        WH_ERROR_PRINT(
+                            "AES-CTR enc without ENCRYPT flag: expected "
+                            "WH_ERROR_USAGE, got %d\n",
+                            ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(ctx, keyId);
+        }
+    }
+    if (ret != 0)
+        goto done;
+
+    /* AES-CTR: decrypt without DECRYPT flag */
+    {
+        Aes     aes[1];
+        uint8_t iv[AES_BLOCK_SIZE]       = {0};
+        uint8_t ctrOut[AES_BLOCK_SIZE]   = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(ctx, WH_NVM_FLAGS_USAGE_ENCRYPT,
+                                   (uint8_t*)"ctr-no-dec", strlen("ctr-no-dec"),
+                                   key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0)
+                    ret = wc_AesSetIV(aes, iv);
+                if (ret == 0) {
+                    ret = wh_Client_AesCtr(ctx, aes, 0, ciphertext,
+                                           sizeof(ciphertext), ctrOut);
+                    if (ret == WH_ERROR_USAGE)
+                        ret = 0;
+                    else {
+                        WH_ERROR_PRINT(
+                            "AES-CTR dec without DECRYPT flag: expected "
+                            "WH_ERROR_USAGE, got %d\n",
+                            ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(ctx, keyId);
+        }
+    }
+    if (ret != 0)
+        goto done;
+#endif /* WOLFSSL_AES_COUNTER */
+
+#ifdef HAVE_AES_ECB
+    /* AES-ECB: encrypt without ENCRYPT flag */
+    {
+        Aes     aes[1];
+        uint8_t ecbCipher[AES_BLOCK_SIZE] = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(ctx, WH_NVM_FLAGS_NONE,
+                                   (uint8_t*)"ecb-no-enc", strlen("ecb-no-enc"),
+                                   key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    ret = wc_AesEcbEncrypt(aes, ecbCipher, plaintext,
+                                           sizeof(plaintext));
+                    if (ret == WH_ERROR_USAGE)
+                        ret = 0;
+                    else {
+                        WH_ERROR_PRINT(
+                            "AES-ECB enc without ENCRYPT flag: expected "
+                            "WH_ERROR_USAGE, got %d\n",
+                            ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(ctx, keyId);
+        }
+    }
+    if (ret != 0)
+        goto done;
+
+    /* AES-ECB: decrypt without DECRYPT flag */
+    {
+        Aes     aes[1];
+        uint8_t ecbOut[AES_BLOCK_SIZE] = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(ctx, WH_NVM_FLAGS_USAGE_ENCRYPT,
+                                   (uint8_t*)"ecb-no-dec", strlen("ecb-no-dec"),
+                                   key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    ret = wc_AesEcbDecrypt(aes, ecbOut, ciphertext,
+                                           sizeof(ciphertext));
+                    if (ret == WH_ERROR_USAGE)
+                        ret = 0;
+                    else {
+                        WH_ERROR_PRINT(
+                            "AES-ECB dec without DECRYPT flag: expected "
+                            "WH_ERROR_USAGE, got %d\n",
+                            ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(ctx, keyId);
+        }
+    }
+    if (ret != 0)
+        goto done;
+#endif /* HAVE_AES_ECB */
+
+#ifdef HAVE_AESGCM
+    /* AES-GCM: encrypt without ENCRYPT flag */
+    {
+        Aes     aes[1];
+        uint8_t gcmIv[12]              = {0};
+        uint8_t gcmCipher[AES_BLOCK_SIZE] = {0};
+        uint8_t gcmTag[AES_BLOCK_SIZE] = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(ctx, WH_NVM_FLAGS_NONE,
+                                   (uint8_t*)"gcm-no-enc", strlen("gcm-no-enc"),
+                                   key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    ret = wc_AesGcmEncrypt(aes, gcmCipher, plaintext,
+                                           sizeof(plaintext), gcmIv,
+                                           sizeof(gcmIv), gcmTag, sizeof(gcmTag),
+                                           NULL, 0);
+                    if (ret == WH_ERROR_USAGE)
+                        ret = 0;
+                    else {
+                        WH_ERROR_PRINT(
+                            "AES-GCM enc without ENCRYPT flag: expected "
+                            "WH_ERROR_USAGE, got %d\n",
+                            ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(ctx, keyId);
+        }
+    }
+    if (ret != 0)
+        goto done;
+
+    /* AES-GCM: decrypt without DECRYPT flag */
+    {
+        Aes     aes[1];
+        uint8_t gcmIv[12]            = {0};
+        uint8_t gcmOut[AES_BLOCK_SIZE] = {0};
+        uint8_t gcmTag[AES_BLOCK_SIZE] = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(ctx, WH_NVM_FLAGS_USAGE_ENCRYPT,
+                                   (uint8_t*)"gcm-no-dec", strlen("gcm-no-dec"),
+                                   key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    ret = wc_AesGcmDecrypt(aes, gcmOut, ciphertext,
+                                           sizeof(ciphertext), gcmIv,
+                                           sizeof(gcmIv), gcmTag, sizeof(gcmTag),
+                                           NULL, 0);
+                    if (ret == WH_ERROR_USAGE)
+                        ret = 0;
+                    else {
+                        WH_ERROR_PRINT(
+                            "AES-GCM dec without DECRYPT flag: expected "
+                            "WH_ERROR_USAGE, got %d\n",
+                            ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(ctx, keyId);
+        }
+    }
+    if (ret != 0)
+        goto done;
+#endif /* HAVE_AESGCM */
+
+#ifdef WOLFHSM_CFG_DMA
+#ifdef WOLFSSL_AES_COUNTER
+    /* AES-CTR DMA: encrypt without ENCRYPT flag */
+    {
+        Aes     aes[1];
+        uint8_t iv[AES_BLOCK_SIZE]        = {0};
+        uint8_t ctrCipher[AES_BLOCK_SIZE] = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(ctx, WH_NVM_FLAGS_NONE,
+                                   (uint8_t*)"dctr-no-enc",
+                                   strlen("dctr-no-enc"), key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID_DMA);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0)
+                    ret = wc_AesSetIV(aes, iv);
+                if (ret == 0) {
+                    ret = wh_Client_AesCtrDma(ctx, aes, 1, plaintext,
+                                              sizeof(plaintext), ctrCipher);
+                    if (ret == WH_ERROR_USAGE)
+                        ret = 0;
+                    else {
+                        WH_ERROR_PRINT(
+                            "AES-CTR DMA enc without ENCRYPT flag: expected "
+                            "WH_ERROR_USAGE, got %d\n",
+                            ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(ctx, keyId);
+        }
+    }
+    if (ret != 0)
+        goto done;
+
+    /* AES-CTR DMA: decrypt without DECRYPT flag */
+    {
+        Aes     aes[1];
+        uint8_t iv[AES_BLOCK_SIZE]      = {0};
+        uint8_t ctrOut[AES_BLOCK_SIZE]  = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(ctx, WH_NVM_FLAGS_USAGE_ENCRYPT,
+                                   (uint8_t*)"dctr-no-dec",
+                                   strlen("dctr-no-dec"), key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID_DMA);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0)
+                    ret = wc_AesSetIV(aes, iv);
+                if (ret == 0) {
+                    ret = wh_Client_AesCtrDma(ctx, aes, 0, ciphertext,
+                                              sizeof(ciphertext), ctrOut);
+                    if (ret == WH_ERROR_USAGE)
+                        ret = 0;
+                    else {
+                        WH_ERROR_PRINT(
+                            "AES-CTR DMA dec without DECRYPT flag: expected "
+                            "WH_ERROR_USAGE, got %d\n",
+                            ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(ctx, keyId);
+        }
+    }
+    if (ret != 0)
+        goto done;
+#endif /* WOLFSSL_AES_COUNTER */
+
+#ifdef HAVE_AES_ECB
+    /* AES-ECB DMA: encrypt without ENCRYPT flag */
+    {
+        Aes     aes[1];
+        uint8_t ecbCipher[AES_BLOCK_SIZE] = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(ctx, WH_NVM_FLAGS_NONE,
+                                   (uint8_t*)"decb-no-enc",
+                                   strlen("decb-no-enc"), key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID_DMA);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    ret = wh_Client_AesEcbDma(ctx, aes, 1, plaintext,
+                                              sizeof(plaintext), ecbCipher);
+                    if (ret == WH_ERROR_USAGE)
+                        ret = 0;
+                    else {
+                        WH_ERROR_PRINT(
+                            "AES-ECB DMA enc without ENCRYPT flag: expected "
+                            "WH_ERROR_USAGE, got %d\n",
+                            ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(ctx, keyId);
+        }
+    }
+    if (ret != 0)
+        goto done;
+
+    /* AES-ECB DMA: decrypt without DECRYPT flag */
+    {
+        Aes     aes[1];
+        uint8_t ecbOut[AES_BLOCK_SIZE] = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(ctx, WH_NVM_FLAGS_USAGE_ENCRYPT,
+                                   (uint8_t*)"decb-no-dec",
+                                   strlen("decb-no-dec"), key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID_DMA);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    ret = wh_Client_AesEcbDma(ctx, aes, 0, ciphertext,
+                                              sizeof(ciphertext), ecbOut);
+                    if (ret == WH_ERROR_USAGE)
+                        ret = 0;
+                    else {
+                        WH_ERROR_PRINT(
+                            "AES-ECB DMA dec without DECRYPT flag: expected "
+                            "WH_ERROR_USAGE, got %d\n",
+                            ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(ctx, keyId);
+        }
+    }
+    if (ret != 0)
+        goto done;
+#endif /* HAVE_AES_ECB */
+
+#ifdef HAVE_AES_CBC
+    /* AES-CBC DMA: encrypt without ENCRYPT flag */
+    {
+        Aes     aes[1];
+        uint8_t iv[AES_BLOCK_SIZE]        = {0};
+        uint8_t cbcCipher[AES_BLOCK_SIZE] = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(ctx, WH_NVM_FLAGS_NONE,
+                                   (uint8_t*)"dcbc-no-enc",
+                                   strlen("dcbc-no-enc"), key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID_DMA);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0)
+                    ret = wc_AesSetIV(aes, iv);
+                if (ret == 0) {
+                    ret = wh_Client_AesCbcDma(ctx, aes, 1, plaintext,
+                                              sizeof(plaintext), cbcCipher);
+                    if (ret == WH_ERROR_USAGE)
+                        ret = 0;
+                    else {
+                        WH_ERROR_PRINT(
+                            "AES-CBC DMA enc without ENCRYPT flag: expected "
+                            "WH_ERROR_USAGE, got %d\n",
+                            ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(ctx, keyId);
+        }
+    }
+    if (ret != 0)
+        goto done;
+
+    /* AES-CBC DMA: decrypt without DECRYPT flag */
+    {
+        Aes     aes[1];
+        uint8_t iv[AES_BLOCK_SIZE]     = {0};
+        uint8_t cbcOut[AES_BLOCK_SIZE] = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(ctx, WH_NVM_FLAGS_USAGE_ENCRYPT,
+                                   (uint8_t*)"dcbc-no-dec",
+                                   strlen("dcbc-no-dec"), key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID_DMA);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0)
+                    ret = wc_AesSetIV(aes, iv);
+                if (ret == 0) {
+                    ret = wh_Client_AesCbcDma(ctx, aes, 0, ciphertext,
+                                              sizeof(ciphertext), cbcOut);
+                    if (ret == WH_ERROR_USAGE)
+                        ret = 0;
+                    else {
+                        WH_ERROR_PRINT(
+                            "AES-CBC DMA dec without DECRYPT flag: expected "
+                            "WH_ERROR_USAGE, got %d\n",
+                            ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(ctx, keyId);
+        }
+    }
+    if (ret != 0)
+        goto done;
+#endif /* HAVE_AES_CBC */
+
+#ifdef HAVE_AESGCM
+    /* AES-GCM DMA: encrypt without ENCRYPT flag */
+    {
+        Aes     aes[1];
+        uint8_t gcmIv[12]                 = {0};
+        uint8_t gcmCipher[AES_BLOCK_SIZE] = {0};
+        uint8_t gcmTag[AES_BLOCK_SIZE]    = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(ctx, WH_NVM_FLAGS_NONE,
+                                   (uint8_t*)"dgcm-no-enc",
+                                   strlen("dgcm-no-enc"), key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID_DMA);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    ret = wh_Client_AesGcmDma(ctx, aes, 1, plaintext,
+                                              sizeof(plaintext), gcmIv,
+                                              sizeof(gcmIv), NULL, 0,
+                                              NULL, gcmTag, sizeof(gcmTag),
+                                              gcmCipher);
+                    if (ret == WH_ERROR_USAGE)
+                        ret = 0;
+                    else {
+                        WH_ERROR_PRINT(
+                            "AES-GCM DMA enc without ENCRYPT flag: expected "
+                            "WH_ERROR_USAGE, got %d\n",
+                            ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(ctx, keyId);
+        }
+    }
+    if (ret != 0)
+        goto done;
+
+    /* AES-GCM DMA: decrypt without DECRYPT flag */
+    {
+        Aes     aes[1];
+        uint8_t gcmIv[12]              = {0};
+        uint8_t gcmOut[AES_BLOCK_SIZE] = {0};
+        uint8_t gcmTag[AES_BLOCK_SIZE] = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(ctx, WH_NVM_FLAGS_USAGE_ENCRYPT,
+                                   (uint8_t*)"dgcm-no-dec",
+                                   strlen("dgcm-no-dec"), key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID_DMA);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    ret = wh_Client_AesGcmDma(ctx, aes, 0, ciphertext,
+                                              sizeof(ciphertext), gcmIv,
+                                              sizeof(gcmIv), NULL, 0,
+                                              gcmTag, NULL, sizeof(gcmTag),
+                                              gcmOut);
+                    if (ret == WH_ERROR_USAGE)
+                        ret = 0;
+                    else {
+                        WH_ERROR_PRINT(
+                            "AES-GCM DMA dec without DECRYPT flag: expected "
+                            "WH_ERROR_USAGE, got %d\n",
+                            ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(ctx, keyId);
+        }
+    }
+    if (ret != 0)
+        goto done;
+#endif /* HAVE_AESGCM */
+#endif /* WOLFHSM_CFG_DMA */
+
+done:
+    wc_FreeRng(rng);
+    if (ret == 0) {
+        WH_TEST_PRINT("AES key usage policies DEVID=0x%X SUCCESS\n", WH_DEV_ID);
+    }
+    return ret;
+}
+
 int whTest_Crypto_Aes(whClientContext* ctx)
 {
     /* AES round-trips dispatch through the cryptocb, so run on every devId to

--- a/test-refactor/client-server/wh_test_crypto_aes.c
+++ b/test-refactor/client-server/wh_test_crypto_aes.c
@@ -501,8 +501,9 @@ int whTest_CryptoAesKeyUsagePolicies(whClientContext* ctx)
             wh_Client_KeyEvict(ctx, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         goto done;
+    }
 
     /* AES-CTR: decrypt without DECRYPT flag */
     {
@@ -538,8 +539,9 @@ int whTest_CryptoAesKeyUsagePolicies(whClientContext* ctx)
             wh_Client_KeyEvict(ctx, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         goto done;
+    }
 #endif /* WOLFSSL_AES_COUNTER */
 
 #ifdef HAVE_AES_ECB
@@ -574,8 +576,9 @@ int whTest_CryptoAesKeyUsagePolicies(whClientContext* ctx)
             wh_Client_KeyEvict(ctx, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         goto done;
+    }
 
     /* AES-ECB: decrypt without DECRYPT flag */
     {
@@ -608,8 +611,9 @@ int whTest_CryptoAesKeyUsagePolicies(whClientContext* ctx)
             wh_Client_KeyEvict(ctx, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         goto done;
+    }
 #endif /* HAVE_AES_ECB */
 
 #ifdef HAVE_AESGCM
@@ -648,8 +652,9 @@ int whTest_CryptoAesKeyUsagePolicies(whClientContext* ctx)
             wh_Client_KeyEvict(ctx, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         goto done;
+    }
 
     /* AES-GCM: decrypt without DECRYPT flag */
     {
@@ -686,8 +691,9 @@ int whTest_CryptoAesKeyUsagePolicies(whClientContext* ctx)
             wh_Client_KeyEvict(ctx, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         goto done;
+    }
 #endif /* HAVE_AESGCM */
 
 #ifdef WOLFHSM_CFG_DMA
@@ -726,8 +732,9 @@ int whTest_CryptoAesKeyUsagePolicies(whClientContext* ctx)
             wh_Client_KeyEvict(ctx, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         goto done;
+    }
 
     /* AES-CTR DMA: decrypt without DECRYPT flag */
     {
@@ -763,8 +770,9 @@ int whTest_CryptoAesKeyUsagePolicies(whClientContext* ctx)
             wh_Client_KeyEvict(ctx, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         goto done;
+    }
 #endif /* WOLFSSL_AES_COUNTER */
 
 #ifdef HAVE_AES_ECB
@@ -799,8 +807,9 @@ int whTest_CryptoAesKeyUsagePolicies(whClientContext* ctx)
             wh_Client_KeyEvict(ctx, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         goto done;
+    }
 
     /* AES-ECB DMA: decrypt without DECRYPT flag */
     {
@@ -833,8 +842,9 @@ int whTest_CryptoAesKeyUsagePolicies(whClientContext* ctx)
             wh_Client_KeyEvict(ctx, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         goto done;
+    }
 #endif /* HAVE_AES_ECB */
 
 #ifdef HAVE_AES_CBC
@@ -872,8 +882,9 @@ int whTest_CryptoAesKeyUsagePolicies(whClientContext* ctx)
             wh_Client_KeyEvict(ctx, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         goto done;
+    }
 
     /* AES-CBC DMA: decrypt without DECRYPT flag */
     {
@@ -909,8 +920,9 @@ int whTest_CryptoAesKeyUsagePolicies(whClientContext* ctx)
             wh_Client_KeyEvict(ctx, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         goto done;
+    }
 #endif /* HAVE_AES_CBC */
 
 #ifdef HAVE_AESGCM
@@ -950,8 +962,9 @@ int whTest_CryptoAesKeyUsagePolicies(whClientContext* ctx)
             wh_Client_KeyEvict(ctx, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         goto done;
+    }
 
     /* AES-GCM DMA: decrypt without DECRYPT flag */
     {
@@ -989,8 +1002,9 @@ int whTest_CryptoAesKeyUsagePolicies(whClientContext* ctx)
             wh_Client_KeyEvict(ctx, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         goto done;
+    }
 #endif /* HAVE_AESGCM */
 #endif /* WOLFHSM_CFG_DMA */
 

--- a/test-refactor/wh_test_list.c
+++ b/test-refactor/wh_test_list.c
@@ -43,6 +43,7 @@ WH_TEST_DECL(whTest_CertVerify);
 WH_TEST_DECL(whTest_NvmOptional);
 WH_TEST_DECL(whTest_ClientCerts);
 WH_TEST_DECL(whTest_Crypto_Aes);
+WH_TEST_DECL(whTest_CryptoAesKeyUsagePolicies);
 WH_TEST_DECL(whTest_Crypto_Cmac);
 WH_TEST_DECL(whTest_Crypto_Curve25519);
 WH_TEST_DECL(whTest_Crypto_Ecc);
@@ -73,6 +74,7 @@ const size_t whTestsServerCount = sizeof(whTestsServer) / sizeof(whTestsServer[0
 const whTestCase whTestsClient[] = {
     { "whTest_ClientCerts", whTest_ClientCerts },
     { "whTest_Crypto_Aes", whTest_Crypto_Aes },
+    { "whTest_CryptoAesKeyUsagePolicies", whTest_CryptoAesKeyUsagePolicies },
     { "whTest_Crypto_Cmac", whTest_Crypto_Cmac },
     { "whTest_Crypto_Curve25519", whTest_Crypto_Curve25519 },
     { "whTest_Crypto_Ecc", whTest_Crypto_Ecc },

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -13297,6 +13297,544 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
     if (ret != 0)
         return ret;
 #endif /* HAVE_AES_CBC */
+
+#ifdef WOLFSSL_AES_COUNTER
+    /* AES-CTR: encrypt without ENCRYPT flag */
+    WH_TEST_PRINT("  Testing AES CTR encrypt without ENCRYPT flag...\n");
+    {
+        Aes     aes[1];
+        uint8_t iv[AES_BLOCK_SIZE] = {0};
+        uint8_t ctrCipher[16]      = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(client, WH_NVM_FLAGS_NONE,
+                                   (uint8_t*)"ctr-no-enc", strlen("ctr-no-enc"),
+                                   key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    (void)wc_AesSetIV(aes, iv);
+                    ret = wh_Client_AesCtr(client, aes, 1, plaintext,
+                                           sizeof(plaintext), ctrCipher);
+                    if (ret == WH_ERROR_USAGE) {
+                        WH_TEST_PRINT("    PASS: Correctly denied encryption\n");
+                        ret = 0;
+                    }
+                    else {
+                        WH_ERROR_PRINT(
+                            "    FAIL: Expected WH_ERROR_USAGE, got %d\n", ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(client, keyId);
+        }
+    }
+    if (ret != 0)
+        return ret;
+
+    /* AES-CTR: decrypt without DECRYPT flag */
+    WH_TEST_PRINT("  Testing AES CTR decrypt without DECRYPT flag...\n");
+    {
+        Aes     aes[1];
+        uint8_t iv[AES_BLOCK_SIZE] = {0};
+        uint8_t ctrOut[16]         = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(client, WH_NVM_FLAGS_USAGE_ENCRYPT,
+                                   (uint8_t*)"ctr-no-dec", strlen("ctr-no-dec"),
+                                   key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    (void)wc_AesSetIV(aes, iv);
+                    ret = wh_Client_AesCtr(client, aes, 0, ciphertext,
+                                           sizeof(ciphertext), ctrOut);
+                    if (ret == WH_ERROR_USAGE) {
+                        WH_TEST_PRINT("    PASS: Correctly denied decryption\n");
+                        ret = 0;
+                    }
+                    else {
+                        WH_ERROR_PRINT(
+                            "    FAIL: Expected WH_ERROR_USAGE, got %d\n", ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(client, keyId);
+        }
+    }
+    if (ret != 0)
+        return ret;
+#endif /* WOLFSSL_AES_COUNTER */
+
+#ifdef HAVE_AES_ECB
+    /* AES-ECB: encrypt without ENCRYPT flag */
+    WH_TEST_PRINT("  Testing AES ECB encrypt without ENCRYPT flag...\n");
+    {
+        Aes     aes[1];
+        uint8_t ecbCipher[16] = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(client, WH_NVM_FLAGS_NONE,
+                                   (uint8_t*)"ecb-no-enc", strlen("ecb-no-enc"),
+                                   key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    ret = wc_AesEcbEncrypt(aes, ecbCipher, plaintext,
+                                           sizeof(plaintext));
+                    if (ret == WH_ERROR_USAGE) {
+                        WH_TEST_PRINT("    PASS: Correctly denied encryption\n");
+                        ret = 0;
+                    }
+                    else {
+                        WH_ERROR_PRINT(
+                            "    FAIL: Expected WH_ERROR_USAGE, got %d\n", ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(client, keyId);
+        }
+    }
+    if (ret != 0)
+        return ret;
+
+    /* AES-ECB: decrypt without DECRYPT flag */
+    WH_TEST_PRINT("  Testing AES ECB decrypt without DECRYPT flag...\n");
+    {
+        Aes     aes[1];
+        uint8_t ecbOut[16] = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(client, WH_NVM_FLAGS_USAGE_ENCRYPT,
+                                   (uint8_t*)"ecb-no-dec", strlen("ecb-no-dec"),
+                                   key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    ret = wc_AesEcbDecrypt(aes, ecbOut, ciphertext,
+                                           sizeof(ciphertext));
+                    if (ret == WH_ERROR_USAGE) {
+                        WH_TEST_PRINT("    PASS: Correctly denied decryption\n");
+                        ret = 0;
+                    }
+                    else {
+                        WH_ERROR_PRINT(
+                            "    FAIL: Expected WH_ERROR_USAGE, got %d\n", ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(client, keyId);
+        }
+    }
+    if (ret != 0)
+        return ret;
+#endif /* HAVE_AES_ECB */
+
+#ifdef HAVE_AESGCM
+    /* AES-GCM: encrypt without ENCRYPT flag */
+    WH_TEST_PRINT("  Testing AES GCM encrypt without ENCRYPT flag...\n");
+    {
+        Aes     aes[1];
+        uint8_t gcmIv[12]     = {0};
+        uint8_t gcmCipher[16] = {0};
+        uint8_t gcmTag[16]    = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(client, WH_NVM_FLAGS_NONE,
+                                   (uint8_t*)"gcm-no-enc", strlen("gcm-no-enc"),
+                                   key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    ret = wc_AesGcmEncrypt(aes, gcmCipher, plaintext,
+                                           sizeof(plaintext), gcmIv,
+                                           sizeof(gcmIv), gcmTag, sizeof(gcmTag),
+                                           NULL, 0);
+                    if (ret == WH_ERROR_USAGE) {
+                        WH_TEST_PRINT("    PASS: Correctly denied encryption\n");
+                        ret = 0;
+                    }
+                    else {
+                        WH_ERROR_PRINT(
+                            "    FAIL: Expected WH_ERROR_USAGE, got %d\n", ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(client, keyId);
+        }
+    }
+    if (ret != 0)
+        return ret;
+
+    /* AES-GCM: decrypt without DECRYPT flag */
+    WH_TEST_PRINT("  Testing AES GCM decrypt without DECRYPT flag...\n");
+    {
+        Aes     aes[1];
+        uint8_t gcmIv[12]  = {0};
+        uint8_t gcmOut[16] = {0};
+        uint8_t gcmTag[16] = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(client, WH_NVM_FLAGS_USAGE_ENCRYPT,
+                                   (uint8_t*)"gcm-no-dec", strlen("gcm-no-dec"),
+                                   key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    ret = wc_AesGcmDecrypt(aes, gcmOut, ciphertext,
+                                           sizeof(ciphertext), gcmIv,
+                                           sizeof(gcmIv), gcmTag, sizeof(gcmTag),
+                                           NULL, 0);
+                    if (ret == WH_ERROR_USAGE) {
+                        WH_TEST_PRINT("    PASS: Correctly denied decryption\n");
+                        ret = 0;
+                    }
+                    else {
+                        WH_ERROR_PRINT(
+                            "    FAIL: Expected WH_ERROR_USAGE, got %d\n", ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(client, keyId);
+        }
+    }
+    if (ret != 0)
+        return ret;
+#endif /* HAVE_AESGCM */
+
+#ifdef WOLFHSM_CFG_DMA
+#ifdef WOLFSSL_AES_COUNTER
+    /* AES-CTR DMA: encrypt without ENCRYPT flag */
+    WH_TEST_PRINT("  Testing AES CTR DMA encrypt without ENCRYPT flag...\n");
+    {
+        Aes     aes[1];
+        uint8_t iv[AES_BLOCK_SIZE] = {0};
+        uint8_t ctrCipher[16]      = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(client, WH_NVM_FLAGS_NONE,
+                                   (uint8_t*)"dctr-no-enc",
+                                   strlen("dctr-no-enc"), key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID_DMA);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    (void)wc_AesSetIV(aes, iv);
+                    ret = wh_Client_AesCtrDma(client, aes, 1, plaintext,
+                                              sizeof(plaintext), ctrCipher);
+                    if (ret == WH_ERROR_USAGE) {
+                        WH_TEST_PRINT("    PASS: Correctly denied encryption\n");
+                        ret = 0;
+                    }
+                    else {
+                        WH_ERROR_PRINT(
+                            "    FAIL: Expected WH_ERROR_USAGE, got %d\n", ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(client, keyId);
+        }
+    }
+    if (ret != 0)
+        return ret;
+
+    /* AES-CTR DMA: decrypt without DECRYPT flag */
+    WH_TEST_PRINT("  Testing AES CTR DMA decrypt without DECRYPT flag...\n");
+    {
+        Aes     aes[1];
+        uint8_t iv[AES_BLOCK_SIZE] = {0};
+        uint8_t ctrOut[16]         = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(client, WH_NVM_FLAGS_USAGE_ENCRYPT,
+                                   (uint8_t*)"dctr-no-dec",
+                                   strlen("dctr-no-dec"), key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID_DMA);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    (void)wc_AesSetIV(aes, iv);
+                    ret = wh_Client_AesCtrDma(client, aes, 0, ciphertext,
+                                              sizeof(ciphertext), ctrOut);
+                    if (ret == WH_ERROR_USAGE) {
+                        WH_TEST_PRINT("    PASS: Correctly denied decryption\n");
+                        ret = 0;
+                    }
+                    else {
+                        WH_ERROR_PRINT(
+                            "    FAIL: Expected WH_ERROR_USAGE, got %d\n", ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(client, keyId);
+        }
+    }
+    if (ret != 0)
+        return ret;
+#endif /* WOLFSSL_AES_COUNTER */
+
+#ifdef HAVE_AES_ECB
+    /* AES-ECB DMA: encrypt without ENCRYPT flag */
+    WH_TEST_PRINT("  Testing AES ECB DMA encrypt without ENCRYPT flag...\n");
+    {
+        Aes     aes[1];
+        uint8_t ecbCipher[16] = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(client, WH_NVM_FLAGS_NONE,
+                                   (uint8_t*)"decb-no-enc",
+                                   strlen("decb-no-enc"), key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID_DMA);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    ret = wh_Client_AesEcbDma(client, aes, 1, plaintext,
+                                              sizeof(plaintext), ecbCipher);
+                    if (ret == WH_ERROR_USAGE) {
+                        WH_TEST_PRINT("    PASS: Correctly denied encryption\n");
+                        ret = 0;
+                    }
+                    else {
+                        WH_ERROR_PRINT(
+                            "    FAIL: Expected WH_ERROR_USAGE, got %d\n", ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(client, keyId);
+        }
+    }
+    if (ret != 0)
+        return ret;
+
+    /* AES-ECB DMA: decrypt without DECRYPT flag */
+    WH_TEST_PRINT("  Testing AES ECB DMA decrypt without DECRYPT flag...\n");
+    {
+        Aes     aes[1];
+        uint8_t ecbOut[16] = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(client, WH_NVM_FLAGS_USAGE_ENCRYPT,
+                                   (uint8_t*)"decb-no-dec",
+                                   strlen("decb-no-dec"), key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID_DMA);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    ret = wh_Client_AesEcbDma(client, aes, 0, ciphertext,
+                                              sizeof(ciphertext), ecbOut);
+                    if (ret == WH_ERROR_USAGE) {
+                        WH_TEST_PRINT("    PASS: Correctly denied decryption\n");
+                        ret = 0;
+                    }
+                    else {
+                        WH_ERROR_PRINT(
+                            "    FAIL: Expected WH_ERROR_USAGE, got %d\n", ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(client, keyId);
+        }
+    }
+    if (ret != 0)
+        return ret;
+#endif /* HAVE_AES_ECB */
+
+#ifdef HAVE_AES_CBC
+    /* AES-CBC DMA: encrypt without ENCRYPT flag */
+    WH_TEST_PRINT("  Testing AES CBC DMA encrypt without ENCRYPT flag...\n");
+    {
+        Aes     aes[1];
+        uint8_t iv[AES_BLOCK_SIZE] = {0};
+        uint8_t cbcCipher[16]      = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(client, WH_NVM_FLAGS_NONE,
+                                   (uint8_t*)"dcbc-no-enc",
+                                   strlen("dcbc-no-enc"), key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID_DMA);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    (void)wc_AesSetIV(aes, iv);
+                    ret = wh_Client_AesCbcDma(client, aes, 1, plaintext,
+                                              sizeof(plaintext), cbcCipher);
+                    if (ret == WH_ERROR_USAGE) {
+                        WH_TEST_PRINT("    PASS: Correctly denied encryption\n");
+                        ret = 0;
+                    }
+                    else {
+                        WH_ERROR_PRINT(
+                            "    FAIL: Expected WH_ERROR_USAGE, got %d\n", ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(client, keyId);
+        }
+    }
+    if (ret != 0)
+        return ret;
+
+    /* AES-CBC DMA: decrypt without DECRYPT flag */
+    WH_TEST_PRINT("  Testing AES CBC DMA decrypt without DECRYPT flag...\n");
+    {
+        Aes     aes[1];
+        uint8_t iv[AES_BLOCK_SIZE] = {0};
+        uint8_t cbcOut[16]         = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(client, WH_NVM_FLAGS_USAGE_ENCRYPT,
+                                   (uint8_t*)"dcbc-no-dec",
+                                   strlen("dcbc-no-dec"), key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID_DMA);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    (void)wc_AesSetIV(aes, iv);
+                    ret = wh_Client_AesCbcDma(client, aes, 0, ciphertext,
+                                              sizeof(ciphertext), cbcOut);
+                    if (ret == WH_ERROR_USAGE) {
+                        WH_TEST_PRINT("    PASS: Correctly denied decryption\n");
+                        ret = 0;
+                    }
+                    else {
+                        WH_ERROR_PRINT(
+                            "    FAIL: Expected WH_ERROR_USAGE, got %d\n", ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(client, keyId);
+        }
+    }
+    if (ret != 0)
+        return ret;
+#endif /* HAVE_AES_CBC */
+
+#ifdef HAVE_AESGCM
+    /* AES-GCM DMA: encrypt without ENCRYPT flag */
+    WH_TEST_PRINT("  Testing AES GCM DMA encrypt without ENCRYPT flag...\n");
+    {
+        Aes     aes[1];
+        uint8_t gcmIv[12]     = {0};
+        uint8_t gcmCipher[16] = {0};
+        uint8_t gcmTag[16]    = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(client, WH_NVM_FLAGS_NONE,
+                                   (uint8_t*)"dgcm-no-enc",
+                                   strlen("dgcm-no-enc"), key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID_DMA);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    ret = wh_Client_AesGcmDma(client, aes, 1, plaintext,
+                                              sizeof(plaintext), gcmIv,
+                                              sizeof(gcmIv), NULL, 0,
+                                              NULL, gcmTag, sizeof(gcmTag),
+                                              gcmCipher);
+                    if (ret == WH_ERROR_USAGE) {
+                        WH_TEST_PRINT("    PASS: Correctly denied encryption\n");
+                        ret = 0;
+                    }
+                    else {
+                        WH_ERROR_PRINT(
+                            "    FAIL: Expected WH_ERROR_USAGE, got %d\n", ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(client, keyId);
+        }
+    }
+    if (ret != 0)
+        return ret;
+
+    /* AES-GCM DMA: decrypt without DECRYPT flag */
+    WH_TEST_PRINT("  Testing AES GCM DMA decrypt without DECRYPT flag...\n");
+    {
+        Aes     aes[1];
+        uint8_t gcmIv[12]  = {0};
+        uint8_t gcmOut[16] = {0};
+        uint8_t gcmTag[16] = {0};
+
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_KeyCache(client, WH_NVM_FLAGS_USAGE_ENCRYPT,
+                                   (uint8_t*)"dgcm-no-dec",
+                                   strlen("dgcm-no-dec"), key, keyLen, &keyId);
+        if (ret == 0) {
+            ret = wc_AesInit(aes, NULL, WH_DEV_ID_DMA);
+            if (ret == 0) {
+                ret = wh_Client_AesSetKeyId(aes, keyId);
+                if (ret == 0) {
+                    /* dec_tag must be non-NULL for decrypt direction */
+                    ret = wh_Client_AesGcmDma(client, aes, 0, ciphertext,
+                                              sizeof(ciphertext), gcmIv,
+                                              sizeof(gcmIv), NULL, 0,
+                                              gcmTag, NULL, sizeof(gcmTag),
+                                              gcmOut);
+                    if (ret == WH_ERROR_USAGE) {
+                        WH_TEST_PRINT("    PASS: Correctly denied decryption\n");
+                        ret = 0;
+                    }
+                    else {
+                        WH_ERROR_PRINT(
+                            "    FAIL: Expected WH_ERROR_USAGE, got %d\n", ret);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_AesFree(aes);
+            }
+            wh_Client_KeyEvict(client, keyId);
+        }
+    }
+    if (ret != 0)
+        return ret;
+#endif /* HAVE_AESGCM */
+#endif /* WOLFHSM_CFG_DMA */
+
 #endif /* !NO_AES */
 
 #ifdef HAVE_ECC

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -13220,8 +13220,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             wh_Client_KeyEvict(client, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 
     /* AES decrypt without DECRYPT flag */
     WH_TEST_PRINT("  Testing AES CBC decrypt without DECRYPT flag...\n");
@@ -13294,8 +13295,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             }
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 #endif /* HAVE_AES_CBC */
 
 #ifdef WOLFSSL_AES_COUNTER
@@ -13335,8 +13337,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             wh_Client_KeyEvict(client, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 
     /* AES-CTR: decrypt without DECRYPT flag */
     WH_TEST_PRINT("  Testing AES CTR decrypt without DECRYPT flag...\n");
@@ -13374,8 +13377,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             wh_Client_KeyEvict(client, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 #endif /* WOLFSSL_AES_COUNTER */
 
 #ifdef HAVE_AES_ECB
@@ -13411,8 +13415,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             wh_Client_KeyEvict(client, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 
     /* AES-ECB: decrypt without DECRYPT flag */
     WH_TEST_PRINT("  Testing AES ECB decrypt without DECRYPT flag...\n");
@@ -13446,8 +13451,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             wh_Client_KeyEvict(client, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 #endif /* HAVE_AES_ECB */
 
 #ifdef HAVE_AESGCM
@@ -13487,8 +13493,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             wh_Client_KeyEvict(client, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 
     /* AES-GCM: decrypt without DECRYPT flag */
     WH_TEST_PRINT("  Testing AES GCM decrypt without DECRYPT flag...\n");
@@ -13526,8 +13533,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             wh_Client_KeyEvict(client, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 #endif /* HAVE_AESGCM */
 
 #ifdef WOLFHSM_CFG_DMA
@@ -13568,8 +13576,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             wh_Client_KeyEvict(client, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 
     /* AES-CTR DMA: decrypt without DECRYPT flag */
     WH_TEST_PRINT("  Testing AES CTR DMA decrypt without DECRYPT flag...\n");
@@ -13607,8 +13616,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             wh_Client_KeyEvict(client, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 #endif /* WOLFSSL_AES_COUNTER */
 
 #ifdef HAVE_AES_ECB
@@ -13644,8 +13654,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             wh_Client_KeyEvict(client, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 
     /* AES-ECB DMA: decrypt without DECRYPT flag */
     WH_TEST_PRINT("  Testing AES ECB DMA decrypt without DECRYPT flag...\n");
@@ -13679,8 +13690,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             wh_Client_KeyEvict(client, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 #endif /* HAVE_AES_ECB */
 
 #ifdef HAVE_AES_CBC
@@ -13720,8 +13732,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             wh_Client_KeyEvict(client, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 
     /* AES-CBC DMA: decrypt without DECRYPT flag */
     WH_TEST_PRINT("  Testing AES CBC DMA decrypt without DECRYPT flag...\n");
@@ -13759,8 +13772,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             wh_Client_KeyEvict(client, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 #endif /* HAVE_AES_CBC */
 
 #ifdef HAVE_AESGCM
@@ -13801,8 +13815,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             wh_Client_KeyEvict(client, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 
     /* AES-GCM DMA: decrypt without DECRYPT flag */
     WH_TEST_PRINT("  Testing AES GCM DMA decrypt without DECRYPT flag...\n");
@@ -13842,8 +13857,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             wh_Client_KeyEvict(client, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 #endif /* HAVE_AESGCM */
 #endif /* WOLFHSM_CFG_DMA */
 
@@ -13897,8 +13913,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             wh_Client_KeyEvict(client, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 #endif /* HAVE_ECC_SIGN */
 
 #ifdef HAVE_ECC_DHE
@@ -13968,8 +13985,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             wh_Client_KeyEvict(client, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 #endif /* HAVE_ECC_DHE */
 #endif /* HAVE_ECC */
 
@@ -14012,8 +14030,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             }
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 #endif /* HAVE_HKDF */
 
 #if defined(WOLFSSL_CMAC) && !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT)
@@ -14062,8 +14081,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             wh_Client_KeyEvict(client, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 
     /* CMAC Verify without VERIFY flag */
     WH_TEST_PRINT("  Testing CMAC verify without VERIFY flag...\n");
@@ -14114,8 +14134,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             wh_Client_KeyEvict(client, keyId);
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 #endif /* WOLFSSL_CMAC && !NO_AES && WOLFSSL_AES_DIRECT */
 
 #ifdef WOLFHSM_CFG_KEYWRAP
@@ -14164,8 +14185,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             }
         }
     }
-    if (ret != 0)
+    if (ret != 0) {
         return ret;
+    }
 #endif /* WOLFHSM_CFG_KEYWRAP */
 
     WH_TEST_PRINT("Key Usage Policy Tests PASSED\n");

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -13315,7 +13315,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             if (ret == 0) {
                 ret = wh_Client_AesSetKeyId(aes, keyId);
                 if (ret == 0) {
-                    (void)wc_AesSetIV(aes, iv);
+                    ret = wc_AesSetIV(aes, iv);
+                }
+                if (ret == 0) {
                     ret = wh_Client_AesCtr(client, aes, 1, plaintext,
                                            sizeof(plaintext), ctrCipher);
                     if (ret == WH_ERROR_USAGE) {
@@ -13352,7 +13354,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             if (ret == 0) {
                 ret = wh_Client_AesSetKeyId(aes, keyId);
                 if (ret == 0) {
-                    (void)wc_AesSetIV(aes, iv);
+                    ret = wc_AesSetIV(aes, iv);
+                }
+                if (ret == 0) {
                     ret = wh_Client_AesCtr(client, aes, 0, ciphertext,
                                            sizeof(ciphertext), ctrOut);
                     if (ret == WH_ERROR_USAGE) {
@@ -13544,7 +13548,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             if (ret == 0) {
                 ret = wh_Client_AesSetKeyId(aes, keyId);
                 if (ret == 0) {
-                    (void)wc_AesSetIV(aes, iv);
+                    ret = wc_AesSetIV(aes, iv);
+                }
+                if (ret == 0) {
                     ret = wh_Client_AesCtrDma(client, aes, 1, plaintext,
                                               sizeof(plaintext), ctrCipher);
                     if (ret == WH_ERROR_USAGE) {
@@ -13581,7 +13587,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             if (ret == 0) {
                 ret = wh_Client_AesSetKeyId(aes, keyId);
                 if (ret == 0) {
-                    (void)wc_AesSetIV(aes, iv);
+                    ret = wc_AesSetIV(aes, iv);
+                }
+                if (ret == 0) {
                     ret = wh_Client_AesCtrDma(client, aes, 0, ciphertext,
                                               sizeof(ciphertext), ctrOut);
                     if (ret == WH_ERROR_USAGE) {
@@ -13692,7 +13700,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             if (ret == 0) {
                 ret = wh_Client_AesSetKeyId(aes, keyId);
                 if (ret == 0) {
-                    (void)wc_AesSetIV(aes, iv);
+                    ret = wc_AesSetIV(aes, iv);
+                }
+                if (ret == 0) {
                     ret = wh_Client_AesCbcDma(client, aes, 1, plaintext,
                                               sizeof(plaintext), cbcCipher);
                     if (ret == WH_ERROR_USAGE) {
@@ -13729,7 +13739,9 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
             if (ret == 0) {
                 ret = wh_Client_AesSetKeyId(aes, keyId);
                 if (ret == 0) {
-                    (void)wc_AesSetIV(aes, iv);
+                    ret = wc_AesSetIV(aes, iv);
+                }
+                if (ret == 0) {
                     ret = wh_Client_AesCbcDma(client, aes, 0, ciphertext,
                                               sizeof(ciphertext), cbcOut);
                     if (ret == WH_ERROR_USAGE) {


### PR DESCRIPTION
# Test: Add key usage policy enforcement tests for AES CTR/ECB/GCM and all DMA handlers

## Background

`wh_Server_KeystoreEnforceKeyUsage` is called in every AES cipher handler on the server
side to prevent a cached key from being used in an operation its policy does not permit
(e.g., an ENCRYPT-only key being used to decrypt).  However, the existing positive tests
in `whTestCrypto_Aes` always cache keys with both `WH_NVM_FLAGS_USAGE_ENCRYPT` and
`WH_NVM_FLAGS_USAGE_DECRYPT` set, so the enforcement logic is never actually exercised.

## Problem

Three gaps were identified:

1. **No negative tests for CTR, ECB, or GCM** — only `_HandleAesCbc` had rejection tests
   (lines 5101–5214 of `wh_test_crypto.c`).  Deleting the enforcement call from any of
   the other three handlers caused zero test failures.

2. **No tests at all for the DMA handlers** — `_HandleAesCtrDma`, `_HandleAesEcbDma`,
   `_HandleAesCbcDma`, and `_HandleAesGcmDma` each contain enforcement code but had no
   test coverage of any kind.

## Fix

Added negative tests to `whTest_CryptoKeyUsagePolicies` in `test/wh_test_crypto.c`.
Each test caches a key with restricted flags, then attempts the forbidden operation and
asserts that the server returns `WH_ERROR_USAGE`.

### Non-DMA handlers

| Mode | Test | Key flags cached |
|---|---|---|
| AES-CTR | encrypt (`enc=1`) without ENCRYPT flag | `WH_NVM_FLAGS_NONE` |
| AES-CTR | decrypt (`enc=0`) without DECRYPT flag | `WH_NVM_FLAGS_USAGE_ENCRYPT` |
| AES-ECB | encrypt without ENCRYPT flag | `WH_NVM_FLAGS_NONE` |
| AES-ECB | decrypt without DECRYPT flag | `WH_NVM_FLAGS_USAGE_ENCRYPT` |
| AES-GCM | encrypt without ENCRYPT flag | `WH_NVM_FLAGS_NONE` |
| AES-GCM | decrypt without DECRYPT flag | `WH_NVM_FLAGS_USAGE_ENCRYPT` |

### DMA handlers (active when built with `DMA=1`)

| Mode | Test |
|---|---|
| AES-CTR DMA | encrypt / decrypt rejection |
| AES-ECB DMA | encrypt / decrypt rejection |
| AES-CBC DMA | encrypt / decrypt rejection |
| AES-GCM DMA | encrypt / decrypt rejection |

### Notes

- AES-CTR uses `wh_Client_AesCtr` directly (with `enc=0` / `enc=1`) because
  `wc_AesCtrEncrypt` is symmetric and always sends `enc=1` through the wolfcrypt
  crypto callback.
- AES-ECB and AES-GCM use the standard wolfcrypt functions (`wc_AesEcbEncrypt`,
  `wc_AesGcmDecrypt`, etc.), which set the direction flag correctly through the callback.
- For GCM DMA decrypt, `dec_tag` is passed as a non-NULL zero buffer to satisfy the
  client-side `BADARGS` guard; the server rejects the request at the key usage check
  before any cryptographic operation or DMA address processing occurs.

## Files Changed

| File | Change |
|---|---|
| `test/wh_test_crypto.c` | Add 14 rejection tests (6 non-DMA + 8 DMA) to `whTest_CryptoKeyUsagePolicies` |
