### PR TITLE
fix: validate req_size in cert erasetrusted

### DIFF
--- a/src/wh_server_cert.c
+++ b/src/wh_server_cert.c
@@ -953,6 +953,15 @@ int wh_Server_HandleCertRequest(whServerContext* server, uint16_t magic,
             whMessageCert_EraseTrustedRequest req  = {0};
             whMessageCert_SimpleResponse      resp = {0};
 
+            /* Validate minimum size */
+            if (req_size < sizeof(req)) {
+                resp.rc = WH_ERROR_BADARGS;
+                wh_MessageCert_TranslateSimpleResponse(
+                    magic, &resp, (whMessageCert_SimpleResponse*)resp_packet);
+                *out_resp_size = sizeof(resp);
+                break;
+            }
+
             /* Convert request struct */
             wh_MessageCert_TranslateEraseTrustedRequest(
                 magic, (whMessageCert_EraseTrustedRequest*)req_packet, &req);


### PR DESCRIPTION
## Bug
In `wh_Server_HandleCertRequest` (src/wh_server_cert.c), the `WH_MESSAGE_CERT_ACTION_ERASETRUSTED` case calls `wh_MessageCert_TranslateEraseTrustedRequest` and then `wh_Server_CertEraseTrusted(server, req.id)` without first validating that `req_size >= sizeof(req)`. It is the lone outlier among the cert handlers: ADDTRUSTED, VERIFY, and the DMA handlers all guard request size before translating. An undersized request packet leaves `req.id` populated from stale/attacker-influenced buffer bytes, which can erase the wrong trusted NVM object. Data-integrity issue (the fixed-size translate reads within the comm buffer, so no out-of-bounds access).

## Fix
Add a minimum-size check at the top of the ERASETRUSTED case, mirroring the existing ADDTRUSTED handler: on `req_size < sizeof(req)`, set `resp.rc = WH_ERROR_BADARGS`, emit the simple response, and break. ~9 lines, no API change.

## Verification
Compiled the translation unit against a prebuilt wolfSSL install with the cert-manager + server config (`-DWOLFHSM_CFG_CERTIFICATE_MANAGER -DWOLFHSM_CFG_ENABLE_SERVER`); builds clean (exit 0).

Reported by static analysis (Fenrir finding F-267).

`[fenrir-sweep:held]`