### PR TITLE
Add data len check in wh_CommClient_RecvResponse

### DIFF
--- a/docs/src-ja/chapter04.md
+++ b/docs/src-ja/chapter04.md
@@ -145,7 +145,7 @@ rc = wh_CommClient_SendRequest(context, req_magic, req_type, &request_id,
 uint16_t resp_magic, resp_type, resp_id, resp_size;
 char response_data[20];
 while((rc = wh_CommClient_RecvResponse(context,&resp_magic, &resp_type, &resp_id,
-                    &resp_size, resp_data)) == WH_ERROR_NOTREADY) {
+                    &resp_size, sizeof(response_data), response_data)) == WH_ERROR_NOTREADY) {
         /* 他のタスクを実行 or yield */
 }
 ```

--- a/src/wh_client.c
+++ b/src/wh_client.c
@@ -255,12 +255,11 @@ int wh_Client_SendRequest(whClientContext* c,
 
 int wh_Client_RecvResponse(whClientContext *c,
         uint16_t *out_group, uint16_t *out_action,
-        uint16_t *out_size, void* data)
+        uint16_t *out_size, uint16_t data_size, void* data)
 {
     int      rc        = 0;
     uint16_t resp_kind = 0;
     uint16_t resp_id   = 0;
-    uint16_t resp_size = 0;
 
     if (c == NULL) {
         return WH_ERROR_BADARGS;
@@ -268,7 +267,7 @@ int wh_Client_RecvResponse(whClientContext *c,
 
     /* Comm layer performs magic and sequence validation */
     rc = wh_CommClient_RecvResponse(c->comm, NULL, &resp_kind, &resp_id,
-                                    &resp_size, data);
+                                    out_size, data_size, data);
     if (rc == 0) {
         if ((resp_kind != c->last_req_kind) || (resp_id != c->last_req_id)) {
             /* Response kind/id doesn't match outstanding request. */
@@ -280,9 +279,6 @@ int wh_Client_RecvResponse(whClientContext *c,
             }
             if (out_action != NULL) {
                 *out_action = WH_MESSAGE_ACTION(resp_kind);
-            }
-            if (out_size != NULL) {
-                *out_size = resp_size;
             }
         }
     }
@@ -329,7 +325,7 @@ int wh_Client_CommInitResponse(whClientContext* c,
 
     rc = wh_Client_RecvResponse(c,
             &resp_group, &resp_action,
-            &resp_size, &msg);
+            &resp_size, sizeof(msg), &msg);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_COMM) ||
@@ -409,7 +405,7 @@ int wh_Client_CommInfoResponse(whClientContext* c,
 
     rc = wh_Client_RecvResponse(c,
             &resp_group, &resp_action,
-            &resp_size, &msg);
+            &resp_size, sizeof(msg), &msg);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_COMM) ||
@@ -587,7 +583,7 @@ int wh_Client_CommCloseResponse(whClientContext* c)
 
     rc = wh_Client_RecvResponse(c,
             &resp_group, &resp_action,
-            &resp_size, NULL);
+            &resp_size, 0, NULL);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_COMM) ||
@@ -660,7 +656,7 @@ int wh_Client_EchoResponse(whClientContext* c, uint16_t *out_size, void* data)
 
     rc = wh_Client_RecvResponse(c,
          &resp_group, &resp_action,
-         &resp_size, msg);
+         &resp_size, WOLFHSM_CFG_COMM_DATA_LEN, msg);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_COMM) ||
@@ -722,7 +718,8 @@ int wh_Client_CustomCbResponse(whClientContext*          c,
     }
 
     rc =
-        wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size, &resp);
+        wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
+                               sizeof(resp), &resp);
     if (rc != WH_ERROR_OK) {
         return rc;
     }
@@ -872,7 +869,7 @@ int wh_Client_KeyCacheResponse(whClientContext* c, uint16_t* keyId)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &size, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
         if (resp->rc != 0) {
             ret = resp->rc;
@@ -959,7 +956,8 @@ int wh_Client_KeyCacheRandomResponse(whClientContext* c, uint16_t* outKeyId)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &size,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
         if (resp->rc != 0) {
             ret = resp->rc;
@@ -1027,7 +1025,8 @@ int wh_Client_KeyEvictResponse(whClientContext* c)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)&resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &size, sizeof(resp),
+                                 (uint8_t*)&resp);
 
     if (ret == 0) {
         if (resp.rc != 0) {
@@ -1090,7 +1089,7 @@ int wh_Client_KeyExportResponse(whClientContext* c, uint8_t* label,
     }
     packOut = (uint8_t*)(resp + 1);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &size, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
         if (resp->rc != 0) {
             ret = resp->rc;
@@ -1175,7 +1174,7 @@ int wh_Client_KeyExportPublicResponse(whClientContext* c, uint8_t* label,
     }
     packOut = (uint8_t*)(resp + 1);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &size, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
         if (resp->rc != 0) {
             ret = resp->rc;
@@ -1252,7 +1251,7 @@ int wh_Client_KeyCommitResponse(whClientContext* c)
         return WH_ERROR_BADARGS;
     }
 
-    ret  = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)resp);
+    ret  = wh_Client_RecvResponse(c, &group, &action, &size, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
         if (resp->rc != 0) {
             ret = resp->rc;
@@ -1308,7 +1307,7 @@ int wh_Client_KeyEraseResponse(whClientContext* c)
         return WH_ERROR_BADARGS;
     }
 
-    ret  = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)resp);
+    ret  = wh_Client_RecvResponse(c, &group, &action, &size, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         if (resp->rc != 0) {
             ret = resp->rc;
@@ -1364,7 +1363,7 @@ int wh_Client_KeyRevokeResponse(whClientContext* c)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &size, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         if (resp->rc != 0) {
             ret = resp->rc;
@@ -1422,7 +1421,7 @@ int wh_Client_CounterInitResponse(whClientContext* c, uint32_t* counter)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &size, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
         if (resp->rc != 0) {
             ret = resp->rc;
@@ -1500,7 +1499,7 @@ int wh_Client_CounterIncrementResponse(whClientContext* c, uint32_t* counter)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &size, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
         if (resp->rc != 0) {
             ret = resp->rc;
@@ -1560,7 +1559,7 @@ int wh_Client_CounterReadResponse(whClientContext* c, uint32_t* counter)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &size, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
         if (resp->rc != 0) {
             ret = resp->rc;
@@ -1620,7 +1619,7 @@ int wh_Client_CounterDestroyResponse(whClientContext* c)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &size, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
         if (resp->rc != 0) {
             ret = resp->rc;
@@ -1715,7 +1714,8 @@ int wh_Client_KeyCacheDmaResponse(whClientContext* c, uint16_t* keyId)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &size, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &size,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     /* NOTREADY: response not in yet - return without POST so the pending
      * request keeps its mapping; POST runs once the response arrives. */
     if (ret == WH_ERROR_NOTREADY) {
@@ -1826,7 +1826,7 @@ int wh_Client_KeyExportDmaResponse(whClientContext* c, uint8_t* label,
     }
 
     rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
-                                (uint8_t*)resp);
+                                WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     /* NOTREADY: response not in yet - return without POST so the pending
      * request keeps its mapping; POST runs once the response arrives. */
     if (rc == WH_ERROR_NOTREADY) {
@@ -1951,7 +1951,7 @@ int wh_Client_KeyExportPublicDmaResponse(whClientContext* c, uint8_t* label,
     }
 
     rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
-                                (uint8_t*)resp);
+                                WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     /* NOTREADY: response not in yet - return without POST so the pending
      * request keeps its mapping; POST runs once the response arrives. */
     if (rc == WH_ERROR_NOTREADY) {

--- a/src/wh_client.c
+++ b/src/wh_client.c
@@ -253,9 +253,9 @@ int wh_Client_SendRequest(whClientContext* c,
     return rc;
 }
 
-int wh_Client_RecvResponse(whClientContext *c,
-        uint16_t *out_group, uint16_t *out_action,
-        uint16_t *out_size, uint16_t data_size, void* data)
+int wh_Client_RecvResponse(whClientContext* c, uint16_t* out_group,
+                           uint16_t* out_action, uint16_t* out_size,
+                           uint16_t data_size, void* data)
 {
     int      rc        = 0;
     uint16_t resp_kind = 0;
@@ -323,9 +323,8 @@ int wh_Client_CommInitResponse(whClientContext* c,
         return WH_ERROR_BADARGS;
     }
 
-    rc = wh_Client_RecvResponse(c,
-            &resp_group, &resp_action,
-            &resp_size, sizeof(msg), &msg);
+    rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
+                                sizeof(msg), &msg);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_COMM) ||
@@ -403,9 +402,8 @@ int wh_Client_CommInfoResponse(whClientContext* c,
         return WH_ERROR_BADARGS;
     }
 
-    rc = wh_Client_RecvResponse(c,
-            &resp_group, &resp_action,
-            &resp_size, sizeof(msg), &msg);
+    rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
+                                sizeof(msg), &msg);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_COMM) ||
@@ -581,9 +579,8 @@ int wh_Client_CommCloseResponse(whClientContext* c)
         return WH_ERROR_BADARGS;
     }
 
-    rc = wh_Client_RecvResponse(c,
-            &resp_group, &resp_action,
-            &resp_size, 0, NULL);
+    rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size, 0,
+                                NULL);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_COMM) ||
@@ -654,9 +651,8 @@ int wh_Client_EchoResponse(whClientContext* c, uint16_t *out_size, void* data)
         return WH_ERROR_BADARGS;
     }
 
-    rc = wh_Client_RecvResponse(c,
-         &resp_group, &resp_action,
-         &resp_size, WOLFHSM_CFG_COMM_DATA_LEN, msg);
+    rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
+                                WOLFHSM_CFG_COMM_DATA_LEN, msg);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_COMM) ||
@@ -717,9 +713,8 @@ int wh_Client_CustomCbResponse(whClientContext*          c,
         return WH_ERROR_BADARGS;
     }
 
-    rc =
-        wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
-                               sizeof(resp), &resp);
+    rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
+                                sizeof(resp), &resp);
     if (rc != WH_ERROR_OK) {
         return rc;
     }
@@ -869,7 +864,8 @@ int wh_Client_KeyCacheResponse(whClientContext* c, uint16_t* keyId)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &size, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &size,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
         if (resp->rc != 0) {
             ret = resp->rc;
@@ -1089,7 +1085,8 @@ int wh_Client_KeyExportResponse(whClientContext* c, uint8_t* label,
     }
     packOut = (uint8_t*)(resp + 1);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &size, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &size,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
         if (resp->rc != 0) {
             ret = resp->rc;
@@ -1174,7 +1171,8 @@ int wh_Client_KeyExportPublicResponse(whClientContext* c, uint8_t* label,
     }
     packOut = (uint8_t*)(resp + 1);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &size, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &size,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
         if (resp->rc != 0) {
             ret = resp->rc;
@@ -1251,7 +1249,8 @@ int wh_Client_KeyCommitResponse(whClientContext* c)
         return WH_ERROR_BADARGS;
     }
 
-    ret  = wh_Client_RecvResponse(c, &group, &action, &size, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &size,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
         if (resp->rc != 0) {
             ret = resp->rc;
@@ -1307,7 +1306,8 @@ int wh_Client_KeyEraseResponse(whClientContext* c)
         return WH_ERROR_BADARGS;
     }
 
-    ret  = wh_Client_RecvResponse(c, &group, &action, &size, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &size,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         if (resp->rc != 0) {
             ret = resp->rc;
@@ -1363,7 +1363,8 @@ int wh_Client_KeyRevokeResponse(whClientContext* c)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &size, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &size,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         if (resp->rc != 0) {
             ret = resp->rc;
@@ -1421,7 +1422,8 @@ int wh_Client_CounterInitResponse(whClientContext* c, uint32_t* counter)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &size, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &size,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
         if (resp->rc != 0) {
             ret = resp->rc;
@@ -1499,7 +1501,8 @@ int wh_Client_CounterIncrementResponse(whClientContext* c, uint32_t* counter)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &size, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &size,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
         if (resp->rc != 0) {
             ret = resp->rc;
@@ -1559,7 +1562,8 @@ int wh_Client_CounterReadResponse(whClientContext* c, uint32_t* counter)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &size, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &size,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
         if (resp->rc != 0) {
             ret = resp->rc;
@@ -1619,7 +1623,8 @@ int wh_Client_CounterDestroyResponse(whClientContext* c)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &size, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &size,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
         if (resp->rc != 0) {
             ret = resp->rc;

--- a/src/wh_client_auth.c
+++ b/src/wh_client_auth.c
@@ -134,7 +134,7 @@ int wh_Client_AuthLoginResponse(whClientContext* c, int32_t* out_rc,
     }
 
     rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
-                                buffer);
+                                sizeof(buffer), buffer);
     if (rc == WH_ERROR_OK) {
         /* Validate response */
         if ((resp_group != WH_MESSAGE_GROUP_AUTH) ||
@@ -219,7 +219,7 @@ int wh_Client_AuthLogoutResponse(whClientContext* c, int32_t* out_rc)
     }
 
     rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
-                                buffer);
+                                sizeof(buffer), buffer);
     if (rc == WH_ERROR_OK) {
         /* Validate response */
         if ((resp_group != WH_MESSAGE_GROUP_AUTH) ||
@@ -338,7 +338,7 @@ int wh_Client_AuthUserAddResponse(whClientContext* c, int32_t* out_rc,
     }
 
     rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
-                                buffer);
+                                sizeof(buffer), buffer);
     if (rc == WH_ERROR_OK) {
         /* Validate response */
         if ((resp_group != WH_MESSAGE_GROUP_AUTH) ||
@@ -413,7 +413,7 @@ int wh_Client_AuthUserDeleteResponse(whClientContext* c, int32_t* out_rc)
     }
 
     rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
-                                buffer);
+                                sizeof(buffer), buffer);
     if (rc == WH_ERROR_OK) {
         /* Validate response */
         if ((resp_group != WH_MESSAGE_GROUP_AUTH) ||
@@ -489,7 +489,7 @@ int wh_Client_AuthUserGetResponse(whClientContext* c, int32_t* out_rc,
     }
 
     rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
-                                buffer);
+                                sizeof(buffer), buffer);
     if (rc == WH_ERROR_OK) {
         /* Validate response */
         if ((resp_group != WH_MESSAGE_GROUP_AUTH) ||
@@ -576,7 +576,7 @@ int wh_Client_AuthUserSetPermissionsResponse(whClientContext* c,
     }
 
     rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
-                                buffer);
+                                sizeof(buffer), buffer);
     if (rc == WH_ERROR_OK) {
         /* Validate response */
         if ((resp_group != WH_MESSAGE_GROUP_AUTH) ||
@@ -702,7 +702,7 @@ int wh_Client_AuthUserSetCredentialsResponse(whClientContext* c,
     }
 
     rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
-                                buffer);
+                                sizeof(buffer), buffer);
     if (rc == WH_ERROR_OK) {
         /* Validate response */
         if ((resp_group != WH_MESSAGE_GROUP_AUTH) ||

--- a/src/wh_client_cert.c
+++ b/src/wh_client_cert.c
@@ -78,7 +78,7 @@ int wh_Client_CertInitResponse(whClientContext* c, int32_t* out_rc)
     }
 
     /* Receive and validate response */
-    rc = wh_Client_RecvResponse(c, &group, &action, &size, &resp);
+    rc = wh_Client_RecvResponse(c, &group, &action, &size, sizeof(resp), &resp);
     if (rc == 0) {
         if ((group != WH_MESSAGE_GROUP_CERT) ||
             (action != WH_MESSAGE_CERT_ACTION_INIT) || (size != sizeof(resp))) {
@@ -166,7 +166,7 @@ int wh_Client_CertAddTrustedResponse(whClientContext* c, int32_t* out_rc)
     }
 
     /* Receive and validate response */
-    rc = wh_Client_RecvResponse(c, &group, &action, &size, &resp);
+    rc = wh_Client_RecvResponse(c, &group, &action, &size, sizeof(resp), &resp);
     if (rc == 0) {
         if ((group != WH_MESSAGE_GROUP_CERT) ||
             (action != WH_MESSAGE_CERT_ACTION_ADDTRUSTED) ||
@@ -237,7 +237,7 @@ int wh_Client_CertEraseTrustedResponse(whClientContext* c, int32_t* out_rc)
     }
 
     /* Receive and validate response */
-    rc = wh_Client_RecvResponse(c, &group, &action, &size, &resp);
+    rc = wh_Client_RecvResponse(c, &group, &action, &size, sizeof(resp), &resp);
     if (rc == 0) {
         if ((group != WH_MESSAGE_GROUP_CERT) ||
             (action != WH_MESSAGE_CERT_ACTION_ERASETRUSTED) ||
@@ -310,7 +310,8 @@ int wh_Client_CertReadTrustedResponse(whClientContext* c, uint8_t* cert,
     }
 
     /* Receive and validate response */
-    rc = wh_Client_RecvResponse(c, &group, &action, &size, buffer);
+    rc = wh_Client_RecvResponse(c, &group, &action, &size, sizeof(buffer),
+                                buffer);
     if (rc == 0) {
         if ((group != WH_MESSAGE_GROUP_CERT) ||
             (action != WH_MESSAGE_CERT_ACTION_READTRUSTED) ||
@@ -419,7 +420,7 @@ static int _certVerifyResponse(whClientContext* c, whKeyId* out_keyId,
     }
 
     /* Receive and validate response */
-    rc = wh_Client_RecvResponse(c, &group, &action, &size, &resp);
+    rc = wh_Client_RecvResponse(c, &group, &action, &size, sizeof(resp), &resp);
     if (rc == 0) {
         if ((group != WH_MESSAGE_GROUP_CERT) ||
             (action != WH_MESSAGE_CERT_ACTION_VERIFY) ||
@@ -573,7 +574,7 @@ static int _certVerifyMultiRootResponse(whClientContext* c, whKeyId* out_keyId,
         return WH_ERROR_BADARGS;
     }
 
-    rc = wh_Client_RecvResponse(c, &group, &action, &size, &resp);
+    rc = wh_Client_RecvResponse(c, &group, &action, &size, sizeof(resp), &resp);
     if (rc == 0) {
         if ((group != WH_MESSAGE_GROUP_CERT) ||
             (action != WH_MESSAGE_CERT_ACTION_VERIFY_MULTI_ROOT) ||
@@ -703,7 +704,7 @@ int wh_Client_CertVerifyCacheClearResponse(whClientContext* c, int32_t* out_rc)
         return WH_ERROR_BADARGS;
     }
 
-    rc = wh_Client_RecvResponse(c, &group, &action, &size, &resp);
+    rc = wh_Client_RecvResponse(c, &group, &action, &size, sizeof(resp), &resp);
     if (rc == WH_ERROR_OK) {
         if ((group != WH_MESSAGE_GROUP_CERT) ||
             (action != WH_MESSAGE_CERT_ACTION_VERIFY_CACHE_CLEAR) ||
@@ -768,7 +769,7 @@ int wh_Client_CertVerifyCacheSetEnabledResponse(whClientContext* c,
         return WH_ERROR_BADARGS;
     }
 
-    rc = wh_Client_RecvResponse(c, &group, &action, &size, &resp);
+    rc = wh_Client_RecvResponse(c, &group, &action, &size, sizeof(resp), &resp);
     if (rc == WH_ERROR_OK) {
         if ((group != WH_MESSAGE_GROUP_CERT) ||
             (action != WH_MESSAGE_CERT_ACTION_VERIFY_CACHE_SET_ENABLED) ||
@@ -863,7 +864,7 @@ int wh_Client_CertAddTrustedDmaResponse(whClientContext* c, int32_t* out_rc)
     }
 
     /* Receive and validate response */
-    rc = wh_Client_RecvResponse(c, &group, &action, &size, &resp);
+    rc = wh_Client_RecvResponse(c, &group, &action, &size, sizeof(resp), &resp);
     /* Not ready yet: keep the mapping; POST runs when the response arrives. */
     if (rc == WH_ERROR_NOTREADY) {
         return rc;
@@ -961,7 +962,7 @@ int wh_Client_CertReadTrustedDmaResponse(whClientContext* c, int32_t* out_rc)
     }
 
     /* Receive and validate response */
-    rc = wh_Client_RecvResponse(c, &group, &action, &size, &resp);
+    rc = wh_Client_RecvResponse(c, &group, &action, &size, sizeof(resp), &resp);
     /* Not ready yet: keep the mapping; POST runs when the response arrives. */
     if (rc == WH_ERROR_NOTREADY) {
         return rc;
@@ -1066,7 +1067,7 @@ static int _certVerifyDmaResponse(whClientContext* c, whKeyId* out_keyId,
     }
 
     /* Receive and validate response */
-    rc = wh_Client_RecvResponse(c, &group, &action, &size, &resp);
+    rc = wh_Client_RecvResponse(c, &group, &action, &size, sizeof(resp), &resp);
     /* Not ready yet: keep the mapping; POST runs when the response arrives. */
     if (rc == WH_ERROR_NOTREADY) {
         return rc;
@@ -1235,7 +1236,7 @@ static int _certVerifyMultiRootDmaResponse(whClientContext* c,
         return WH_ERROR_BADARGS;
     }
 
-    rc = wh_Client_RecvResponse(c, &group, &action, &size, &resp);
+    rc = wh_Client_RecvResponse(c, &group, &action, &size, sizeof(resp), &resp);
     /* Not ready yet: keep the mapping; POST runs when the response arrives. */
     if (rc == WH_ERROR_NOTREADY) {
         return rc;
@@ -1392,7 +1393,7 @@ int wh_Client_CertVerifyAcertResponse(whClientContext* c, int32_t* out_rc)
         return WH_ERROR_BADARGS;
     }
 
-    rc = wh_Client_RecvResponse(c, &group, &action, &size, &resp);
+    rc = wh_Client_RecvResponse(c, &group, &action, &size, sizeof(resp), &resp);
     if (rc == 0) {
         if ((group != WH_MESSAGE_GROUP_CERT) ||
             (action != WH_MESSAGE_CERT_ACTION_VERIFY_ACERT) ||
@@ -1482,7 +1483,7 @@ int wh_Client_CertVerifyAcertDmaResponse(whClientContext* c, int32_t* out_rc)
         return WH_ERROR_BADARGS;
     }
 
-    rc = wh_Client_RecvResponse(c, &group, &action, &size, &resp);
+    rc = wh_Client_RecvResponse(c, &group, &action, &size, sizeof(resp), &resp);
     /* Not ready yet: keep the mapping; POST runs when the response arrives. */
     if (rc == WH_ERROR_NOTREADY) {
         return rc;

--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -249,7 +249,8 @@ int wh_Client_RngGenerateResponse(whClientContext* ctx, uint8_t* out,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -390,7 +391,8 @@ int wh_Client_RngGenerateDmaResponse(whClientContext* ctx)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -516,7 +518,8 @@ int wh_Client_AesCtrResponse(whClientContext* ctx, Aes* aes, uint8_t* out,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_CTR, (uint8_t**)&res);
         if (ret == WH_ERROR_OK) {
@@ -701,7 +704,8 @@ int wh_Client_AesCtrDmaResponse(whClientContext* ctx, Aes* aes)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &res_len,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -847,7 +851,8 @@ int wh_Client_AesEcbResponse(whClientContext* ctx, Aes* aes, uint8_t* out,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_ECB, (uint8_t**)&res);
         if (ret == WH_ERROR_OK) {
@@ -1018,7 +1023,8 @@ int wh_Client_AesEcbDmaResponse(whClientContext* ctx, Aes* aes)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &res_len,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -1171,7 +1177,8 @@ int wh_Client_AesCbcResponse(whClientContext* ctx, Aes* aes, uint8_t* out,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_CBC, (uint8_t**)&res);
         if (ret == WH_ERROR_OK) {
@@ -1354,7 +1361,8 @@ int wh_Client_AesCbcDmaResponse(whClientContext* ctx, Aes* aes)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &res_len,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -1527,7 +1535,8 @@ int wh_Client_AesGcmResponse(whClientContext* ctx, Aes* aes, uint8_t* out,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_GCM, (uint8_t**)&res);
         if (ret == WH_ERROR_OK) {
@@ -1751,7 +1760,8 @@ int wh_Client_AesGcmDmaResponse(whClientContext* ctx, Aes* aes,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &res_len,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -1997,7 +2007,8 @@ static int _EccMakeKeyResponse(whClientContext* ctx, whKeyId* out_key_id,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -2255,7 +2266,8 @@ static int _EccSharedSecretResponse(whClientContext* ctx, uint8_t* out,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -2490,7 +2502,8 @@ int wh_Client_EccSignResponse(whClientContext* ctx, uint8_t* sig,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -2692,7 +2705,8 @@ int wh_Client_EccVerifyResponse(whClientContext* ctx, ecc_key* opt_key,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -4421,7 +4435,8 @@ static int _RsaMakeKeyResponse(whClientContext* ctx, whKeyId* out_key_id,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -4653,7 +4668,8 @@ int wh_Client_RsaFunctionResponse(whClientContext* ctx, uint8_t* out,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -4848,7 +4864,8 @@ int wh_Client_RsaGetSizeResponse(whClientContext* ctx, int* out_size)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -5044,8 +5061,8 @@ static int _HkdfMakeKey(whClientContext* ctx, int hashType, whKeyId keyIdIn,
     if (ret == 0) {
         uint16_t res_len = 0;
         do {
-            ret =
-                wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+            ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                         WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
         } while (ret == WH_ERROR_NOTREADY);
 
         WH_DEBUG_CLIENT_VERBOSE("HKDF Res recv: ret:%d, res_len: %u\n", ret,
@@ -5212,7 +5229,8 @@ static int _CmacKdfMakeKey(whClientContext* ctx, whKeyId saltKeyId,
 
     uint16_t res_len = 0;
     do {
-        ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+        ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                     WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     } while (ret == WH_ERROR_NOTREADY);
 
     if (ret == WH_ERROR_OK) {
@@ -5440,7 +5458,8 @@ int wh_Client_CmacGenerateResponse(whClientContext* ctx, Cmac* cmac,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -5561,7 +5580,8 @@ int wh_Client_CmacUpdateResponse(whClientContext* ctx, Cmac* cmac)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -5651,7 +5671,8 @@ int wh_Client_CmacFinalResponse(whClientContext* ctx, Cmac* cmac,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -5891,7 +5912,8 @@ int wh_Client_CmacGenerateDmaResponse(whClientContext* ctx, Cmac* cmac,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -6036,7 +6058,8 @@ int wh_Client_CmacDmaUpdateResponse(whClientContext* ctx, Cmac* cmac)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -6126,7 +6149,8 @@ int wh_Client_CmacDmaFinalResponse(whClientContext* ctx, Cmac* cmac,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -6369,7 +6393,8 @@ int wh_Client_Sha256UpdateResponse(whClientContext* ctx, wc_Sha256* sha)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -6449,7 +6474,8 @@ int wh_Client_Sha256FinalResponse(whClientContext* ctx, wc_Sha256* sha,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != 0) {
         return ret;
     }
@@ -6667,7 +6693,8 @@ int wh_Client_Sha256DmaUpdateResponse(whClientContext* ctx, wc_Sha256* sha)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -6771,7 +6798,8 @@ int wh_Client_Sha256DmaFinalResponse(whClientContext* ctx, wc_Sha256* sha,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -6966,7 +6994,8 @@ int wh_Client_Sha224UpdateResponse(whClientContext* ctx, wc_Sha224* sha)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -7047,7 +7076,8 @@ int wh_Client_Sha224FinalResponse(whClientContext* ctx, wc_Sha224* sha,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != 0) {
         return ret;
     }
@@ -7253,7 +7283,8 @@ int wh_Client_Sha224DmaUpdateResponse(whClientContext* ctx, wc_Sha224* sha)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -7353,7 +7384,8 @@ int wh_Client_Sha224DmaFinalResponse(whClientContext* ctx, wc_Sha224* sha,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -7548,7 +7580,8 @@ int wh_Client_Sha384UpdateResponse(whClientContext* ctx, wc_Sha384* sha)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -7630,7 +7663,8 @@ int wh_Client_Sha384FinalResponse(whClientContext* ctx, wc_Sha384* sha,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != 0) {
         return ret;
     }
@@ -7837,7 +7871,8 @@ int wh_Client_Sha384DmaUpdateResponse(whClientContext* ctx, wc_Sha384* sha)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -7938,7 +7973,8 @@ int wh_Client_Sha384DmaFinalResponse(whClientContext* ctx, wc_Sha384* sha,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -8132,7 +8168,8 @@ int wh_Client_Sha512UpdateResponse(whClientContext* ctx, wc_Sha512* sha)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -8220,7 +8257,8 @@ int wh_Client_Sha512FinalResponse(whClientContext* ctx, wc_Sha512* sha,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != 0) {
         return ret;
     }
@@ -8450,7 +8488,8 @@ int wh_Client_Sha512DmaUpdateResponse(whClientContext* ctx, wc_Sha512* sha)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -8557,7 +8596,8 @@ int wh_Client_Sha512DmaFinalResponse(whClientContext* ctx, wc_Sha512* sha,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -10913,8 +10953,8 @@ static int _MlKemMakeKey(whClientContext* ctx, int level,
 
     do {
         ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
-                                        WOLFHSM_CFG_COMM_DATA_LEN,
-                                        (uint8_t*)dataPtr);
+                                     WOLFHSM_CFG_COMM_DATA_LEN,
+                                     (uint8_t*)dataPtr);
     } while (ret == WH_ERROR_NOTREADY);
     if (ret != WH_ERROR_OK) {
         return ret;

--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -249,7 +249,7 @@ int wh_Client_RngGenerateResponse(whClientContext* ctx, uint8_t* out,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -390,7 +390,7 @@ int wh_Client_RngGenerateDmaResponse(whClientContext* ctx)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -516,7 +516,7 @@ int wh_Client_AesCtrResponse(whClientContext* ctx, Aes* aes, uint8_t* out,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_CTR, (uint8_t**)&res);
         if (ret == WH_ERROR_OK) {
@@ -701,7 +701,7 @@ int wh_Client_AesCtrDmaResponse(whClientContext* ctx, Aes* aes)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &res_len, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -847,7 +847,7 @@ int wh_Client_AesEcbResponse(whClientContext* ctx, Aes* aes, uint8_t* out,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_ECB, (uint8_t**)&res);
         if (ret == WH_ERROR_OK) {
@@ -1018,7 +1018,7 @@ int wh_Client_AesEcbDmaResponse(whClientContext* ctx, Aes* aes)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &res_len, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -1171,7 +1171,7 @@ int wh_Client_AesCbcResponse(whClientContext* ctx, Aes* aes, uint8_t* out,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_CBC, (uint8_t**)&res);
         if (ret == WH_ERROR_OK) {
@@ -1354,7 +1354,7 @@ int wh_Client_AesCbcDmaResponse(whClientContext* ctx, Aes* aes)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &res_len, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -1527,7 +1527,7 @@ int wh_Client_AesGcmResponse(whClientContext* ctx, Aes* aes, uint8_t* out,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_GCM, (uint8_t**)&res);
         if (ret == WH_ERROR_OK) {
@@ -1751,7 +1751,7 @@ int wh_Client_AesGcmDmaResponse(whClientContext* ctx, Aes* aes,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &res_len, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -1997,7 +1997,7 @@ static int _EccMakeKeyResponse(whClientContext* ctx, whKeyId* out_key_id,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -2255,7 +2255,7 @@ static int _EccSharedSecretResponse(whClientContext* ctx, uint8_t* out,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -2490,7 +2490,7 @@ int wh_Client_EccSignResponse(whClientContext* ctx, uint8_t* sig,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -2692,7 +2692,7 @@ int wh_Client_EccVerifyResponse(whClientContext* ctx, ecc_key* opt_key,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -2886,7 +2886,7 @@ int wh_Client_EccCheckPubKey(whClientContext* ctx, ecc_key* key,
     if (ret == 0) {
         do {
             ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz,
-                (uint8_t*)packet);
+                WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)packet);
         } while (ret == WH_ERROR_NOTREADY);
     }
     if (ret == 0) {
@@ -3051,6 +3051,7 @@ static int _Curve25519MakeKey(whClientContext* ctx, uint16_t size,
     if (ret == 0) {
         do {
             ret = wh_Client_RecvResponse(ctx, &group, &action, &data_len,
+                                         WOLFHSM_CFG_COMM_DATA_LEN,
                                          (uint8_t*)dataPtr);
         } while (ret == WH_ERROR_NOTREADY);
     }
@@ -3248,7 +3249,8 @@ static int _Curve25519SharedSecretResponse(whClientContext* ctx, uint8_t* out,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -3566,6 +3568,7 @@ static int _Ed25519MakeKey(whClientContext* ctx, whKeyId* inout_key_id,
     uint16_t res_len = 0;
     do {
         ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                     WOLFHSM_CFG_COMM_DATA_LEN,
                                      (uint8_t*)dataPtr);
     } while (ret == WH_ERROR_NOTREADY);
 
@@ -3762,6 +3765,7 @@ int wh_Client_Ed25519Sign(whClientContext* ctx, ed25519_key* key,
             uint16_t res_len = 0;
             do {
                 ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                             WOLFHSM_CFG_COMM_DATA_LEN,
                                              (uint8_t*)dataPtr);
             } while (ret == WH_ERROR_NOTREADY);
 
@@ -3902,6 +3906,7 @@ int wh_Client_Ed25519Verify(whClientContext* ctx, ed25519_key* key,
             uint16_t res_len = 0;
             do {
                 ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                             WOLFHSM_CFG_COMM_DATA_LEN,
                                              (uint8_t*)dataPtr);
             } while (ret == WH_ERROR_NOTREADY);
 
@@ -4042,6 +4047,7 @@ int wh_Client_Ed25519SignDma(whClientContext* ctx, ed25519_key* key,
             uint16_t res_len = 0;
             do {
                 ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                             WOLFHSM_CFG_COMM_DATA_LEN,
                                              (uint8_t*)dataPtr);
             } while (ret == WH_ERROR_NOTREADY);
 
@@ -4189,6 +4195,7 @@ int wh_Client_Ed25519VerifyDma(whClientContext* ctx, ed25519_key* key,
             uint16_t res_len = 0;
             do {
                 ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                             WOLFHSM_CFG_COMM_DATA_LEN,
                                              (uint8_t*)dataPtr);
             } while (ret == WH_ERROR_NOTREADY);
 
@@ -4414,7 +4421,7 @@ static int _RsaMakeKeyResponse(whClientContext* ctx, whKeyId* out_key_id,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -4646,7 +4653,7 @@ int wh_Client_RsaFunctionResponse(whClientContext* ctx, uint8_t* out,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -4841,7 +4848,7 @@ int wh_Client_RsaGetSizeResponse(whClientContext* ctx, int* out_size)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -5038,7 +5045,7 @@ static int _HkdfMakeKey(whClientContext* ctx, int hashType, whKeyId keyIdIn,
         uint16_t res_len = 0;
         do {
             ret =
-                wh_Client_RecvResponse(ctx, &group, &action, &res_len, dataPtr);
+                wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
         } while (ret == WH_ERROR_NOTREADY);
 
         WH_DEBUG_CLIENT_VERBOSE("HKDF Res recv: ret:%d, res_len: %u\n", ret,
@@ -5205,7 +5212,7 @@ static int _CmacKdfMakeKey(whClientContext* ctx, whKeyId saltKeyId,
 
     uint16_t res_len = 0;
     do {
-        ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, dataPtr);
+        ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     } while (ret == WH_ERROR_NOTREADY);
 
     if (ret == WH_ERROR_OK) {
@@ -5433,7 +5440,7 @@ int wh_Client_CmacGenerateResponse(whClientContext* ctx, Cmac* cmac,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -5554,7 +5561,7 @@ int wh_Client_CmacUpdateResponse(whClientContext* ctx, Cmac* cmac)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -5644,7 +5651,7 @@ int wh_Client_CmacFinalResponse(whClientContext* ctx, Cmac* cmac,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -5884,7 +5891,7 @@ int wh_Client_CmacGenerateDmaResponse(whClientContext* ctx, Cmac* cmac,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -6029,7 +6036,7 @@ int wh_Client_CmacDmaUpdateResponse(whClientContext* ctx, Cmac* cmac)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -6119,7 +6126,7 @@ int wh_Client_CmacDmaFinalResponse(whClientContext* ctx, Cmac* cmac,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -6362,7 +6369,7 @@ int wh_Client_Sha256UpdateResponse(whClientContext* ctx, wc_Sha256* sha)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -6442,7 +6449,7 @@ int wh_Client_Sha256FinalResponse(whClientContext* ctx, wc_Sha256* sha,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != 0) {
         return ret;
     }
@@ -6660,7 +6667,7 @@ int wh_Client_Sha256DmaUpdateResponse(whClientContext* ctx, wc_Sha256* sha)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -6764,7 +6771,7 @@ int wh_Client_Sha256DmaFinalResponse(whClientContext* ctx, wc_Sha256* sha,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -6959,7 +6966,7 @@ int wh_Client_Sha224UpdateResponse(whClientContext* ctx, wc_Sha224* sha)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -7040,7 +7047,7 @@ int wh_Client_Sha224FinalResponse(whClientContext* ctx, wc_Sha224* sha,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != 0) {
         return ret;
     }
@@ -7246,7 +7253,7 @@ int wh_Client_Sha224DmaUpdateResponse(whClientContext* ctx, wc_Sha224* sha)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -7346,7 +7353,7 @@ int wh_Client_Sha224DmaFinalResponse(whClientContext* ctx, wc_Sha224* sha,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -7541,7 +7548,7 @@ int wh_Client_Sha384UpdateResponse(whClientContext* ctx, wc_Sha384* sha)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -7623,7 +7630,7 @@ int wh_Client_Sha384FinalResponse(whClientContext* ctx, wc_Sha384* sha,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != 0) {
         return ret;
     }
@@ -7830,7 +7837,7 @@ int wh_Client_Sha384DmaUpdateResponse(whClientContext* ctx, wc_Sha384* sha)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -7931,7 +7938,7 @@ int wh_Client_Sha384DmaFinalResponse(whClientContext* ctx, wc_Sha384* sha,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -8125,7 +8132,7 @@ int wh_Client_Sha512UpdateResponse(whClientContext* ctx, wc_Sha512* sha)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -8213,7 +8220,7 @@ int wh_Client_Sha512FinalResponse(whClientContext* ctx, wc_Sha512* sha,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != 0) {
         return ret;
     }
@@ -8443,7 +8450,7 @@ int wh_Client_Sha512DmaUpdateResponse(whClientContext* ctx, wc_Sha512* sha)
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -8550,7 +8557,7 @@ int wh_Client_Sha512DmaFinalResponse(whClientContext* ctx, wc_Sha512* sha,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -8808,7 +8815,8 @@ static int _Sha3UpdateResponse(whClientContext* ctx, wc_Sha3* sha,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -8887,7 +8895,8 @@ static int _Sha3FinalResponse(whClientContext* ctx, wc_Sha3* sha,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret != 0) {
         return ret;
     }
@@ -9260,7 +9269,8 @@ static int _Sha3DmaUpdateResponse(whClientContext* ctx, wc_Sha3* sha,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -9356,7 +9366,8 @@ static int _Sha3DmaFinalResponse(whClientContext* ctx, wc_Sha3* sha,
         return WH_ERROR_BADARGS;
     }
 
-    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz, dataPtr);
+    ret = wh_Client_RecvResponse(ctx, NULL, NULL, &respSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_NOTREADY) {
         return ret;
     }
@@ -9716,6 +9727,7 @@ static int _MlDsaMakeKey(whClientContext* ctx, int size, int level,
                 uint16_t res_len;
                 do {
                     ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                                 WOLFHSM_CFG_COMM_DATA_LEN,
                                                  (uint8_t*)dataPtr);
                 } while (ret == WH_ERROR_NOTREADY);
 
@@ -9947,6 +9959,7 @@ int wh_Client_MlDsaSign(whClientContext* ctx, const byte* in, word32 in_len,
                 /* Recv Response */
                 do {
                     ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                                 WOLFHSM_CFG_COMM_DATA_LEN,
                                                  (uint8_t*)dataPtr);
                 } while (ret == WH_ERROR_NOTREADY);
 
@@ -10094,6 +10107,7 @@ int wh_Client_MlDsaVerify(whClientContext* ctx, const byte* sig, word32 sig_len,
                 /* Recv Response */
                 do {
                     ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                                 WOLFHSM_CFG_COMM_DATA_LEN,
                                                  (uint8_t*)dataPtr);
                 } while (ret == WH_ERROR_NOTREADY);
                 if (ret == 0) {
@@ -10294,6 +10308,7 @@ static int _MlDsaMakeKeyDma(whClientContext* ctx, int level,
         if (ret == WH_ERROR_OK) {
             do {
                 ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                             WOLFHSM_CFG_COMM_DATA_LEN,
                                              (uint8_t*)dataPtr);
             } while (ret == WH_ERROR_NOTREADY);
         }
@@ -10529,6 +10544,7 @@ int wh_Client_MlDsaSignDma(whClientContext* ctx, const byte* in, word32 in_len,
                 /* Recv Response */
                 do {
                     ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                                 WOLFHSM_CFG_COMM_DATA_LEN,
                                                  (uint8_t*)dataPtr);
                 } while (ret == WH_ERROR_NOTREADY);
 
@@ -10672,6 +10688,7 @@ int wh_Client_MlDsaVerifyDma(whClientContext* ctx, const byte* sig,
                 /* Recv Response */
                 do {
                     ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                                 WOLFHSM_CFG_COMM_DATA_LEN,
                                                  (uint8_t*)dataPtr);
                 } while (ret == WH_ERROR_NOTREADY);
 
@@ -10896,6 +10913,7 @@ static int _MlKemMakeKey(whClientContext* ctx, int level,
 
     do {
         ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                        WOLFHSM_CFG_COMM_DATA_LEN,
                                         (uint8_t*)dataPtr);
     } while (ret == WH_ERROR_NOTREADY);
     if (ret != WH_ERROR_OK) {
@@ -11079,6 +11097,7 @@ int wh_Client_MlKemEncapsulate(whClientContext* ctx, MlKemKey* key,
                 evict = 0;
                 do {
                     ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                                 WOLFHSM_CFG_COMM_DATA_LEN,
                                                  (uint8_t*)dataPtr);
                 } while (ret == WH_ERROR_NOTREADY);
             }
@@ -11207,6 +11226,7 @@ int wh_Client_MlKemDecapsulate(whClientContext* ctx, MlKemKey* key,
                 evict = 0;
                 do {
                     ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                                 WOLFHSM_CFG_COMM_DATA_LEN,
                                                  (uint8_t*)dataPtr);
                 } while (ret == WH_ERROR_NOTREADY);
             }
@@ -11406,6 +11426,7 @@ static int _MlKemMakeKeyDma(whClientContext* ctx, int level,
     if (ret == WH_ERROR_OK) {
         do {
             ret = wh_Client_RecvResponse(ctx, &group, &action, &req_len,
+                                         WOLFHSM_CFG_COMM_DATA_LEN,
                                          (uint8_t*)dataPtr);
         } while (ret == WH_ERROR_NOTREADY);
     }
@@ -11581,6 +11602,7 @@ int wh_Client_MlKemEncapsulateDma(whClientContext* ctx, MlKemKey* key,
                 evict = 0;
                 do {
                     ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                                 WOLFHSM_CFG_COMM_DATA_LEN,
                                                  (uint8_t*)dataPtr);
                 } while (ret == WH_ERROR_NOTREADY);
             }
@@ -11705,6 +11727,7 @@ int wh_Client_MlKemDecapsulateDma(whClientContext* ctx, MlKemKey* key,
                 evict = 0;
                 do {
                     ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
+                                                 WOLFHSM_CFG_COMM_DATA_LEN,
                                                  (uint8_t*)dataPtr);
                 } while (ret == WH_ERROR_NOTREADY);
             }
@@ -11859,6 +11882,7 @@ int wh_Client_LmsMakeKeyDma(whClientContext* ctx, LmsKey* key,
         if (ret == WH_ERROR_OK) {
             do {
                 ret = wh_Client_RecvResponse(ctx, &group, &action, &req_len,
+                                             WOLFHSM_CFG_COMM_DATA_LEN,
                                              (uint8_t*)dataPtr);
             } while (ret == WH_ERROR_NOTREADY);
         }
@@ -11961,6 +11985,7 @@ int wh_Client_LmsSignDma(whClientContext* ctx, const byte* msg, word32 msgSz,
         if (ret == WH_ERROR_OK) {
             do {
                 ret = wh_Client_RecvResponse(ctx, &group, &action, &req_len,
+                                             WOLFHSM_CFG_COMM_DATA_LEN,
                                              (uint8_t*)dataPtr);
             } while (ret == WH_ERROR_NOTREADY);
         }
@@ -12060,6 +12085,7 @@ int wh_Client_LmsVerifyDma(whClientContext* ctx, const byte* sig, word32 sigSz,
         if (ret == WH_ERROR_OK) {
             do {
                 ret = wh_Client_RecvResponse(ctx, &group, &action, &req_len,
+                                             WOLFHSM_CFG_COMM_DATA_LEN,
                                              (uint8_t*)dataPtr);
             } while (ret == WH_ERROR_NOTREADY);
         }
@@ -12130,6 +12156,7 @@ int wh_Client_LmsSigsLeftDma(whClientContext* ctx, LmsKey* key)
         if (ret == WH_ERROR_OK) {
             do {
                 ret = wh_Client_RecvResponse(ctx, &group, &action, &req_len,
+                                             WOLFHSM_CFG_COMM_DATA_LEN,
                                              (uint8_t*)dataPtr);
             } while (ret == WH_ERROR_NOTREADY);
         }
@@ -12302,6 +12329,7 @@ int wh_Client_XmssMakeKeyDma(whClientContext* ctx, XmssKey* key,
         if (ret == WH_ERROR_OK) {
             do {
                 ret = wh_Client_RecvResponse(ctx, &group, &action, &req_len,
+                                             WOLFHSM_CFG_COMM_DATA_LEN,
                                              (uint8_t*)dataPtr);
             } while (ret == WH_ERROR_NOTREADY);
         }
@@ -12404,6 +12432,7 @@ int wh_Client_XmssSignDma(whClientContext* ctx, const byte* msg, word32 msgSz,
         if (ret == WH_ERROR_OK) {
             do {
                 ret = wh_Client_RecvResponse(ctx, &group, &action, &req_len,
+                                             WOLFHSM_CFG_COMM_DATA_LEN,
                                              (uint8_t*)dataPtr);
             } while (ret == WH_ERROR_NOTREADY);
         }
@@ -12504,6 +12533,7 @@ int wh_Client_XmssVerifyDma(whClientContext* ctx, const byte* sig,
         if (ret == WH_ERROR_OK) {
             do {
                 ret = wh_Client_RecvResponse(ctx, &group, &action, &req_len,
+                                             WOLFHSM_CFG_COMM_DATA_LEN,
                                              (uint8_t*)dataPtr);
             } while (ret == WH_ERROR_NOTREADY);
         }
@@ -12574,6 +12604,7 @@ int wh_Client_XmssSigsLeftDma(whClientContext* ctx, XmssKey* key)
         if (ret == WH_ERROR_OK) {
             do {
                 ret = wh_Client_RecvResponse(ctx, &group, &action, &req_len,
+                                             WOLFHSM_CFG_COMM_DATA_LEN,
                                              (uint8_t*)dataPtr);
             } while (ret == WH_ERROR_NOTREADY);
         }

--- a/src/wh_client_keywrap.c
+++ b/src/wh_client_keywrap.c
@@ -75,7 +75,8 @@ int wh_Client_KeyWrapResponse(whClientContext*   ctx,
     }
 
     /* Receive the response */
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &size, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &size,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -181,7 +182,8 @@ int wh_Client_KeyWrapExportResponse(whClientContext*   ctx,
     }
 
     /* Receive the response */
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &size, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &size,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -298,7 +300,8 @@ int wh_Client_KeyUnwrapAndExportResponse(whClientContext*   ctx,
     }
 
     /* Receive the response */
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &size, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &size,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -414,7 +417,8 @@ int wh_Client_KeyUnwrapAndCacheResponse(whClientContext*   ctx,
     }
 
     /* Receive the response */
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &size, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &size,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -519,7 +523,8 @@ int wh_Client_DataWrapResponse(whClientContext*   ctx,
     }
 
     /* Receive the response */
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &size, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &size,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -632,7 +637,8 @@ int wh_Client_DataUnwrapResponse(whClientContext*   ctx,
     }
 
     /* Receive the response */
-    ret = wh_Client_RecvResponse(ctx, &group, &action, &size, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(ctx, &group, &action, &size,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret != WH_ERROR_OK) {
         return ret;
     }

--- a/src/wh_client_nvm.c
+++ b/src/wh_client_nvm.c
@@ -69,9 +69,8 @@ int wh_Client_NvmInitResponse(whClientContext* c, int32_t *out_rc,
         return WH_ERROR_BADARGS;
     }
 
-    rc = wh_Client_RecvResponse(c,
-            &resp_group, &resp_action,
-            &resp_size, sizeof(msg), &msg);
+    rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
+                                sizeof(msg), &msg);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_NVM) ||
@@ -141,9 +140,8 @@ int wh_Client_NvmCleanupResponse(whClientContext* c, int32_t *out_rc)
         return WH_ERROR_BADARGS;
     }
 
-    rc = wh_Client_RecvResponse(c,
-            &resp_group, &resp_action,
-            &resp_size, sizeof(msg), &msg);
+    rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
+                                sizeof(msg), &msg);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_NVM) ||
@@ -207,9 +205,8 @@ int wh_Client_NvmGetAvailableResponse(whClientContext* c, int32_t *out_rc,
         return WH_ERROR_BADARGS;
     }
 
-    rc = wh_Client_RecvResponse(c,
-            &resp_group, &resp_action,
-            &resp_size, sizeof(msg), &msg);
+    rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
+                                sizeof(msg), &msg);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_NVM) ||
@@ -311,9 +308,8 @@ int wh_Client_NvmAddObjectResponse(whClientContext* c, int32_t *out_rc)
         return WH_ERROR_BADARGS;
     }
 
-    rc = wh_Client_RecvResponse(c,
-            &resp_group, &resp_action,
-            &resp_size, sizeof(msg), &msg);
+    rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
+                                sizeof(msg), &msg);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_NVM) ||
@@ -388,9 +384,8 @@ int wh_Client_NvmListResponse(whClientContext* c, int32_t *out_rc,
         return WH_ERROR_BADARGS;
     }
 
-    rc = wh_Client_RecvResponse(c,
-            &resp_group, &resp_action,
-            &resp_size, sizeof(msg), &msg);
+    rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
+                                sizeof(msg), &msg);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_NVM) ||
@@ -467,9 +462,8 @@ int wh_Client_NvmGetMetadataResponse(whClientContext* c, int32_t *out_rc,
         return WH_ERROR_BADARGS;
     }
 
-    rc = wh_Client_RecvResponse(c,
-            &resp_group, &resp_action,
-            &resp_size, sizeof(msg), &msg);
+    rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
+                                sizeof(msg), &msg);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_NVM) ||
@@ -563,9 +557,8 @@ int wh_Client_NvmDestroyObjectsResponse(whClientContext* c, int32_t *out_rc)
         return WH_ERROR_BADARGS;
     }
 
-    rc = wh_Client_RecvResponse(c,
-            &resp_group, &resp_action,
-            &resp_size, sizeof(msg), &msg);
+    rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
+                                sizeof(msg), &msg);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_NVM) ||
@@ -640,9 +633,8 @@ int wh_Client_NvmReadResponse(whClientContext* c, int32_t *out_rc,
         return WH_ERROR_BADARGS;
     }
 
-    rc = wh_Client_RecvResponse(c,
-            &resp_group, &resp_action,
-            &resp_size, sizeof(buffer), buffer);
+    rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
+                                sizeof(buffer), buffer);
     if (rc == 0) {
         /* Validate response */
         if ((resp_group != WH_MESSAGE_GROUP_NVM) ||

--- a/src/wh_client_nvm.c
+++ b/src/wh_client_nvm.c
@@ -71,7 +71,7 @@ int wh_Client_NvmInitResponse(whClientContext* c, int32_t *out_rc,
 
     rc = wh_Client_RecvResponse(c,
             &resp_group, &resp_action,
-            &resp_size, &msg);
+            &resp_size, sizeof(msg), &msg);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_NVM) ||
@@ -143,7 +143,7 @@ int wh_Client_NvmCleanupResponse(whClientContext* c, int32_t *out_rc)
 
     rc = wh_Client_RecvResponse(c,
             &resp_group, &resp_action,
-            &resp_size, &msg);
+            &resp_size, sizeof(msg), &msg);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_NVM) ||
@@ -209,7 +209,7 @@ int wh_Client_NvmGetAvailableResponse(whClientContext* c, int32_t *out_rc,
 
     rc = wh_Client_RecvResponse(c,
             &resp_group, &resp_action,
-            &resp_size, &msg);
+            &resp_size, sizeof(msg), &msg);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_NVM) ||
@@ -313,7 +313,7 @@ int wh_Client_NvmAddObjectResponse(whClientContext* c, int32_t *out_rc)
 
     rc = wh_Client_RecvResponse(c,
             &resp_group, &resp_action,
-            &resp_size, &msg);
+            &resp_size, sizeof(msg), &msg);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_NVM) ||
@@ -390,7 +390,7 @@ int wh_Client_NvmListResponse(whClientContext* c, int32_t *out_rc,
 
     rc = wh_Client_RecvResponse(c,
             &resp_group, &resp_action,
-            &resp_size, &msg);
+            &resp_size, sizeof(msg), &msg);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_NVM) ||
@@ -469,7 +469,7 @@ int wh_Client_NvmGetMetadataResponse(whClientContext* c, int32_t *out_rc,
 
     rc = wh_Client_RecvResponse(c,
             &resp_group, &resp_action,
-            &resp_size, &msg);
+            &resp_size, sizeof(msg), &msg);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_NVM) ||
@@ -565,7 +565,7 @@ int wh_Client_NvmDestroyObjectsResponse(whClientContext* c, int32_t *out_rc)
 
     rc = wh_Client_RecvResponse(c,
             &resp_group, &resp_action,
-            &resp_size, &msg);
+            &resp_size, sizeof(msg), &msg);
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_NVM) ||
@@ -642,7 +642,7 @@ int wh_Client_NvmReadResponse(whClientContext* c, int32_t *out_rc,
 
     rc = wh_Client_RecvResponse(c,
             &resp_group, &resp_action,
-            &resp_size, buffer);
+            &resp_size, sizeof(buffer), buffer);
     if (rc == 0) {
         /* Validate response */
         if ((resp_group != WH_MESSAGE_GROUP_NVM) ||
@@ -760,7 +760,8 @@ int wh_Client_NvmAddObjectDmaResponse(whClientContext* c, int32_t* out_rc)
         return WH_ERROR_BADARGS;
     }
 
-    rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size, &msg);
+    rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
+                                sizeof(msg), &msg);
     /* NOTREADY: response not in yet - return without POST so the pending
      * request keeps its mappings; POST runs once the response arrives. */
     if (rc == WH_ERROR_NOTREADY) {
@@ -866,7 +867,8 @@ int wh_Client_NvmReadDmaResponse(whClientContext* c, int32_t* out_rc)
         return WH_ERROR_BADARGS;
     }
 
-    rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size, &msg);
+    rc = wh_Client_RecvResponse(c, &resp_group, &resp_action, &resp_size,
+                                sizeof(msg), &msg);
     /* NOTREADY: response not in yet - return without POST so the pending
      * request keeps its mapping; POST runs once the response arrives. */
     if (rc == WH_ERROR_NOTREADY) {

--- a/src/wh_client_she.c
+++ b/src/wh_client_she.c
@@ -95,7 +95,8 @@ int wh_Client_SheSetUidResponse(whClientContext* c)
     }
 
     resp = (whMessageShe_SetUidResponse*)wh_CommClient_GetDataPtr(c->comm);
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret  = wh_Client_RecvResponse(c, &group, &action, &dataSz,
+                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
         ret = resp->rc;
     }
@@ -146,8 +147,8 @@ int wh_Client_SheSecureBoot(whClientContext* c, uint8_t* bootloader,
 
     if (ret == 0) {
         do {
-            ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
-                                         WOLFHSM_CFG_COMM_DATA_LEN, respBuf);
+            ret      = wh_Client_RecvResponse(c, &group, &action, &dataSz,
+                                              WOLFHSM_CFG_COMM_DATA_LEN, respBuf);
             initResp = (whMessageShe_SecureBootInitResponse*)respBuf;
         } while (ret == WH_ERROR_NOTREADY);
     }
@@ -183,9 +184,9 @@ int wh_Client_SheSecureBoot(whClientContext* c, uint8_t* bootloader,
 
         if (ret == 0) {
             do {
-                ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
-                                             WOLFHSM_CFG_COMM_DATA_LEN,
-                                             respBuf);
+                ret =
+                    wh_Client_RecvResponse(c, &group, &action, &dataSz,
+                                           WOLFHSM_CFG_COMM_DATA_LEN, respBuf);
             } while (ret == WH_ERROR_NOTREADY);
         }
 
@@ -203,8 +204,8 @@ int wh_Client_SheSecureBoot(whClientContext* c, uint8_t* bootloader,
 
     if (ret == 0) {
         do {
-            ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
-                                         WOLFHSM_CFG_COMM_DATA_LEN, respBuf);
+            ret        = wh_Client_RecvResponse(c, &group, &action, &dataSz,
+                                                WOLFHSM_CFG_COMM_DATA_LEN, respBuf);
             finishResp = (whMessageShe_SecureBootFinishResponse*)respBuf;
         } while (ret == WH_ERROR_NOTREADY);
     }
@@ -244,7 +245,8 @@ int wh_Client_SheGetStatusResponse(whClientContext* c, uint8_t* sreg)
 
     resp = (whMessageShe_GetStatusResponse*)wh_CommClient_GetDataPtr(c->comm);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
 
     /* return error or set sreg */
     if (ret == 0) {
@@ -308,7 +310,8 @@ int wh_Client_SheLoadKeyResponse(whClientContext* c, uint8_t* messageFour,
 
     resp = (whMessageShe_LoadKeyResponse*)wh_CommClient_GetDataPtr(c->comm);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;
@@ -368,7 +371,8 @@ int wh_Client_SheLoadPlainKeyResponse(whClientContext* c)
     resp =
         (whMessageShe_LoadPlainKeyResponse*)wh_CommClient_GetDataPtr(c->comm);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         ret = resp->rc;
     }
@@ -418,7 +422,8 @@ int wh_Client_SheExportRamKeyResponse(whClientContext* c, uint8_t* messageOne,
     resp =
         (whMessageShe_ExportRamKeyResponse*)wh_CommClient_GetDataPtr(c->comm);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;
@@ -475,7 +480,8 @@ int wh_Client_SheInitRndResponse(whClientContext* c)
     }
 
     resp = (whMessageShe_InitRngResponse*)wh_CommClient_GetDataPtr(c->comm);
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret  = wh_Client_RecvResponse(c, &group, &action, &dataSz,
+                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         ret = resp->rc;
     }
@@ -518,7 +524,8 @@ int wh_Client_SheRndResponse(whClientContext* c, uint8_t* out, uint32_t* outSz)
 
     resp = (whMessageShe_RndResponse*)wh_CommClient_GetDataPtr(c->comm);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
 
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR)
@@ -578,7 +585,8 @@ int wh_Client_SheExtendSeedResponse(whClientContext* c)
     }
 
     resp = (whMessageShe_ExtendSeedResponse*)wh_CommClient_GetDataPtr(c->comm);
-    ret  = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret  = wh_Client_RecvResponse(c, &group, &action, &dataSz,
+                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
 
     if (ret == 0) {
         ret = resp->rc;
@@ -641,7 +649,8 @@ int wh_Client_SheEncEcbResponse(whClientContext* c, uint8_t* out, uint32_t sz)
     /* out is after fixed sized fields */
     packOut = (uint8_t*)(resp + 1);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;
@@ -713,7 +722,8 @@ int wh_Client_SheEncCbcResponse(whClientContext* c, uint8_t* out, uint32_t sz)
     /* out is after fixed sized fields */
     packOut = (uint8_t*)(resp + 1);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;
@@ -781,7 +791,8 @@ int wh_Client_SheDecEcbResponse(whClientContext* c, uint8_t* out, uint32_t sz)
     /* out is after fixed sized fields */
     packOut = (uint8_t*)(resp + 1);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;
@@ -853,7 +864,8 @@ int wh_Client_SheDecCbcResponse(whClientContext* c, uint8_t* out, uint32_t sz)
     /* out is after fixed sized fields */
     packOut = (uint8_t*)(resp + 1);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;
@@ -920,7 +932,8 @@ int wh_Client_SheGenerateMacResponse(whClientContext* c, uint8_t* out,
 
     resp = (whMessageShe_GenMacResponse*)wh_CommClient_GetDataPtr(c->comm);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;
@@ -992,7 +1005,8 @@ int wh_Client_SheVerifyMacResponse(whClientContext* c, uint8_t* outStatus)
     }
 
     resp = (whMessageShe_VerifyMacResponse*)wh_CommClient_GetDataPtr(c->comm);
-    ret  = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    ret  = wh_Client_RecvResponse(c, &group, &action, &dataSz,
+                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;

--- a/src/wh_client_she.c
+++ b/src/wh_client_she.c
@@ -95,7 +95,7 @@ int wh_Client_SheSetUidResponse(whClientContext* c)
     }
 
     resp = (whMessageShe_SetUidResponse*)wh_CommClient_GetDataPtr(c->comm);
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
         ret = resp->rc;
     }
@@ -146,7 +146,8 @@ int wh_Client_SheSecureBoot(whClientContext* c, uint8_t* bootloader,
 
     if (ret == 0) {
         do {
-            ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, respBuf);
+            ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
+                                         WOLFHSM_CFG_COMM_DATA_LEN, respBuf);
             initResp = (whMessageShe_SecureBootInitResponse*)respBuf;
         } while (ret == WH_ERROR_NOTREADY);
     }
@@ -183,6 +184,7 @@ int wh_Client_SheSecureBoot(whClientContext* c, uint8_t* bootloader,
         if (ret == 0) {
             do {
                 ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
+                                             WOLFHSM_CFG_COMM_DATA_LEN,
                                              respBuf);
             } while (ret == WH_ERROR_NOTREADY);
         }
@@ -201,7 +203,8 @@ int wh_Client_SheSecureBoot(whClientContext* c, uint8_t* bootloader,
 
     if (ret == 0) {
         do {
-            ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, respBuf);
+            ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
+                                         WOLFHSM_CFG_COMM_DATA_LEN, respBuf);
             finishResp = (whMessageShe_SecureBootFinishResponse*)respBuf;
         } while (ret == WH_ERROR_NOTREADY);
     }
@@ -241,7 +244,7 @@ int wh_Client_SheGetStatusResponse(whClientContext* c, uint8_t* sreg)
 
     resp = (whMessageShe_GetStatusResponse*)wh_CommClient_GetDataPtr(c->comm);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
 
     /* return error or set sreg */
     if (ret == 0) {
@@ -305,7 +308,7 @@ int wh_Client_SheLoadKeyResponse(whClientContext* c, uint8_t* messageFour,
 
     resp = (whMessageShe_LoadKeyResponse*)wh_CommClient_GetDataPtr(c->comm);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;
@@ -365,7 +368,7 @@ int wh_Client_SheLoadPlainKeyResponse(whClientContext* c)
     resp =
         (whMessageShe_LoadPlainKeyResponse*)wh_CommClient_GetDataPtr(c->comm);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         ret = resp->rc;
     }
@@ -415,7 +418,7 @@ int wh_Client_SheExportRamKeyResponse(whClientContext* c, uint8_t* messageOne,
     resp =
         (whMessageShe_ExportRamKeyResponse*)wh_CommClient_GetDataPtr(c->comm);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;
@@ -472,7 +475,7 @@ int wh_Client_SheInitRndResponse(whClientContext* c)
     }
 
     resp = (whMessageShe_InitRngResponse*)wh_CommClient_GetDataPtr(c->comm);
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         ret = resp->rc;
     }
@@ -515,7 +518,7 @@ int wh_Client_SheRndResponse(whClientContext* c, uint8_t* out, uint32_t* outSz)
 
     resp = (whMessageShe_RndResponse*)wh_CommClient_GetDataPtr(c->comm);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
 
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR)
@@ -575,7 +578,7 @@ int wh_Client_SheExtendSeedResponse(whClientContext* c)
     }
 
     resp = (whMessageShe_ExtendSeedResponse*)wh_CommClient_GetDataPtr(c->comm);
-    ret  = wh_Client_RecvResponse(c, &group, &action, &dataSz, (uint8_t*)resp);
+    ret  = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
 
     if (ret == 0) {
         ret = resp->rc;
@@ -638,7 +641,7 @@ int wh_Client_SheEncEcbResponse(whClientContext* c, uint8_t* out, uint32_t sz)
     /* out is after fixed sized fields */
     packOut = (uint8_t*)(resp + 1);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;
@@ -710,7 +713,7 @@ int wh_Client_SheEncCbcResponse(whClientContext* c, uint8_t* out, uint32_t sz)
     /* out is after fixed sized fields */
     packOut = (uint8_t*)(resp + 1);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;
@@ -778,7 +781,7 @@ int wh_Client_SheDecEcbResponse(whClientContext* c, uint8_t* out, uint32_t sz)
     /* out is after fixed sized fields */
     packOut = (uint8_t*)(resp + 1);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;
@@ -850,7 +853,7 @@ int wh_Client_SheDecCbcResponse(whClientContext* c, uint8_t* out, uint32_t sz)
     /* out is after fixed sized fields */
     packOut = (uint8_t*)(resp + 1);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;
@@ -917,7 +920,7 @@ int wh_Client_SheGenerateMacResponse(whClientContext* c, uint8_t* out,
 
     resp = (whMessageShe_GenMacResponse*)wh_CommClient_GetDataPtr(c->comm);
 
-    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, (uint8_t*)resp);
+    ret = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;
@@ -989,7 +992,7 @@ int wh_Client_SheVerifyMacResponse(whClientContext* c, uint8_t* outStatus)
     }
 
     resp = (whMessageShe_VerifyMacResponse*)wh_CommClient_GetDataPtr(c->comm);
-    ret  = wh_Client_RecvResponse(c, &group, &action, &dataSz, (uint8_t*)resp);
+    ret  = wh_Client_RecvResponse(c, &group, &action, &dataSz, WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;

--- a/src/wh_comm.c
+++ b/src/wh_comm.c
@@ -156,9 +156,10 @@ int wh_CommClient_SendRequest(whCommClient* context, uint16_t magic,
  * *out_size set to the required size. On success *out_size holds the actual
  * payload size.
  */
-int wh_CommClient_RecvResponse(whCommClient* context,
-        uint16_t* out_magic, uint16_t* out_kind, uint16_t* out_seq,
-        uint16_t* out_size, uint16_t data_size, void* data)
+int wh_CommClient_RecvResponse(whCommClient* context, uint16_t* out_magic,
+                               uint16_t* out_kind, uint16_t* out_seq,
+                               uint16_t* out_size, uint16_t data_size,
+                               void* data)
 {
     int rc = 0;
     uint16_t magic = 0;
@@ -227,8 +228,7 @@ int wh_CommClient_RecvResponse(whCommClient* context,
                 return WH_ERROR_NOTREADY;
             }
 
-            if ((data != NULL) &&
-                (payload_size != 0) &&
+            if ((data != NULL) && (payload_size != 0) &&
                 (data != context->data)) {
                 if (payload_size > data_size) {
                     rc = WH_ERROR_BUFFER_SIZE;
@@ -240,7 +240,8 @@ int wh_CommClient_RecvResponse(whCommClient* context,
             if (out_magic != NULL) *out_magic = magic;
             if (out_kind != NULL) *out_kind = kind;
             if (out_seq != NULL) *out_seq = seq;
-            if (out_size != NULL) *out_size = payload_size;
+            if (out_size != NULL)
+                *out_size = payload_size;
             context->pending = 0;
         }
     }

--- a/src/wh_comm.c
+++ b/src/wh_comm.c
@@ -151,18 +151,21 @@ int wh_CommClient_SendRequest(whCommClient* context, uint16_t magic,
 }
 
 /* If a response packet has been buffered, get the header and copy the data out
- * of the buffer.
+ * of the buffer. data_size is the capacity of the caller-supplied data buffer;
+ * if the received payload exceeds it, returns WH_ERROR_BUFFER_SIZE with
+ * *out_size set to the required size. On success *out_size holds the actual
+ * payload size.
  */
 int wh_CommClient_RecvResponse(whCommClient* context,
         uint16_t* out_magic, uint16_t* out_kind, uint16_t* out_seq,
-        uint16_t* out_size, void* data)
+        uint16_t* out_size, uint16_t data_size, void* data)
 {
     int rc = 0;
     uint16_t magic = 0;
     uint16_t kind = 0;
     uint16_t seq = 0;
     uint16_t size = sizeof(context->packet);
-    uint16_t data_size = 0;
+    uint16_t payload_size = 0;
 
     if ((context == NULL) || (context->hdr == NULL) ||
         (context->initialized == 0) || (context->transport_cb == NULL) ||
@@ -193,7 +196,7 @@ int wh_CommClient_RecvResponse(whCommClient* context,
             rc = WH_ERROR_ABORTED;
         }
         if (rc == 0) {
-            data_size = size - sizeof(*context->hdr);
+            payload_size = size - sizeof(*context->hdr);
             magic = context->hdr->magic;
             kind = wh_Translate16(magic, context->hdr->kind);
             seq = wh_Translate16(magic, context->hdr->seq);
@@ -224,15 +227,20 @@ int wh_CommClient_RecvResponse(whCommClient* context,
                 return WH_ERROR_NOTREADY;
             }
 
-            if (    (data != NULL) &&
-                    (data_size != 0) &&
-                    (data != context->data)) {
-                memcpy(data, context->data, data_size);
+            if ((data != NULL) &&
+                (payload_size != 0) &&
+                (data != context->data)) {
+                if (payload_size > data_size) {
+                    rc = WH_ERROR_BUFFER_SIZE;
+                }
+                else {
+                    memcpy(data, context->data, payload_size);
+                }
             }
             if (out_magic != NULL) *out_magic = magic;
             if (out_kind != NULL) *out_kind = kind;
             if (out_seq != NULL) *out_seq = seq;
-            if (out_size != NULL) *out_size = data_size;
+            if (out_size != NULL) *out_size = payload_size;
             context->pending = 0;
         }
     }

--- a/test-refactor/misc/wh_test_comm.c
+++ b/test-refactor/misc/wh_test_comm.c
@@ -136,7 +136,8 @@ static int _whTest_CommMem(void)
     WH_TEST_ASSERT_RETURN(
         WH_ERROR_NOTREADY ==
         wh_CommClient_RecvResponse(client, &rx_resp_flags, &rx_resp_type,
-                                   &rx_resp_seq, &rx_resp_len, rx_resp));
+                                   &rx_resp_seq, &rx_resp_len, sizeof(rx_resp),
+                                   rx_resp));
 
     for (counter = 0; counter < REPEAT_COUNT; counter++) {
         (void)snprintf((char*)tx_req, sizeof(tx_req), "Request:%u", counter);
@@ -152,7 +153,8 @@ static int _whTest_CommMem(void)
             WH_TEST_ASSERT_RETURN(WH_ERROR_NOTREADY ==
                                   wh_CommClient_RecvResponse(
                                       client, &rx_resp_flags, &rx_resp_type,
-                                      &rx_resp_seq, &rx_resp_len, rx_resp));
+                                      &rx_resp_seq, &rx_resp_len,
+                                      sizeof(rx_resp), rx_resp));
 
             WH_TEST_ASSERT_RETURN(
                 WH_ERROR_REQUEST_PENDING ==
@@ -183,7 +185,8 @@ static int _whTest_CommMem(void)
 
         WH_TEST_RETURN_ON_FAIL(
             wh_CommClient_RecvResponse(client, &rx_resp_flags, &rx_resp_type,
-                                       &rx_resp_seq, &rx_resp_len, rx_resp));
+                                       &rx_resp_seq, &rx_resp_len,
+                                       sizeof(rx_resp), rx_resp));
 
         WH_TEST_DEBUG_PRINT(
             "Client RecvResponse:%d, flags %x, type:%x, seq:%d, len:%d, %s\n",
@@ -222,14 +225,16 @@ static int _whTest_CommMem(void)
     /* Successful recv clears pending */
     WH_TEST_RETURN_ON_FAIL(
         wh_CommClient_RecvResponse(client, &rx_resp_flags, &rx_resp_type,
-                                   &rx_resp_seq, &rx_resp_len, rx_resp));
+                                   &rx_resp_seq, &rx_resp_len, sizeof(rx_resp),
+                                   rx_resp));
     WH_TEST_ASSERT_RETURN(0 == wh_CommClient_IsRequestPending(client));
 
     /* Second Recv with no outstanding request again yields NOTREADY */
     WH_TEST_ASSERT_RETURN(
         WH_ERROR_NOTREADY ==
         wh_CommClient_RecvResponse(client, &rx_resp_flags, &rx_resp_type,
-                                   &rx_resp_seq, &rx_resp_len, rx_resp));
+                                   &rx_resp_seq, &rx_resp_len, sizeof(rx_resp),
+                                   rx_resp));
 
     /* Send, then manually abort. Seq must not advance. */
     WH_TEST_RETURN_ON_FAIL(wh_CommClient_SendRequest(
@@ -253,7 +258,8 @@ static int _whTest_CommMem(void)
     WH_TEST_ASSERT_RETURN(
         WH_ERROR_NOTREADY ==
         wh_CommClient_RecvResponse(client, &rx_resp_flags, &rx_resp_type,
-                                   &rx_resp_seq, &rx_resp_len, rx_resp));
+                                   &rx_resp_seq, &rx_resp_len, sizeof(rx_resp),
+                                   rx_resp));
     WH_TEST_ASSERT_RETURN(0 == wh_CommClient_IsRequestPending(client));
 
     WH_TEST_RETURN_ON_FAIL(wh_CommServer_Cleanup(server));

--- a/test-refactor/misc/wh_test_comm.c
+++ b/test-refactor/misc/wh_test_comm.c
@@ -133,11 +133,11 @@ static int _whTest_CommMem(void)
 
     /* RecvResponse with no outstanding request short-circuits to NOTREADY
      * without touching the transport. */
-    WH_TEST_ASSERT_RETURN(
-        WH_ERROR_NOTREADY ==
-        wh_CommClient_RecvResponse(client, &rx_resp_flags, &rx_resp_type,
-                                   &rx_resp_seq, &rx_resp_len, sizeof(rx_resp),
-                                   rx_resp));
+    WH_TEST_ASSERT_RETURN(WH_ERROR_NOTREADY ==
+                          wh_CommClient_RecvResponse(client, &rx_resp_flags,
+                                                     &rx_resp_type,
+                                                     &rx_resp_seq, &rx_resp_len,
+                                                     sizeof(rx_resp), rx_resp));
 
     for (counter = 0; counter < REPEAT_COUNT; counter++) {
         (void)snprintf((char*)tx_req, sizeof(tx_req), "Request:%u", counter);
@@ -183,10 +183,9 @@ static int _whTest_CommMem(void)
             "Server SendResponse:%d, flags %x, type:%x, seq:%d, len:%d, %s\n",
             ret, rx_req_flags, rx_req_type, rx_req_seq, tx_resp_len, tx_resp);
 
-        WH_TEST_RETURN_ON_FAIL(
-            wh_CommClient_RecvResponse(client, &rx_resp_flags, &rx_resp_type,
-                                       &rx_resp_seq, &rx_resp_len,
-                                       sizeof(rx_resp), rx_resp));
+        WH_TEST_RETURN_ON_FAIL(wh_CommClient_RecvResponse(
+            client, &rx_resp_flags, &rx_resp_type, &rx_resp_seq, &rx_resp_len,
+            sizeof(rx_resp), rx_resp));
 
         WH_TEST_DEBUG_PRINT(
             "Client RecvResponse:%d, flags %x, type:%x, seq:%d, len:%d, %s\n",
@@ -223,18 +222,17 @@ static int _whTest_CommMem(void)
         server, rx_req_flags, rx_req_type, rx_req_seq, tx_resp_len, tx_resp));
 
     /* Successful recv clears pending */
-    WH_TEST_RETURN_ON_FAIL(
-        wh_CommClient_RecvResponse(client, &rx_resp_flags, &rx_resp_type,
-                                   &rx_resp_seq, &rx_resp_len, sizeof(rx_resp),
-                                   rx_resp));
+    WH_TEST_RETURN_ON_FAIL(wh_CommClient_RecvResponse(
+        client, &rx_resp_flags, &rx_resp_type, &rx_resp_seq, &rx_resp_len,
+        sizeof(rx_resp), rx_resp));
     WH_TEST_ASSERT_RETURN(0 == wh_CommClient_IsRequestPending(client));
 
     /* Second Recv with no outstanding request again yields NOTREADY */
-    WH_TEST_ASSERT_RETURN(
-        WH_ERROR_NOTREADY ==
-        wh_CommClient_RecvResponse(client, &rx_resp_flags, &rx_resp_type,
-                                   &rx_resp_seq, &rx_resp_len, sizeof(rx_resp),
-                                   rx_resp));
+    WH_TEST_ASSERT_RETURN(WH_ERROR_NOTREADY ==
+                          wh_CommClient_RecvResponse(client, &rx_resp_flags,
+                                                     &rx_resp_type,
+                                                     &rx_resp_seq, &rx_resp_len,
+                                                     sizeof(rx_resp), rx_resp));
 
     /* Send, then manually abort. Seq must not advance. */
     WH_TEST_RETURN_ON_FAIL(wh_CommClient_SendRequest(
@@ -255,11 +253,11 @@ static int _whTest_CommMem(void)
 
     /* After abort the late response is ignored - pending is 0 so
      * RecvResponse short-circuits before consulting the transport. */
-    WH_TEST_ASSERT_RETURN(
-        WH_ERROR_NOTREADY ==
-        wh_CommClient_RecvResponse(client, &rx_resp_flags, &rx_resp_type,
-                                   &rx_resp_seq, &rx_resp_len, sizeof(rx_resp),
-                                   rx_resp));
+    WH_TEST_ASSERT_RETURN(WH_ERROR_NOTREADY ==
+                          wh_CommClient_RecvResponse(client, &rx_resp_flags,
+                                                     &rx_resp_type,
+                                                     &rx_resp_seq, &rx_resp_len,
+                                                     sizeof(rx_resp), rx_resp));
     WH_TEST_ASSERT_RETURN(0 == wh_CommClient_IsRequestPending(client));
 
     WH_TEST_RETURN_ON_FAIL(wh_CommServer_Cleanup(server));

--- a/test-refactor/misc/wh_test_she_keywrap.c
+++ b/test-refactor/misc/wh_test_she_keywrap.c
@@ -467,7 +467,8 @@ static int _SheSecureBoot(TestCtx* t, uint8_t* bootloader,
         t->client, WH_MESSAGE_GROUP_SHE, WH_SHE_SECURE_BOOT_INIT,
         sizeof(*initReq), (uint8_t*)initReq));
     WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(t->server));
-    ret = wh_Client_RecvResponse(t->client, &group, &action, &dataSz, respBuf);
+    ret = wh_Client_RecvResponse(t->client, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, respBuf);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -485,7 +486,8 @@ static int _SheSecureBoot(TestCtx* t, uint8_t* bootloader,
         t->client, WH_MESSAGE_GROUP_SHE, WH_SHE_SECURE_BOOT_UPDATE,
         (uint16_t)(sizeof(*updateReq) + bootloaderLen), (uint8_t*)updateReq));
     WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(t->server));
-    ret = wh_Client_RecvResponse(t->client, &group, &action, &dataSz, respBuf);
+    ret = wh_Client_RecvResponse(t->client, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, respBuf);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -498,7 +500,8 @@ static int _SheSecureBoot(TestCtx* t, uint8_t* bootloader,
     WH_TEST_RETURN_ON_FAIL(wh_Client_SendRequest(
         t->client, WH_MESSAGE_GROUP_SHE, WH_SHE_SECURE_BOOT_FINISH, 0, NULL));
     WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(t->server));
-    ret = wh_Client_RecvResponse(t->client, &group, &action, &dataSz, respBuf);
+    ret = wh_Client_RecvResponse(t->client, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, respBuf);
     if (ret != WH_ERROR_OK) {
         return ret;
     }

--- a/test-refactor/misc/wh_test_she_no_nvm.c
+++ b/test-refactor/misc/wh_test_she_no_nvm.c
@@ -456,7 +456,8 @@ static int _SheSecureBoot(TestCtx* t, uint8_t* bootloader,
         t->client, WH_MESSAGE_GROUP_SHE, WH_SHE_SECURE_BOOT_INIT,
         sizeof(*initReq), (uint8_t*)initReq));
     WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(t->server));
-    ret = wh_Client_RecvResponse(t->client, &group, &action, &dataSz, respBuf);
+    ret = wh_Client_RecvResponse(t->client, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, respBuf);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -474,7 +475,8 @@ static int _SheSecureBoot(TestCtx* t, uint8_t* bootloader,
         t->client, WH_MESSAGE_GROUP_SHE, WH_SHE_SECURE_BOOT_UPDATE,
         (uint16_t)(sizeof(*updateReq) + bootloaderLen), (uint8_t*)updateReq));
     WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(t->server));
-    ret = wh_Client_RecvResponse(t->client, &group, &action, &dataSz, respBuf);
+    ret = wh_Client_RecvResponse(t->client, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, respBuf);
     if (ret != WH_ERROR_OK) {
         return ret;
     }
@@ -487,7 +489,8 @@ static int _SheSecureBoot(TestCtx* t, uint8_t* bootloader,
     WH_TEST_RETURN_ON_FAIL(wh_Client_SendRequest(
         t->client, WH_MESSAGE_GROUP_SHE, WH_SHE_SECURE_BOOT_FINISH, 0, NULL));
     WH_TEST_RETURN_ON_FAIL(wh_Server_HandleRequestMessage(t->server));
-    ret = wh_Client_RecvResponse(t->client, &group, &action, &dataSz, respBuf);
+    ret = wh_Client_RecvResponse(t->client, &group, &action, &dataSz,
+                                 WOLFHSM_CFG_COMM_DATA_LEN, respBuf);
     if (ret != WH_ERROR_OK) {
         return ret;
     }

--- a/test/wh_test_comm.c
+++ b/test/wh_test_comm.c
@@ -151,7 +151,8 @@ int whTest_CommMem(void)
     WH_TEST_ASSERT_RETURN(
         WH_ERROR_NOTREADY ==
         wh_CommClient_RecvResponse(client, &rx_resp_flags, &rx_resp_type,
-                                   &rx_resp_seq, &rx_resp_len, rx_resp));
+                                   &rx_resp_seq, &rx_resp_len, sizeof(rx_resp),
+                                   rx_resp));
 
     for (counter = 0; counter < REPEAT_COUNT; counter++) {
         (void)snprintf((char*)tx_req, sizeof(tx_req), "Request:%u", counter);
@@ -167,7 +168,8 @@ int whTest_CommMem(void)
             WH_TEST_ASSERT_RETURN(WH_ERROR_NOTREADY ==
                                   wh_CommClient_RecvResponse(
                                       client, &rx_resp_flags, &rx_resp_type,
-                                      &rx_resp_seq, &rx_resp_len, rx_resp));
+                                      &rx_resp_seq, &rx_resp_len,
+                                      sizeof(rx_resp), rx_resp));
 
             WH_TEST_ASSERT_RETURN(
                 WH_ERROR_REQUEST_PENDING ==
@@ -198,7 +200,8 @@ int whTest_CommMem(void)
 
         WH_TEST_RETURN_ON_FAIL(
             wh_CommClient_RecvResponse(client, &rx_resp_flags, &rx_resp_type,
-                                       &rx_resp_seq, &rx_resp_len, rx_resp));
+                                       &rx_resp_seq, &rx_resp_len,
+                                       sizeof(rx_resp), rx_resp));
 
         WH_TEST_DEBUG_PRINT(
             "Client RecvResponse:%d, flags %x, type:%x, seq:%d, len:%d, %s\n",
@@ -237,14 +240,16 @@ int whTest_CommMem(void)
     /* Successful recv clears pending */
     WH_TEST_RETURN_ON_FAIL(
         wh_CommClient_RecvResponse(client, &rx_resp_flags, &rx_resp_type,
-                                   &rx_resp_seq, &rx_resp_len, rx_resp));
+                                   &rx_resp_seq, &rx_resp_len, sizeof(rx_resp),
+                                   rx_resp));
     WH_TEST_ASSERT_RETURN(0 == wh_CommClient_IsRequestPending(client));
 
     /* Second Recv with no outstanding request again yields NOTREADY */
     WH_TEST_ASSERT_RETURN(
         WH_ERROR_NOTREADY ==
         wh_CommClient_RecvResponse(client, &rx_resp_flags, &rx_resp_type,
-                                   &rx_resp_seq, &rx_resp_len, rx_resp));
+                                   &rx_resp_seq, &rx_resp_len, sizeof(rx_resp),
+                                   rx_resp));
 
     /* Send, then manually abort. Seq must not advance. */
     WH_TEST_RETURN_ON_FAIL(wh_CommClient_SendRequest(
@@ -268,7 +273,8 @@ int whTest_CommMem(void)
     WH_TEST_ASSERT_RETURN(
         WH_ERROR_NOTREADY ==
         wh_CommClient_RecvResponse(client, &rx_resp_flags, &rx_resp_type,
-                                   &rx_resp_seq, &rx_resp_len, rx_resp));
+                                   &rx_resp_seq, &rx_resp_len, sizeof(rx_resp),
+                                   rx_resp));
     WH_TEST_ASSERT_RETURN(0 == wh_CommClient_IsRequestPending(client));
 
     WH_TEST_RETURN_ON_FAIL(wh_CommServer_Cleanup(server));
@@ -338,7 +344,8 @@ static void* _whCommClientTask(void* cf)
         do {
             ret = wh_CommClient_RecvResponse(client, &rx_resp_flags,
                                              &rx_resp_type, &rx_resp_seq,
-                                             &rx_resp_len, rx_resp);
+                                             &rx_resp_len, sizeof(rx_resp),
+                                             rx_resp);
             WH_TEST_ASSERT_MSG((ret == WH_ERROR_NOTREADY) || (0 == ret),
                                "Client RecvResponse: ret=%d", ret);
             if(ret != WH_ERROR_NOTREADY) {

--- a/test/wh_test_comm.c
+++ b/test/wh_test_comm.c
@@ -148,11 +148,11 @@ int whTest_CommMem(void)
 
     /* RecvResponse with no outstanding request short-circuits to NOTREADY
      * without touching the transport. */
-    WH_TEST_ASSERT_RETURN(
-        WH_ERROR_NOTREADY ==
-        wh_CommClient_RecvResponse(client, &rx_resp_flags, &rx_resp_type,
-                                   &rx_resp_seq, &rx_resp_len, sizeof(rx_resp),
-                                   rx_resp));
+    WH_TEST_ASSERT_RETURN(WH_ERROR_NOTREADY ==
+                          wh_CommClient_RecvResponse(client, &rx_resp_flags,
+                                                     &rx_resp_type,
+                                                     &rx_resp_seq, &rx_resp_len,
+                                                     sizeof(rx_resp), rx_resp));
 
     for (counter = 0; counter < REPEAT_COUNT; counter++) {
         (void)snprintf((char*)tx_req, sizeof(tx_req), "Request:%u", counter);
@@ -198,10 +198,9 @@ int whTest_CommMem(void)
             "Server SendResponse:%d, flags %x, type:%x, seq:%d, len:%d, %s\n",
             ret, rx_req_flags, rx_req_type, rx_req_seq, tx_resp_len, tx_resp);
 
-        WH_TEST_RETURN_ON_FAIL(
-            wh_CommClient_RecvResponse(client, &rx_resp_flags, &rx_resp_type,
-                                       &rx_resp_seq, &rx_resp_len,
-                                       sizeof(rx_resp), rx_resp));
+        WH_TEST_RETURN_ON_FAIL(wh_CommClient_RecvResponse(
+            client, &rx_resp_flags, &rx_resp_type, &rx_resp_seq, &rx_resp_len,
+            sizeof(rx_resp), rx_resp));
 
         WH_TEST_DEBUG_PRINT(
             "Client RecvResponse:%d, flags %x, type:%x, seq:%d, len:%d, %s\n",
@@ -238,18 +237,17 @@ int whTest_CommMem(void)
         server, rx_req_flags, rx_req_type, rx_req_seq, tx_resp_len, tx_resp));
 
     /* Successful recv clears pending */
-    WH_TEST_RETURN_ON_FAIL(
-        wh_CommClient_RecvResponse(client, &rx_resp_flags, &rx_resp_type,
-                                   &rx_resp_seq, &rx_resp_len, sizeof(rx_resp),
-                                   rx_resp));
+    WH_TEST_RETURN_ON_FAIL(wh_CommClient_RecvResponse(
+        client, &rx_resp_flags, &rx_resp_type, &rx_resp_seq, &rx_resp_len,
+        sizeof(rx_resp), rx_resp));
     WH_TEST_ASSERT_RETURN(0 == wh_CommClient_IsRequestPending(client));
 
     /* Second Recv with no outstanding request again yields NOTREADY */
-    WH_TEST_ASSERT_RETURN(
-        WH_ERROR_NOTREADY ==
-        wh_CommClient_RecvResponse(client, &rx_resp_flags, &rx_resp_type,
-                                   &rx_resp_seq, &rx_resp_len, sizeof(rx_resp),
-                                   rx_resp));
+    WH_TEST_ASSERT_RETURN(WH_ERROR_NOTREADY ==
+                          wh_CommClient_RecvResponse(client, &rx_resp_flags,
+                                                     &rx_resp_type,
+                                                     &rx_resp_seq, &rx_resp_len,
+                                                     sizeof(rx_resp), rx_resp));
 
     /* Send, then manually abort. Seq must not advance. */
     WH_TEST_RETURN_ON_FAIL(wh_CommClient_SendRequest(
@@ -270,11 +268,11 @@ int whTest_CommMem(void)
 
     /* After abort the late response is ignored - pending is 0 so
      * RecvResponse short-circuits before consulting the transport. */
-    WH_TEST_ASSERT_RETURN(
-        WH_ERROR_NOTREADY ==
-        wh_CommClient_RecvResponse(client, &rx_resp_flags, &rx_resp_type,
-                                   &rx_resp_seq, &rx_resp_len, sizeof(rx_resp),
-                                   rx_resp));
+    WH_TEST_ASSERT_RETURN(WH_ERROR_NOTREADY ==
+                          wh_CommClient_RecvResponse(client, &rx_resp_flags,
+                                                     &rx_resp_type,
+                                                     &rx_resp_seq, &rx_resp_len,
+                                                     sizeof(rx_resp), rx_resp));
     WH_TEST_ASSERT_RETURN(0 == wh_CommClient_IsRequestPending(client));
 
     WH_TEST_RETURN_ON_FAIL(wh_CommServer_Cleanup(server));
@@ -342,10 +340,9 @@ static void* _whCommClientTask(void* cf)
         }
 
         do {
-            ret = wh_CommClient_RecvResponse(client, &rx_resp_flags,
-                                             &rx_resp_type, &rx_resp_seq,
-                                             &rx_resp_len, sizeof(rx_resp),
-                                             rx_resp);
+            ret = wh_CommClient_RecvResponse(
+                client, &rx_resp_flags, &rx_resp_type, &rx_resp_seq,
+                &rx_resp_len, sizeof(rx_resp), rx_resp);
             WH_TEST_ASSERT_MSG((ret == WH_ERROR_NOTREADY) || (0 == ret),
                                "Client RecvResponse: ret=%d", ret);
             if(ret != WH_ERROR_NOTREADY) {

--- a/wolfhsm/wh_client.h
+++ b/wolfhsm/wh_client.h
@@ -304,13 +304,16 @@ int wh_Client_SendRequest(whClientContext* c, uint16_t group, uint16_t action,
  * @param c The client context.
  * @param out_group Pointer to store the received group value.
  * @param out_action Pointer to store the received action value.
- * @param out_size Pointer to store the received size value.
+ * @param out_size Pointer to store the received size value. On
+ * WH_ERROR_BUFFER_SIZE this is set to the required size.
+ * @param data_size Capacity in bytes of the caller-supplied data buffer.
+ * Returns WH_ERROR_BUFFER_SIZE if the response payload exceeds it.
  * @param data Pointer to store the received data.
  * @return 0 if successful, a negative value if an error occurred.
  */
 int wh_Client_RecvResponse(whClientContext* c, uint16_t* out_group,
                            uint16_t* out_action, uint16_t* out_size,
-                           void* data);
+                           uint16_t data_size, void* data);
 
 /**
  * @brief Reports whether a request has been sent whose matching response has

--- a/wolfhsm/wh_comm.h
+++ b/wolfhsm/wh_comm.h
@@ -215,9 +215,10 @@ int wh_CommClient_SendRequest(whCommClient* context, uint16_t magic,
  * *out_size set to the required size. On success *out_size holds the actual
  * payload size.
  */
-int wh_CommClient_RecvResponse(whCommClient* context,
-        uint16_t* out_magic, uint16_t* out_kind, uint16_t* out_seq,
-        uint16_t* out_size, uint16_t data_size, void* data);
+int wh_CommClient_RecvResponse(whCommClient* context, uint16_t* out_magic,
+                               uint16_t* out_kind, uint16_t* out_seq,
+                               uint16_t* out_size, uint16_t data_size,
+                               void* data);
 
 /* Get a pointer to the data portion of the internal buffer that is
  * HW_COMM_DATA_LEN bytes.

--- a/wolfhsm/wh_comm.h
+++ b/wolfhsm/wh_comm.h
@@ -210,11 +210,14 @@ int wh_CommClient_SendRequest(whCommClient* context, uint16_t magic,
     uint16_t kind, uint16_t *out_seq, uint16_t data_size, const void* data);
 
 /* If a response packet has been buffered, get the header and copy the data out
- * of the buffer.
+ * of the buffer. data_size is the capacity of the caller-supplied data buffer;
+ * if the received payload exceeds it, returns WH_ERROR_BUFFER_SIZE with
+ * *out_size set to the required size. On success *out_size holds the actual
+ * payload size.
  */
 int wh_CommClient_RecvResponse(whCommClient* context,
         uint16_t* out_magic, uint16_t* out_kind, uint16_t* out_seq,
-        uint16_t* out_size, void* data);
+        uint16_t* out_size, uint16_t data_size, void* data);
 
 /* Get a pointer to the data portion of the internal buffer that is
  * HW_COMM_DATA_LEN bytes.


### PR DESCRIPTION
`wh_CommClient_RecvResponse` does a `memcpy` into a caller provided buf without checking the length -- the function does not contain a length param, however the calling functions do. 

This change adds the `data_size` param, so this change does break the API. Alternative was to use existing `uint16_t* out_size` as an `inout` param, but that felt too sneaky and easy to overlook.

All 130ish callers updated. `src-jp` references the params (and is updated), but the English `src` does not.