### PR TITLE
fix: widen avail-objects count to avoid truncation

### DIFF
--- a/src/wh_nvm_flash_log.c
+++ b/src/wh_nvm_flash_log.c
@@ -555,7 +555,7 @@ int wh_NvmFlashLog_GetAvailable(void* c, uint32_t* out_avail_size,
                                 whNvmId*  out_reclaim_objects)
 {
     whNvmFlashLogContext* ctx = (whNvmFlashLogContext*)c;
-    uint8_t               count;
+    int                   count;
 
     if (ctx == NULL || !ctx->is_initialized)
         return WH_ERROR_BADARGS;


### PR DESCRIPTION
Bug: In `wh_NvmFlashLog_GetAvailable` (src/wh_nvm_flash_log.c), the local `count` was declared `uint8_t` but `nfl_ObjectCount()` returns `int`. The assignment `count = nfl_ObjectCount(ctx, NULL);` narrows int -> uint8_t. `whNvmId` is `uint16_t` and `WOLFHSM_CFG_NVM_OBJECT_COUNT` is user-overridable (default 32), so a build configured with >255 objects truncates the count. Example: 256 objects -> count wraps to 0 -> `*out_avail_objects = WOLFHSM_CFG_NVM_OBJECT_COUNT - count` reports 256 available when 0 remain. The sibling call in the same file already uses a wider type for the same function, confirming this narrowing is unintentional.

Fix: declare `count` as `int` to match `nfl_ObjectCount()`'s return type. One-line change.

Build-verified: compiled the translation unit with `-Wconversion` (with `WOLFHSM_CFG_SERVER_NVM_FLASH_LOG` defined, against a wolfSSL install). Before the fix, gcc warned `conversion from 'int' to 'uint8_t' ... may change value` at the `count =` assignment. After the fix: gcc exit 0, that warning is gone, object file and `wh_NvmFlashLog_GetAvailable` symbol produced.

Reported by static analysis (Fenrir finding 388).

`[fenrir-sweep:held]`
