### PR TITLE
fix: guard flash offset+size overflow

### DIFF
--- a/port/posix/posix_flash_file.c
+++ b/port/posix/posix_flash_file.c
@@ -179,7 +179,8 @@ int posixFlashFile_Read(   void* c,
 {
     posixFlashFileContext* context = c;
     if (    (context == NULL) ||
-            (offset + size > MAX_OFFSET(context))){
+            (offset > MAX_OFFSET(context)) ||
+            (size > MAX_OFFSET(context) - offset)){
         return WH_ERROR_BADARGS;
     }
 
@@ -205,7 +206,8 @@ int posixFlashFile_Program(void* c,
 {
     posixFlashFileContext* context = c;
     if (    (context == NULL) ||
-            (offset + size > MAX_OFFSET(context))){
+            (offset > MAX_OFFSET(context)) ||
+            (size > MAX_OFFSET(context) - offset)){
         return WH_ERROR_BADARGS;
     }
 
@@ -242,7 +244,8 @@ int posixFlashFile_Verify( void* c,
     uint32_t data_offset = 0;
 
     if (    (context == NULL) ||
-            (offset + size > MAX_OFFSET(context))){
+            (offset > MAX_OFFSET(context)) ||
+            (size > MAX_OFFSET(context) - offset)){
         return WH_ERROR_BADARGS;
     }
 
@@ -278,7 +281,8 @@ int posixFlashFile_Erase(void* c,
 {
     posixFlashFileContext* context = c;
     if (    (context == NULL) ||
-            (offset + size > MAX_OFFSET(context))){
+            (offset > MAX_OFFSET(context)) ||
+            (size > MAX_OFFSET(context) - offset)){
         return WH_ERROR_BADARGS;
     }
 
@@ -314,7 +318,8 @@ int posixFlashFile_BlankCheck(void* c,
     uint32_t this_size = 0;
 
     if (    (context == NULL) ||
-            (offset + size > MAX_OFFSET(context))){
+            (offset > MAX_OFFSET(context)) ||
+            (size > MAX_OFFSET(context) - offset)){
         return WH_ERROR_BADARGS;
     }
 


### PR DESCRIPTION
## Bug

In `port/posix/posix_flash_file.c`, the bounds check in `posixFlashFile_Read`, `_Program`, `_Erase`, `_Verify`, and `_BlankCheck` (lines 182, 208, 245, 281, 317 on master) is:

```c
(offset + size > MAX_OFFSET(context))
```

`offset`, `size`, and `partition_size` are all `uint32_t` (posix_flash_file.h:38-40), and `MAX_OFFSET(context)` is `partition_size * 2`, also `uint32_t`. The addition `offset + size` is 32-bit unsigned and wraps at 2^32. A caller passing a large `offset` with a `size` that makes the sum wrap below `MAX_OFFSET` bypasses the check and proceeds into `pread`/`pwrite`/erase with an out-of-range offset. These functions are unconditionally compiled (no build guard).

## Fix

Replace the single overflow-prone comparison with an overflow-safe two-part guard at all 5 sites:

```c
(offset > MAX_OFFSET(context)) ||
(size > MAX_OFFSET(context) - offset)
```

Checking `offset > MAX_OFFSET` first ensures `MAX_OFFSET - offset` cannot underflow before the second comparison, so both the wrap-around and the offset-alone-out-of-range cases are rejected.

## Verification

Built the port file on Ubuntu 24.04 with gcc -Wall (BUILD_OK). Ran a harness against the real `posixFlashFile_Read` with `partition_size=0x1000` (MAX_OFFSET=0x2000):
- `offset=0xFFFFF000, size=0x2000` (true sum 0x100001000, wraps to 0x1000): before the fix the check passed and the function proceeded; after the fix it returns `WH_ERROR_BADARGS`.
- `offset=0x3000, size=0x10` (offset alone out of range): returns `WH_ERROR_BADARGS` (confirms no underflow regression).
- `offset=0, size=8` (in bounds): returns OK.

Reported by static analysis (Fenrir finding F-133).

`[fenrir-sweep:released]`