### PR TITLE
fix: prevent offset+len overflow in flash log read

### DIFF
--- a/src/wh_nvm_flash_log.c
+++ b/src/wh_nvm_flash_log.c
@@ -687,7 +687,7 @@ int wh_NvmFlashLog_Read(void* c, whNvmId id, whNvmSize offset,
     if (obj == NULL)
         return WH_ERROR_NOTFOUND;
 
-    if (offset + data_len > obj->meta.len)
+    if ((uint32_t)offset + (uint32_t)data_len > obj->meta.len)
         return WH_ERROR_BADARGS;
 
     obj_data = (uint8_t*)obj + sizeof(whNvmFlashLogMetadata) + offset;


### PR DESCRIPTION
## Bug

In `wh_NvmFlashLog_Read` (`src/wh_nvm_flash_log.c:690`), the bounds check

```c
if (offset + data_len > obj->meta.len)
```

adds two `whNvmSize` (`uint16_t`) values. On a platform where `int` is 16 bits (standards-permissible; C only guarantees `int >= 16` bits), the addition wraps modulo 65536. A crafted `offset=0xFFFF, data_len=11` against a 10-byte object wraps to 10, passes the check, and the subsequent `memcpy(data, obj_data, data_len)` at line 693 reads out of bounds.

On mainstream >=32-bit-int targets (e.g. ARM Cortex-M) integer promotion computes the sum in 32-bit `int`, so it does not wrap there — this is a latent portability / defense-in-depth defect for 16-bit-int embedded targets.

## Fix

Force 32-bit arithmetic with explicit casts so the sum never wraps regardless of `int` width:

```c
if ((uint32_t)offset + (uint32_t)data_len > obj->meta.len)
```

This mirrors the already-remediated sibling check in `src/wh_server_nvm.c` (which avoids the addition via subtraction).

## Build verification

Compiled the changed translation unit on Ubuntu 24.04 / gcc (32-bit int) against the repo's own test config (`test/config/wolfhsm_cfg.h`, `-DWOLFHSM_CFG`) linked to a prebuilt wolfSSL install: `gcc_exit=0`, no warnings.

Reported by static analysis (Fenrir finding 389).

`[fenrir-sweep:held]`
