### PR TITLE
gate CRYPTO AFFINITY under  WOLFHSM_CFG_CRYPTO_AFFINITY

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -73,6 +73,15 @@ jobs:
     - name: Build and test ASAN SHE
       run: cd test && make clean && make -j SHE=1 ASAN=1 WOLFSSL_DIR=../wolfssl && make run
 
+    # Build and test with per-client crypto affinity enabled (runs the crypto
+    # affinity unit test, gated behind WOLFHSM_CFG_CRYPTO_AFFINITY)
+    - name: Build and test CRYPTO_AFFINITY ASAN
+      run: cd test && make clean && make -j CRYPTO_AFFINITY=1 ASAN=1 WOLFSSL_DIR=../wolfssl && make run
+
+    # Build and test crypto affinity alongside DMA (exercises HW-devId path)
+    - name: Build and test CRYPTO_AFFINITY DMA ASAN
+      run: cd test && make clean && make -j CRYPTO_AFFINITY=1 DMA=1 ASAN=1 WOLFSSL_DIR=../wolfssl && make run
+
     # Build and test with DEBUG=1
     - name: Build and test with DEBUG
       run: cd test && make clean && make -j DEBUG=1 WOLFSSL_DIR=../wolfssl && make run

--- a/docs/draft/crypto_affinity.md
+++ b/docs/draft/crypto_affinity.md
@@ -2,6 +2,8 @@
 
 The crypto affinity feature allows a client to control whether the server uses **software** or **hardware** cryptographic implementations on a per-request basis.
 
+> **Compile-time guard:** The feature is gated behind `WOLFHSM_CFG_CRYPTO_AFFINITY` (default off). When the macro is not defined, `wh_Client_SetCryptoAffinity`/`wh_Client_GetCryptoAffinity` are not compiled, so the client cannot change affinity, and the server ignores the request header affinity field and always uses its configured `devId`. The affinity field is still present in the client context and carried in every crypto request header for wire-format compatibility; without the setter it simply retains its default value.
+
 Affinity is stored as **client-local state** and is transmitted to the server in every crypto request message header. There is no dedicated round-trip required to change affinity -- setting it is instantaneous and takes effect on the next crypto operation. Affinity persists for all subsequent requests once changed.
 
 ## Affinity Values

--- a/docs/src/5-Features.md
+++ b/docs/src/5-Features.md
@@ -138,7 +138,7 @@ The same ID can name a key the client just cached, one provisioned into NVM at t
 
 Many of the platforms wolfHSM targets ship a dedicated crypto accelerator alongside their secure core. The server can use these accelerators per-algorithm through the same crypto callback mechanism: a port-supplied callback, registered at server init, redirects supported operations to the vendor's hardware driver, and anything not implemented in hardware falls back to wolfCrypt software. Which algorithms are accelerated depends on the silicon and is documented in each platform's port.
 
-Clients control whether a given crypto request should prefer hardware or software execution through the **crypto affinity** API. Affinity is a per-client setting with two values:
+Clients control whether a given crypto request should prefer hardware or software execution through the **crypto affinity** API. This feature is compiled in only when `WOLFHSM_CFG_CRYPTO_AFFINITY` is defined; when it is not, the server always uses its configured device ID and the client API below is unavailable. Affinity is a per-client setting with two values:
 
 - `WH_CRYPTO_AFFINITY_HW` (default): the server attempts to execute the operation using the configured hardware crypto device. If the server was not configured with a valid hardware device ID, or if the requested algorithm is not implemented in hardware, the request transparently falls back to wolfCrypt's software implementation.
 - `WH_CRYPTO_AFFINITY_SW`: the server always executes the operation using wolfCrypt's software implementation, bypassing any registered hardware device.

--- a/src/wh_client.c
+++ b/src/wh_client.c
@@ -512,6 +512,7 @@ int wh_Client_CommInfo(whClientContext* c,
     return rc;
 }
 
+#if defined(WOLFHSM_CFG_CRYPTO_AFFINITY)
 int wh_Client_SetCryptoAffinity(whClientContext* c, uint32_t affinity)
 {
     if (c == NULL) {
@@ -533,6 +534,7 @@ int wh_Client_GetCryptoAffinity(whClientContext* c, uint32_t* out_affinity)
     *out_affinity = c->cryptoAffinity;
     return WH_ERROR_OK;
 }
+#endif /* WOLFHSM_CFG_CRYPTO_AFFINITY */
 
 int wh_Client_SetDmaMode(whClientContext* c, int useDma)
 {

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -5346,11 +5346,17 @@ int wh_Server_HandleCryptoRequest(whServerContext* ctx, uint16_t magic,
     wh_MessageCrypto_TranslateGenericRequestHeader(
         magic, (whMessageCrypto_GenericRequestHeader*)req_packet, &rqstHeader);
 
+#if defined(WOLFHSM_CFG_CRYPTO_AFFINITY)
     /* Compute devId from the per-message affinity field */
     devId = (rqstHeader.affinity == WH_CRYPTO_AFFINITY_HW &&
              ctx->devId != INVALID_DEVID)
                 ? ctx->devId
                 : INVALID_DEVID;
+#else
+    /* Crypto affinity disabled: always use the server's configured devId and
+     * ignore the request header affinity field. */
+    devId = ctx->devId;
+#endif /* WOLFHSM_CFG_CRYPTO_AFFINITY */
 
     WH_DEBUG_SERVER_VERBOSE("HandleCryptoRequest. Action:%u\n", action);
     WH_DEBUG_VERBOSE_HEXDUMP("[server] Crypto Request:\n", (const uint8_t*)req_packet,
@@ -8354,11 +8360,17 @@ int wh_Server_HandleCryptoDmaRequest(whServerContext* ctx, uint16_t magic,
     wh_MessageCrypto_TranslateGenericRequestHeader(
         magic, (whMessageCrypto_GenericRequestHeader*)req_packet, &rqstHeader);
 
+#if defined(WOLFHSM_CFG_CRYPTO_AFFINITY)
     /* Compute devId from the per-message affinity field */
     devId = (rqstHeader.affinity == WH_CRYPTO_AFFINITY_HW &&
              ctx->devId != INVALID_DEVID)
                 ? ctx->devId
                 : INVALID_DEVID;
+#else
+    /* Crypto affinity disabled: always use the server's configured devId and
+     * ignore the request header affinity field. */
+    devId = ctx->devId;
+#endif /* WOLFHSM_CFG_CRYPTO_AFFINITY */
 
     switch (action) {
         case WC_ALGO_TYPE_HASH:

--- a/test/Makefile
+++ b/test/Makefile
@@ -157,6 +157,11 @@ ifeq ($(SHE),1)
 	DEF += -DWOLFHSM_CFG_SHE_EXTENSION
 endif
 
+# Enable per-client crypto affinity (HW/SW devId selection) and its unit test
+ifeq ($(CRYPTO_AFFINITY),1)
+	DEF += -DWOLFHSM_CFG_CRYPTO_AFFINITY
+endif
+
 # Support a TLS-capable build
 ifeq ($(TLS),1)
 	DEF += -DWOLFHSM_CFG_TLS

--- a/test/wh_test.c
+++ b/test/wh_test.c
@@ -114,7 +114,7 @@ int whTest_Unit(void)
     /* Crypto Tests */
     WH_TEST_ASSERT(0 == whTest_Crypto());
 
-#ifdef WOLF_CRYPTO_CB
+#if defined(WOLF_CRYPTO_CB) && defined(WOLFHSM_CFG_CRYPTO_AFFINITY)
     WH_TEST_ASSERT(0 == whTest_CryptoAffinity());
 #endif
 

--- a/test/wh_test_crypto_affinity.c
+++ b/test/wh_test_crypto_affinity.c
@@ -26,8 +26,10 @@
 
 #include "wolfhsm/wh_settings.h"
 
-/* Only compile if we have crypto, client, server, and crypto callbacks */
-#if !defined(WOLFHSM_CFG_NO_CRYPTO) && defined(WOLF_CRYPTO_CB)
+/* Only compile if the crypto affinity feature is enabled and we have crypto,
+ * client, server, and crypto callbacks */
+#if !defined(WOLFHSM_CFG_NO_CRYPTO) && defined(WOLF_CRYPTO_CB) && \
+    defined(WOLFHSM_CFG_CRYPTO_AFFINITY)
 
 #include <stdint.h>
 #include <stdio.h>
@@ -518,4 +520,5 @@ int whTest_CryptoAffinity(void)
     return WH_ERROR_OK;
 }
 
-#endif /* !WOLFHSM_CFG_NO_CRYPTO && WOLF_CRYPTO_CB */
+#endif /* !WOLFHSM_CFG_NO_CRYPTO && WOLF_CRYPTO_CB && \
+          WOLFHSM_CFG_CRYPTO_AFFINITY */

--- a/test/wh_test_posix_threadsafe_stress.c
+++ b/test/wh_test_posix_threadsafe_stress.c
@@ -2031,19 +2031,8 @@ static int validatePhaseResult(StressTestContext* ctx, ContentionPhase phase,
 
     switch (phase) {
         case PHASE_COUNTER_CONCURRENT_INCREMENT: {
-            /* Validate counter value matches expected increments
-             * Expected: number of successful increments
-             * Count ROLE_OP_A threads (all 4 in this phase) */
-            uint32_t counter  = 0;
-            int      opACount = 0;
-            int      i;
-
-            /* Count how many threads were doing increments (ROLE_OP_A) */
-            for (i = 0; i < NUM_CLIENTS; i++) {
-                if (ctx->clientRoles[i] == ROLE_OP_A) {
-                    opACount++;
-                }
-            }
+            /* Validate counter value matches expected increments */
+            uint32_t counter = 0;
 
             /* Read final counter value using client 0 */
             rc = doCounterRead(&ctx->pairs[0].client, HOT_COUNTER_ID, &counter);

--- a/wolfhsm/wh_client.h
+++ b/wolfhsm/wh_client.h
@@ -483,7 +483,6 @@ int wh_Client_CommInfo(whClientContext* c,
         uint32_t *out_lifecycle_state,
         uint32_t *out_nvm_state);
 
-#if defined(WOLFHSM_CFG_CRYPTO_AFFINITY)
 /**
  * @brief Sets the crypto affinity on the client context.
  *
@@ -509,7 +508,6 @@ int wh_Client_SetCryptoAffinity(whClientContext* c, uint32_t affinity);
  * @return int Returns 0 on success, or WH_ERROR_BADARGS on invalid input.
  */
 int wh_Client_GetCryptoAffinity(whClientContext* c, uint32_t* out_affinity);
-#endif /* WOLFHSM_CFG_CRYPTO_AFFINITY */
 
 /**
  * @brief Turns the DMA path on or off for this client.

--- a/wolfhsm/wh_client.h
+++ b/wolfhsm/wh_client.h
@@ -483,11 +483,14 @@ int wh_Client_CommInfo(whClientContext* c,
         uint32_t *out_lifecycle_state,
         uint32_t *out_nvm_state);
 
+#if defined(WOLFHSM_CFG_CRYPTO_AFFINITY)
 /**
  * @brief Sets the crypto affinity on the client context.
  *
  * Affinity is stored locally and transmitted per-message in every crypto
  * request. No round-trip to the server is required.
+ *
+ * Requires WOLFHSM_CFG_CRYPTO_AFFINITY.
  *
  * @param[in] c Pointer to the client context.
  * @param[in] affinity Requested crypto affinity (WH_CRYPTO_AFFINITY_SW or
@@ -499,11 +502,14 @@ int wh_Client_SetCryptoAffinity(whClientContext* c, uint32_t affinity);
 /**
  * @brief Gets the current crypto affinity from the client context.
  *
+ * Requires WOLFHSM_CFG_CRYPTO_AFFINITY.
+ *
  * @param[in] c Pointer to the client context.
  * @param[out] out_affinity Pointer to store the current crypto affinity.
  * @return int Returns 0 on success, or WH_ERROR_BADARGS on invalid input.
  */
 int wh_Client_GetCryptoAffinity(whClientContext* c, uint32_t* out_affinity);
+#endif /* WOLFHSM_CFG_CRYPTO_AFFINITY */
 
 /**
  * @brief Turns the DMA path on or off for this client.

--- a/wolfhsm/wh_settings.h
+++ b/wolfhsm/wh_settings.h
@@ -40,6 +40,13 @@
  *  keys to be shared across multiple clients
  *      Default: Not defined
  *
+ *  WOLFHSM_CFG_CRYPTO_AFFINITY - If defined, enable per-client crypto affinity,
+ *  allowing a client to request that crypto operations run on the server's
+ *  hardware device (WH_CRYPTO_AFFINITY_HW) or in software
+ *  (WH_CRYPTO_AFFINITY_SW). When not defined, the server always uses its
+ *  configured devId and the affinity request header field is ignored.
+ *      Default: Not defined
+ *
  *  WOLFHSM_CFG_KEYWRAP - If defined, include the key wrap functionality
  *      Default: Not defined
  *
@@ -470,6 +477,12 @@
 
 #if defined(WOLFHSM_CFG_NO_CRYPTO) && defined(WOLFHSM_CFG_KEYWRAP)
 #error "WOLFHSM_CFG_KEYWRAP is incompatible with WOLFHSM_CFG_NO_CRYPTO"
+#endif
+
+/* Crypto affinity selects the devId used for crypto operations, so it has no
+ * meaning without wolfCrypt. */
+#if defined(WOLFHSM_CFG_NO_CRYPTO) && defined(WOLFHSM_CFG_CRYPTO_AFFINITY)
+#error "WOLFHSM_CFG_CRYPTO_AFFINITY is incompatible with WOLFHSM_CFG_NO_CRYPTO"
 #endif
 
 #if defined(WOLFHSM_CFG_HWKEYSTORE)


### PR DESCRIPTION
To allow ports that do not support affinity to error out at compile time.

If you think a negative macro is better, I'll do it. 