### PR TITLE
fix: zero-init ML-DSA keygen DMA response

### DIFF
--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -6132,7 +6132,7 @@ static int _HandleMlDsaKeyGenDma(whServerContext* ctx, uint16_t magic,
     uint16_t    keySize       = 0;
 
     whMessageCrypto_MlDsaKeyGenDmaRequest req;
-    whMessageCrypto_MlDsaKeyGenDmaResponse res;
+    whMessageCrypto_MlDsaKeyGenDmaResponse res = {0};
 
     if (inSize < sizeof(whMessageCrypto_MlDsaKeyGenDmaRequest)) {
         return WH_ERROR_BADARGS;


### PR DESCRIPTION
## Bug

In `_HandleMlDsaKeyGenDma` (src/wh_server_crypto.c), the response struct is declared uninitialized:

```c
whMessageCrypto_MlDsaKeyGenDmaResponse res;
```

Multiple error paths return before `res` is written — `_IsMlDsaLevelSupported` failure (WH_ERROR_BADARGS), `wc_MlDsaKey_Init`/`SetParams`/`MakeKey` failure, and DMA WRITE_PRE address-check failure before `res.keyId`/`res.keySize` are set. All fall through to `wh_MessageCrypto_TranslateMlDsaKeyGenDmaResponse` with `*outSize = sizeof(res)`, transmitting indeterminate stack bytes for `res.keyId`, `res.keySize`, and `res.dmaAddrStatus` to the client. (`dmaAddrStatus.badAddr` is only set on WH_ERROR_ACCESS, so it is garbage for every other error.)

## Fix

Zero-initialize the response struct at declaration:

```c
whMessageCrypto_MlDsaKeyGenDmaResponse res = {0};
```

Error paths now transmit deterministic zeros instead of stack garbage. This matches the sibling DMA handlers, e.g. `_HandleAesCtrDma` which does `memset(&res, 0, sizeof(res))` before any response send.

## Build verification

Compiled the translation unit against the standard wolfHSM server + ML-DSA + DMA config on Ubuntu 24.04:

```
gcc -c -DWOLFHSM_CFG -DWOLFHSM_CFG_ENABLE_SERVER -DWOLFHSM_CFG_DMA -DWOLFSSL_HAVE_MLDSA \
    -I. -Itest/config -I<wolfssl-install>/include src/wh_server_crypto.c
```

Exit 0, `_HandleMlDsaKeyGenDma` present as a defined text symbol.

Reported by static analysis (Fenrir finding 463).

`[fenrir-sweep:held]`
