### PR TITLE
fix: reset ret after EccVerify pubkey export fail

### DIFF
--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -1592,6 +1592,7 @@ static int _HandleEccVerify(whServerContext* ctx, uint16_t magic, int devId,
                 if (ret < 0) {
                     /* Problem dumping the public key.  Set to 0 length */
                     pub_size = 0;
+                    ret      = 0;
                 }
                 else {
                     pub_size = ret;


### PR DESCRIPTION
## Bug

In `_HandleEccVerify` (`src/wh_server_crypto.c`), when the optional public-key export path runs after a successful ECDSA verification, `wc_EccPublicKeyToDer()` can return a negative error (e.g. the output buffer is too small). The error branch sets `pub_size = 0` but does **not** reset `ret`, so `ret` keeps the negative DER error code:

```c
if (ret < 0) {
    /* Problem dumping the public key.  Set to 0 length */
    pub_size = 0;
}
```

At `cleanup:`, the response is only written under `if (ret == 0)`. With `ret` still negative, the successful verify result (`res.res`) is never written, `*outSize` is left unset, and the function returns the negative error. Net effect: a **successful** ECDSA verify is reported to the client as a transport failure whenever the pubkey-export buffer is too small.

## Fix

Reset `ret = 0` in the error branch, matching the stated intent of the comment ("Set to 0 length" implies continue) and the symmetric success branch, which already does `ret = 0`:

```c
if (ret < 0) {
    /* Problem dumping the public key.  Set to 0 length */
    pub_size = 0;
    ret      = 0;
}
```

The verify result is then returned with a zero-length pubkey, as intended.

## Verification

Built `wh_server_crypto.c` against an installed wolfSSL (`HAVE_ECC`) with the test Makefile's `-std=c90 -Werror -Wall -Wextra`; the TU compiles clean with the fix applied.

Reported by static analysis (Fenrir finding F-154).

`[fenrir-sweep:released]`