### PR TITLE
fix: force-zero key cache on server cleanup

### DIFF
--- a/src/wh_server.c
+++ b/src/wh_server.c
@@ -51,6 +51,7 @@
 
 /* Server API's */
 #include "wolfhsm/wh_server.h"
+#include "wolfhsm/wh_utils.h"
 #include "wolfhsm/wh_server_nvm.h"
 #ifdef WOLFHSM_CFG_ENABLE_AUTHENTICATION
 #include "wolfhsm/wh_auth.h"
@@ -190,7 +191,7 @@ int wh_Server_Cleanup(whServerContext* server)
     (void)wh_Log_Cleanup(&server->log);
 #endif /* WOLFHSM_CFG_LOGGING */
 
-    memset(server, 0, sizeof(*server));
+    wh_Utils_ForceZero(server, sizeof(*server));
 
     return WH_ERROR_OK;
 }


### PR DESCRIPTION
wh_Server_Cleanup() ends by wiping the whole server context with plain memset(server, 0, sizeof(*server)). whServerContext embeds the key cache (whKeyCacheContext localCache -> whCacheSlot/whBigCacheSlot, each holding a plaintext uint8_t buffer[] of cached key material), so this store clears sensitive key bytes. wolfHSM already uses wh_Utils_ForceZero for exactly this purpose across wh_server_she.c and wh_server_keystore.c; using plain memset here is inconsistent with that convention and is a store the compiler is permitted to reason about.

Fix: include wolfhsm/wh_utils.h and replace the memset in wh_Server_Cleanup with wh_Utils_ForceZero(server, sizeof(*server)). The matching memset in wh_Server_Init is left untouched (it zeroes an incoming, not-yet-populated context; no key material).

Verified: compiled src/wh_server.c under the POSIX test config (server enabled, crypto on) with -Werror; objdump -dr of wh_Server_Cleanup shows the call now relocates to wh_Utils_ForceZero and the memset is gone from that function.

Reported by static analysis (Fenrir finding F-131).

`[fenrir-sweep:held]`