### PR TITLE
Add TEST_POSIX guard to include posix transport header in auth test

### DIFF
--- a/test/wh_test_auth.c
+++ b/test/wh_test_auth.c
@@ -45,7 +45,8 @@
 #include "wh_test_auth.h"
 #endif /* WOLFHSM_CFG_ENABLE_AUTHENTICATION */
 
-#if defined(WOLFHSM_CFG_TEST_CLIENT_ONLY_TCP)
+#if defined(WOLFHSM_CFG_TEST_CLIENT_ONLY_TCP) && \
+    defined(WOLFHSM_CFG_TEST_POSIX)
 #include "port/posix/posix_transport_tcp.h"
 #endif
 


### PR DESCRIPTION
This adds the `WOLFHSM_CFG_TEST_POSIX` define guard to only include posix_transport_tcp.h when defined.
This fixed some build errors when compiling the tests for other platforms