### PR TITLE
Reject NULL metadata in checked NVM add path

### DIFF
--- a/src/wh_nvm.c
+++ b/src/wh_nvm.c
@@ -275,6 +275,10 @@ int wh_Nvm_AddObjectChecked(whNvmContext* context, const whNvmMetadata* meta,
     int           ret;
     whNvmMetadata sanitized;
 
+    if (meta == NULL) {
+        return WH_ERROR_BADARGS;
+    }
+
     ret = wh_Nvm_CheckPolicy(context, WH_NVM_OP_ADD, meta->id, NULL);
     if (ret != WH_ERROR_OK && ret != WH_ERROR_NOTFOUND) {
         return ret;

--- a/src/wh_server_nvm.c
+++ b/src/wh_server_nvm.c
@@ -394,6 +394,13 @@ int wh_Server_HandleNvmRequest(whServerContext* server,
             }
         }
         if (resp.rc == 0) {
+            /* A permit-all DMA config passes a zero metadata address through
+             * untouched, so reject it before it reaches the NVM layer. */
+            if (metadata == NULL) {
+                resp.rc = WH_ERROR_BADARGS;
+            }
+        }
+        if (resp.rc == 0) {
 #if !defined(WOLFHSM_CFG_NO_CRYPTO) && \
     (defined(WOLFSSL_HAVE_LMS) || defined(WOLFSSL_HAVE_XMSS))
             /* Block direct NVM import of stateful (LMS/XMSS) private key state;

--- a/test-refactor/client-server/wh_test_nvm_ops.c
+++ b/test-refactor/client-server/wh_test_nvm_ops.c
@@ -457,9 +457,44 @@ static const WhNvmTestObjectOps g_dmaTestOps = {
 };
 
 
+/* A zero DMA address passes through the permit-all DMA config untouched,
+ * so the server must reject it, not dereference it. */
+static int _whTest_NvmDmaNullAddrs(whClientContext* ctx)
+{
+    whNvmMetadata meta      = {0};
+    int32_t       server_rc = 0;
+    uint32_t      client_id = 0;
+    uint32_t      server_id = 0;
+
+    WH_TEST_RETURN_ON_FAIL(wh_Client_NvmInit(
+        ctx, &server_rc, &client_id, &server_id));
+    WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_OK);
+
+    /* Zero metadata address */
+    WH_TEST_RETURN_ON_FAIL(wh_Client_NvmAddObjectDma(
+        ctx, NULL, 0, NULL, &server_rc));
+    WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_BADARGS);
+
+    /* Valid metadata, but a zero data address with a non-zero length.
+     * The NVM backend rejects this rather than reading through it. */
+    meta.id     = NVM_TEST_DMA_ID_BASE;
+    meta.access = WH_NVM_ACCESS_ANY;
+    meta.flags  = WH_NVM_FLAGS_NONE;
+    WH_TEST_RETURN_ON_FAIL(wh_Client_NvmAddObjectDma(
+        ctx, &meta, sizeof(meta), NULL, &server_rc));
+    WH_TEST_ASSERT_RETURN(server_rc == WH_ERROR_BADARGS);
+
+    return WH_ERROR_OK;
+}
+
+
 int whTest_NvmDma(whClientContext* ctx)
 {
-    return _runNvmObjectTest(ctx, &g_dmaTestOps, NVM_TEST_DMA_ID_BASE);
+    WH_TEST_RETURN_ON_FAIL(
+        _runNvmObjectTest(ctx, &g_dmaTestOps, NVM_TEST_DMA_ID_BASE));
+    WH_TEST_RETURN_ON_FAIL(_whTest_NvmDmaNullAddrs(ctx));
+
+    return WH_ERROR_OK;
 }
 
 #endif /* WOLFHSM_CFG_DMA */


### PR DESCRIPTION
# Fix NULL metadata dereference in the DMA NVM add path

Fixes F-6789.

## Problem

`wh_Nvm_AddObjectChecked` dereferenced its `meta` argument twice before
validating it: once for `meta->id` when calling `wh_Nvm_CheckPolicy`, and
again for the `sanitized = *meta` copy that strips server-only flags.

That pointer is client-controlled on the DMA path. The `ADDOBJECTDMA`
handler in `wh_Server_HandleNvmRequest` obtains it from
`wh_Server_DmaProcessClientAddress`, which defaults the transformed
address to the raw client address and returns it unchanged when no DMA
callback and no DMA allowlist are registered. That permit-all setup is a
supported configuration, and 0 is a valid DMA address, so a client that
sends `metadata_hostaddr == 0` crashed the server with a NULL dereference.

The client API does not prevent this either: `wh_Client_NvmAddObjectDma`
accepts a NULL metadata pointer and forwards a zero `metadata_hostaddr`.

The other two callers of `wh_Nvm_AddObjectChecked` pass stack addresses,
so only the DMA path was affected.

## Fix

Two layers:

- `wh_Nvm_AddObjectChecked` returns `WH_ERROR_BADARGS` when `meta` is
  NULL, matching the validation `wh_NvmFlash_AddObject` and
  `wh_NvmFlashLog_AddObject` already perform.
- The `ADDOBJECTDMA` handler rejects a NULL transformed metadata pointer
  at the boundary. This is defense in depth: it short-circuits before
  taking the NVM lock and before the LMS/XMSS stateful-blob scan, and it
  makes the handler's contract explicit. The check sits after both DMA
  pre-operations so the matching post-operation cleanup still runs on the
  rejection path.

The data pointer is deliberately not checked at the boundary. Both NVM
backends already reject `data == NULL` with a non-zero length, and
`wh_Crypto_IsStatefulSigPrivBlob` NULL-checks its buffer, so a boundary
check there could never change the outcome and would be unreachable by
any test.

## Testing

`_whTest_NvmDmaNullAddrs` is added to the existing `whTest_NvmDma` entry
point in `test-refactor/client-server/wh_test_nvm_ops.c`. It sends a zero
metadata DMA address and expects `WH_ERROR_BADARGS`, and also sends a
valid metadata pointer with a zero data address and a non-zero length to
pin the backend rejection. The POSIX test port registers neither a DMA
callback nor an allowlist, so it reproduces the vulnerable permit-all
configuration directly.

Before the fix the suite died with SIGSEGV inside `whTest_NvmDma`. After:

- `cd test-refactor && make check DMA=1` — 41 passed, 21 skipped, 0 failed
- `cd test-refactor && make check` — 41 passed, 21 skipped, 0 failed
- `cd test && make DMA=1 && make run` — exit 0