### PR TITLE
Validate SHE client response payload size before use

### DIFF
--- a/src/wh_client_she.c
+++ b/src/wh_client_she.c
@@ -86,7 +86,7 @@ int wh_Client_SheSetUidResponse(whClientContext* c)
 {
     uint16_t group;
     uint16_t action;
-    uint16_t dataSz;
+    uint16_t dataSz = 0;
     int ret;
     whMessageShe_SetUidResponse *resp = NULL;
 
@@ -97,6 +97,9 @@ int wh_Client_SheSetUidResponse(whClientContext* c)
     resp = (whMessageShe_SetUidResponse*)wh_CommClient_GetDataPtr(c->comm);
     ret  = wh_Client_RecvResponse(c, &group, &action, &dataSz,
                                   WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    if (ret == WH_ERROR_OK && dataSz < sizeof(*resp)) {
+        ret = WH_ERROR_ABORTED;
+    }
     if (ret == WH_ERROR_OK) {
         ret = resp->rc;
     }
@@ -122,7 +125,7 @@ int wh_Client_SheSecureBoot(whClientContext* c, uint8_t* bootloader,
     uint32_t bootloaderSent = 0;
     uint16_t group;
     uint16_t action;
-    uint16_t dataSz;
+    uint16_t dataSz = 0;
     uint8_t* respBuf;
 
     whMessageShe_SecureBootInitRequest*    initReq    = NULL;
@@ -151,6 +154,9 @@ int wh_Client_SheSecureBoot(whClientContext* c, uint8_t* bootloader,
                                               WOLFHSM_CFG_COMM_DATA_LEN, respBuf);
             initResp = (whMessageShe_SecureBootInitResponse*)respBuf;
         } while (ret == WH_ERROR_NOTREADY);
+        if (ret == WH_ERROR_OK && dataSz < sizeof(*initResp)) {
+            ret = WH_ERROR_ABORTED;
+        }
     }
 
     /* send update sub command until we've sent the entire bootloader */
@@ -188,6 +194,10 @@ int wh_Client_SheSecureBoot(whClientContext* c, uint8_t* bootloader,
                     wh_Client_RecvResponse(c, &group, &action, &dataSz,
                                            WOLFHSM_CFG_COMM_DATA_LEN, respBuf);
             } while (ret == WH_ERROR_NOTREADY);
+            if (ret == WH_ERROR_OK &&
+                dataSz < sizeof(whMessageShe_SecureBootUpdateResponse)) {
+                ret = WH_ERROR_ABORTED;
+            }
         }
 
         /* increment sent  */
@@ -208,6 +218,9 @@ int wh_Client_SheSecureBoot(whClientContext* c, uint8_t* bootloader,
                                                 WOLFHSM_CFG_COMM_DATA_LEN, respBuf);
             finishResp = (whMessageShe_SecureBootFinishResponse*)respBuf;
         } while (ret == WH_ERROR_NOTREADY);
+        if (ret == WH_ERROR_OK && dataSz < sizeof(*finishResp)) {
+            ret = WH_ERROR_ABORTED;
+        }
     }
 
     if (ret == 0) {
@@ -235,7 +248,7 @@ int wh_Client_SheGetStatusResponse(whClientContext* c, uint8_t* sreg)
 {
     uint16_t group;
     uint16_t action;
-    uint16_t dataSz;
+    uint16_t dataSz = 0;
     int ret;
     whMessageShe_GetStatusResponse *resp = NULL;
 
@@ -247,6 +260,9 @@ int wh_Client_SheGetStatusResponse(whClientContext* c, uint8_t* sreg)
 
     ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    if (ret == WH_ERROR_OK && dataSz < sizeof(*resp)) {
+        ret = WH_ERROR_ABORTED;
+    }
 
     /* return error or set sreg */
     if (ret == 0) {
@@ -301,7 +317,7 @@ int wh_Client_SheLoadKeyResponse(whClientContext* c, uint8_t* messageFour,
     int                           ret;
     uint16_t                      group;
     uint16_t                      action;
-    uint16_t                      dataSz;
+    uint16_t                      dataSz = 0;
     whMessageShe_LoadKeyResponse* resp = NULL;
 
     if (c == NULL || messageFour == NULL || messageFive == NULL) {
@@ -312,6 +328,9 @@ int wh_Client_SheLoadKeyResponse(whClientContext* c, uint8_t* messageFour,
 
     ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    if (ret == WH_ERROR_OK && dataSz < sizeof(*resp)) {
+        ret = WH_ERROR_ABORTED;
+    }
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;
@@ -361,7 +380,7 @@ int wh_Client_SheLoadPlainKeyResponse(whClientContext* c)
     int                                ret;
     uint16_t                           group;
     uint16_t                           action;
-    uint16_t                           dataSz;
+    uint16_t                           dataSz = 0;
     whMessageShe_LoadPlainKeyResponse* resp = NULL;
 
     if (c == NULL) {
@@ -373,6 +392,9 @@ int wh_Client_SheLoadPlainKeyResponse(whClientContext* c)
 
     ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    if (ret == WH_ERROR_OK && dataSz < sizeof(*resp)) {
+        ret = WH_ERROR_ABORTED;
+    }
     if (ret == 0) {
         ret = resp->rc;
     }
@@ -411,7 +433,7 @@ int wh_Client_SheExportRamKeyResponse(whClientContext* c, uint8_t* messageOne,
     int                                ret;
     uint16_t                           group;
     uint16_t                           action;
-    uint16_t                           dataSz;
+    uint16_t                           dataSz = 0;
     whMessageShe_ExportRamKeyResponse* resp = NULL;
 
     if (c == NULL || messageOne == NULL || messageTwo == NULL ||
@@ -424,6 +446,9 @@ int wh_Client_SheExportRamKeyResponse(whClientContext* c, uint8_t* messageOne,
 
     ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    if (ret == WH_ERROR_OK && dataSz < sizeof(*resp)) {
+        ret = WH_ERROR_ABORTED;
+    }
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;
@@ -472,7 +497,7 @@ int wh_Client_SheInitRndResponse(whClientContext* c)
     int ret;
     uint16_t group;
     uint16_t action;
-    uint16_t dataSz;
+    uint16_t dataSz = 0;
     whMessageShe_InitRngResponse* resp = NULL;
 
     if (c == NULL) {
@@ -482,6 +507,9 @@ int wh_Client_SheInitRndResponse(whClientContext* c)
     resp = (whMessageShe_InitRngResponse*)wh_CommClient_GetDataPtr(c->comm);
     ret  = wh_Client_RecvResponse(c, &group, &action, &dataSz,
                                   WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    if (ret == WH_ERROR_OK && dataSz < sizeof(*resp)) {
+        ret = WH_ERROR_ABORTED;
+    }
     if (ret == 0) {
         ret = resp->rc;
     }
@@ -515,7 +543,7 @@ int wh_Client_SheRndResponse(whClientContext* c, uint8_t* out, uint32_t* outSz)
     int ret;
     uint16_t group;
     uint16_t action;
-    uint16_t dataSz;
+    uint16_t dataSz = 0;
     whMessageShe_RndResponse* resp = NULL;
 
     if (c == NULL || out == NULL || outSz == NULL || *outSz < WH_SHE_KEY_SZ) {
@@ -526,6 +554,9 @@ int wh_Client_SheRndResponse(whClientContext* c, uint8_t* out, uint32_t* outSz)
 
     ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    if (ret == WH_ERROR_OK && dataSz < sizeof(*resp)) {
+        ret = WH_ERROR_ABORTED;
+    }
 
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR)
@@ -577,7 +608,7 @@ int wh_Client_SheExtendSeedResponse(whClientContext* c)
     int                              ret;
     uint16_t                         group;
     uint16_t                         action;
-    uint16_t                         dataSz;
+    uint16_t                         dataSz = 0;
     whMessageShe_ExtendSeedResponse* resp = NULL;
 
     if (c == NULL) {
@@ -587,6 +618,9 @@ int wh_Client_SheExtendSeedResponse(whClientContext* c)
     resp = (whMessageShe_ExtendSeedResponse*)wh_CommClient_GetDataPtr(c->comm);
     ret  = wh_Client_RecvResponse(c, &group, &action, &dataSz,
                                   WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    if (ret == WH_ERROR_OK && dataSz < sizeof(*resp)) {
+        ret = WH_ERROR_ABORTED;
+    }
 
     if (ret == 0) {
         ret = resp->rc;
@@ -636,7 +670,7 @@ int wh_Client_SheEncEcbResponse(whClientContext* c, uint8_t* out, uint32_t sz)
     int                          ret;
     uint16_t                     group;
     uint16_t                     action;
-    uint16_t                     dataSz;
+    uint16_t                     dataSz = 0;
     uint8_t*                     packOut;
     whMessageShe_EncEcbResponse* resp = NULL;
 
@@ -652,8 +686,14 @@ int wh_Client_SheEncEcbResponse(whClientContext* c, uint8_t* out, uint32_t sz)
     ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
-        if (resp->rc != WH_SHE_ERC_NO_ERROR) {
+        if (dataSz < sizeof(*resp)) {
+            ret = WH_ERROR_ABORTED;
+        }
+        else if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;
+        }
+        else if (resp->sz > (dataSz - sizeof(*resp))) {
+            ret = WH_ERROR_ABORTED;
         }
         else if (sz < resp->sz) {
             ret = WH_ERROR_BADARGS;
@@ -710,7 +750,7 @@ int wh_Client_SheEncCbcResponse(whClientContext* c, uint8_t* out, uint32_t sz)
     int                          ret;
     uint16_t                     group;
     uint16_t                     action;
-    uint16_t                     dataSz;
+    uint16_t                     dataSz = 0;
     uint8_t*                     packOut;
     whMessageShe_EncCbcResponse* resp = NULL;
 
@@ -725,8 +765,14 @@ int wh_Client_SheEncCbcResponse(whClientContext* c, uint8_t* out, uint32_t sz)
     ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
-        if (resp->rc != WH_SHE_ERC_NO_ERROR) {
+        if (dataSz < sizeof(*resp)) {
+            ret = WH_ERROR_ABORTED;
+        }
+        else if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;
+        }
+        else if (resp->sz > (dataSz - sizeof(*resp))) {
+            ret = WH_ERROR_ABORTED;
         }
         else if (sz < resp->sz) {
             ret = WH_ERROR_BADARGS;
@@ -779,7 +825,7 @@ int wh_Client_SheDecEcbResponse(whClientContext* c, uint8_t* out, uint32_t sz)
     int                          ret;
     uint16_t                     group;
     uint16_t                     action;
-    uint16_t                     dataSz;
+    uint16_t                     dataSz = 0;
     uint8_t*                     packOut;
     whMessageShe_DecEcbResponse* resp = NULL;
 
@@ -794,8 +840,14 @@ int wh_Client_SheDecEcbResponse(whClientContext* c, uint8_t* out, uint32_t sz)
     ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
-        if (resp->rc != WH_SHE_ERC_NO_ERROR) {
+        if (dataSz < sizeof(*resp)) {
+            ret = WH_ERROR_ABORTED;
+        }
+        else if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;
+        }
+        else if (resp->sz > (dataSz - sizeof(*resp))) {
+            ret = WH_ERROR_ABORTED;
         }
         else if (sz < resp->sz) {
             ret = WH_ERROR_BADARGS;
@@ -852,7 +904,7 @@ int wh_Client_SheDecCbcResponse(whClientContext* c, uint8_t* out, uint32_t sz)
     int                          ret;
     uint16_t                     group;
     uint16_t                     action;
-    uint16_t                     dataSz;
+    uint16_t                     dataSz = 0;
     uint8_t*                     packOut;
     whMessageShe_DecCbcResponse* resp = NULL;
 
@@ -867,8 +919,14 @@ int wh_Client_SheDecCbcResponse(whClientContext* c, uint8_t* out, uint32_t sz)
     ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
-        if (resp->rc != WH_SHE_ERC_NO_ERROR) {
+        if (dataSz < sizeof(*resp)) {
+            ret = WH_ERROR_ABORTED;
+        }
+        else if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;
+        }
+        else if (resp->sz > (dataSz - sizeof(*resp))) {
+            ret = WH_ERROR_ABORTED;
         }
         else if (sz < resp->sz) {
             ret = WH_ERROR_BADARGS;
@@ -923,7 +981,7 @@ int wh_Client_SheGenerateMacResponse(whClientContext* c, uint8_t* out,
     int                          ret;
     uint16_t                     group;
     uint16_t                     action;
-    uint16_t                     dataSz;
+    uint16_t                     dataSz = 0;
     whMessageShe_GenMacResponse* resp = NULL;
 
     if (c == NULL || out == NULL || sz < WH_SHE_KEY_SZ) {
@@ -934,6 +992,9 @@ int wh_Client_SheGenerateMacResponse(whClientContext* c, uint8_t* out,
 
     ret = wh_Client_RecvResponse(c, &group, &action, &dataSz,
                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    if (ret == WH_ERROR_OK && dataSz < sizeof(*resp)) {
+        ret = WH_ERROR_ABORTED;
+    }
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;
@@ -997,7 +1058,7 @@ int wh_Client_SheVerifyMacResponse(whClientContext* c, uint8_t* outStatus)
     int                             ret;
     uint16_t                        group;
     uint16_t                        action;
-    uint16_t                        dataSz;
+    uint16_t                        dataSz = 0;
     whMessageShe_VerifyMacResponse* resp = NULL;
 
     if (c == NULL || outStatus == NULL) {
@@ -1007,6 +1068,9 @@ int wh_Client_SheVerifyMacResponse(whClientContext* c, uint8_t* outStatus)
     resp = (whMessageShe_VerifyMacResponse*)wh_CommClient_GetDataPtr(c->comm);
     ret  = wh_Client_RecvResponse(c, &group, &action, &dataSz,
                                   WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
+    if (ret == WH_ERROR_OK && dataSz < sizeof(*resp)) {
+        ret = WH_ERROR_ABORTED;
+    }
     if (ret == 0) {
         if (resp->rc != WH_SHE_ERC_NO_ERROR) {
             ret = resp->rc;


### PR DESCRIPTION
### Problem

The SHE client response helpers read `resp->rc`, `resp->sz`, and payload bytes
without first checking that the server actually returned enough data. Fourteen
handlers across `src/wh_client_she.c` follow this pattern (f-5466, CWE-1284,
Medium).

SHE reads its response **in place** from the shared comm buffer — every handler
passes `wh_CommClient_GetDataPtr(c->comm)`, which returns `context->data`. That
aliasing short-circuits the payload-size check added in `wh_CommClient_RecvResponse`:

```c
if ((data != NULL) && (payload_size != 0) && (data != context->data)) {
    if (payload_size > data_size) { rc = WH_ERROR_BUFFER_SIZE; }
```

So for SHE the length is never validated in any layer. On a short response the
fields past `payload_size` are leftover bytes from the *previous* message: a
stale `rc` reading as `WH_SHE_ERC_NO_ERROR` turns a failed operation into an
apparent success, and the ECB/CBC helpers would trust a stale `resp->sz` when
copying out.

### Fix (`src/wh_client_she.c`)

Every `wh_Client_RecvResponse()` call site (17 across the 14 handlers) now
validates the payload before any field is read:

- **Minimum size** — `dataSz < sizeof(*resp)` fails with `WH_ERROR_ABORTED`.
- **Variable-length payloads** — the four ECB/CBC enc/dec helpers additionally
  require `resp->sz > (dataSz - sizeof(*resp))` to fail, ordered *after* the
  minimum-size guard so the subtraction cannot wrap.
- `dataSz` is initialized to `0` so an untouched value can't read as valid.

**Not included, by design:** per-handler group/action checks. The finding also
recommends validating `WH_MESSAGE_GROUP_SHE` and the expected action, but
`wh_Client_RecvResponse()` already rejects any response whose `resp_kind`
differs from `c->last_req_kind`, and `kind = WH_MESSAGE_KIND(group, action)` —
both are covered for every caller. Duplicating that per handler would be
unreachable code.

Closes f-5466.

### Verification

- Clean build with `make SHE=1` under `-std=c90 -Werror -Wall -Wextra -Wpointer-arith`.
- Full suite `rc=0`; SHE coverage all SUCCESS — secure boot (incl. boundary),
  LoadKey + UID checks, RND, ECB/CBC/CMAC, keywrap interop, write protect,
  wrapped-key reboot interop, NVM-less flows.
- No sanitizer run: the diff adds only size comparisons and early error returns,
  which is not the memory/UB class.

No negative test injecting a truncated SHE response is included — the in-tree
harness has no fault-injecting transport for this path.