### PR TITLE
fix: zero-init RNG DMA response struct

### DIFF
--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -8733,7 +8733,7 @@ static int _HandleRngDma(whServerContext* ctx, uint16_t magic, int devId,
 
     int                            ret = 0;
     whMessageCrypto_RngDmaRequest  req;
-    whMessageCrypto_RngDmaResponse res;
+    whMessageCrypto_RngDmaResponse res = {0};
     void*                          outAddr = NULL;
 
     if (inSize < sizeof(whMessageCrypto_RngDmaRequest)) {


### PR DESCRIPTION
## Bug
`_HandleRngDma` in `src/wh_server_crypto.c` declares its response struct `whMessageCrypto_RngDmaResponse res;` without initialization. That type is composed entirely of a 16-byte `dmaAddrStatus.badAddr` field, which is written only on the two `WH_ERROR_ACCESS` DMA-bounds-check branches. On the success path (and on any non-ACCESS error from `wc_RNG_GenerateBlock`) nothing in `res` is written, yet the full struct is unconditionally translated via `wh_MessageCrypto_TranslateRngDmaResponse` and `*outSize = sizeof(res)` (16 bytes) is returned to the client. Result: 16 bytes of indeterminate server stack are disclosed to the client on every successful RNG-DMA call.

## Fix
Zero-initialize the response struct at declaration: `whMessageCrypto_RngDmaResponse res = {0};`. One line, self-contained; eliminates the indeterminate-stack disclosure on the success and non-ACCESS-error paths.

## Verification
Reproduced against master HEAD. Compiled the translation unit with the live config (`-DWOLFHSM_CFG -DWOLFHSM_CFG_DMA`, WC_NO_RNG undefined) against a wolfSSL `--enable-all` install — clean before and after the fix (gcc -Wall -Wextra, exit 0). The handler is live: guarded by `#ifdef WOLFHSM_CFG_DMA` + `#ifndef WC_NO_RNG`, which is the config a real posix server build uses.

Reported by static analysis (Fenrir finding F-464).

`[fenrir-sweep:held]`