### PR TITLE
fix: store client TLS connect callback

### DIFF
--- a/port/posix/posix_transport_tls.c
+++ b/port/posix/posix_transport_tls.c
@@ -136,6 +136,9 @@ int posixTransportTls_InitConnect(void* context, const void* config,
 
     memset(ctx, 0, sizeof(posixTransportTlsClientContext));
 
+    ctx->connectcb     = connectcb;
+    ctx->connectcb_arg = connectcb_arg;
+
     /* Create SSL context using static memory if heap_hint is provided */
 #ifdef WOLFSSL_STATIC_MEMORY
     if (cfg->heap_hint != NULL) {


### PR DESCRIPTION
Bug: `posixTransportTls_InitConnect` (client) never stores the connected-state callback into the context. After `memset(ctx, 0, ...)` it forwards `connectcb`/`connectcb_arg` only to the underlying TCP transport, leaving `ctx->connectcb` NULL. The existing NULL checks in this file then never fire on the client:

- line ~186: `if (ctx->connectcb != NULL) ctx->connectcb(..., WH_COMM_CONNECTED);`
- SendRequest ~line 276: `if (ctx->connectcb != NULL) ctx->connectcb(..., WH_COMM_DISCONNECTED);` on TLS handshake failure

So client-side connect/disconnect callbacks are silently never invoked. The server path (`posixTransportTls_InitListen`, lines 401-402) already stores these fields correctly; this brings the client into line.

Fix: store `ctx->connectcb`/`ctx->connectcb_arg` right after the memset, mirroring the server. Two lines, self-contained, no API/ABI change.

How build-verified: compiled the translation unit against a prebuilt wolfSSL install with `-DWOLFHSM_CFG_TLS` (crypto enabled); gcc exit 0, clean, and `nm -g --defined-only` confirms `posixTransportTls_InitConnect` is a live text symbol (code is compiled, not dead).

Reported by static analysis (Fenrir finding F-771).

`[fenrir-sweep:held]`