### PR TITLE
Fix increments for void pointers

### DIFF
--- a/port/posix/posix_transport_shm.c
+++ b/port/posix/posix_transport_shm.c
@@ -573,7 +573,7 @@ int posixTransportShm_ClientStaticMemDmaCallback(
 
     if ((dmaPtr != NULL) && (dmaSize > 0) && (len < dmaSize) &&
         (clientAddr >= (uintptr_t)dmaPtr) &&
-        (clientAddr < (uintptr_t)(dmaPtr + dmaSize - len))) {
+        (clientAddr < (uintptr_t)((uint8_t*)dmaPtr + dmaSize - len))) {
         dmaBuffer = clientAddr;
         isInDma   = 1;
     }

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -428,8 +428,8 @@ static int _HandleRsaFunction(whServerContext* ctx, uint16_t magic, int devId,
     }
 
     /* in and out are after the fixed size fields */
-    byte* in  = (uint8_t*)(cryptoDataIn + sizeof(whMessageCrypto_RsaRequest));
-    byte* out = (uint8_t*)(cryptoDataOut + sizeof(whMessageCrypto_RsaResponse));
+    const byte* in  = (const byte*)cryptoDataIn + sizeof(whMessageCrypto_RsaRequest);
+    byte*       out = (byte*)cryptoDataOut + sizeof(whMessageCrypto_RsaResponse);
 
     WH_DEBUG_SERVER_VERBOSE("HandleRsaFunction opType:%d inLen:%u keyId:%u outLen:%u\n",
             op_type, in_len, key_id, out_len);

--- a/src/wh_server_keystore.c
+++ b/src/wh_server_keystore.c
@@ -1495,7 +1495,7 @@ static int _AesGcmKeyUnwrapWithKek(whServerContext* server,
 
     /* Extract IV and authTag from wrappedKeyIn */
     memcpy(iv, wrappedKeyIn, sizeof(iv));
-    memcpy(authTag, wrappedKeyIn + sizeof(iv), sizeof(authTag));
+    memcpy(authTag, (const uint8_t*)wrappedKeyIn + sizeof(iv), sizeof(authTag));
 
     /* Decrypt the encrypted blob */
     ret = wc_AesGcmDecrypt(aes, plainBlob, encBlob, encBlobSz, iv, sizeof(iv),
@@ -1669,7 +1669,7 @@ static int _AesGcmDataUnwrapWithKek(whServerContext* server,
 
     /* Extract IV and authTag from wrappedDataIn */
     memcpy(iv, wrappedDataIn, sizeof(iv));
-    memcpy(authTag, wrappedDataIn + sizeof(iv), sizeof(authTag));
+    memcpy(authTag, (const uint8_t*)wrappedDataIn + sizeof(iv), sizeof(authTag));
 
     /* Decrypt the encrypted blob */
     ret = wc_AesGcmDecrypt(aes, dataOut, encBlob, encBlobSz, iv, sizeof(iv),

--- a/test/Makefile
+++ b/test/Makefile
@@ -42,7 +42,7 @@ DEF += -DWOLFHSM_CFG_TEST_POSIX
 ARCHFLAGS ?=
 
 # Enable extra C compiler warnings
-CFLAGS_EXTRA = -Werror -Wall -Wextra
+CFLAGS_EXTRA = -Werror -Wall -Wextra -Wpointer-arith
 # Place functions / data into separate sections to allow unused code removal
 CFLAGS_EXTRA += -ffunction-sections -fdata-sections
 # Auto-generate header dependency files (.d) alongside object files


### PR DESCRIPTION
## Summary 

- Add `-Wpointer-arith` to `CFLAGS_EXTRA` in `test/Makefile` to catch void pointer arithmetic at build time.
- Fix void pointer arithmetic in `src/wh_server_crypto.c` and `src/wh_server_keystore.c`.

## Test

- cd test && make clean && make WOLFSSL_DIR=<WOLFSSL_DIR> run
- cd test && make clean && make DMA=1 ASAN=1 WOLFSSL_DIR=<WOLFSSL_DIR> run