### PR TITLE
Check RNG response length before copying inline payload

### DIFF
--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -256,11 +256,13 @@ int wh_Client_RngGenerateResponse(whClientContext* ctx, uint8_t* out,
 
     ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_RNG, (uint8_t**)&res);
     if (ret == WH_ERROR_OK) {
-        if (res->sz > WH_MESSAGE_CRYPTO_RNG_MAX_INLINE_SZ ||
+        const uint32_t hdr_sz =
+            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
+        /* Reject a size the received message does not actually carry, or that
+         * exceeds the inline cap or the caller's buffer. */
+        if (res_len < hdr_sz || res->sz > (res_len - hdr_sz) ||
+            res->sz > WH_MESSAGE_CRYPTO_RNG_MAX_INLINE_SZ ||
             res->sz > *inout_size) {
-            /* Server returned more than the inline cap or the caller's buffer
-             * can hold. Guard the inline cap first to avoid reading past the
-             * comm buffer on a malformed response. */
             ret = WH_ERROR_ABORTED;
         }
         else {
@@ -399,6 +401,15 @@ int wh_Client_RngGenerateDmaResponse(whClientContext* ctx)
         ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_RNG, (uint8_t**)&resp);
         /* On success, server has written random bytes directly to client
          * memory — nothing else to copy. */
+        if (ret == WH_ERROR_OK) {
+            const uint32_t hdr_sz =
+                sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*resp);
+            /* Nothing here is read inline; the bound just holds a success rc
+             * to a full response (an error reply carries only the header). */
+            if (respSz < hdr_sz) {
+                ret = WH_ERROR_ABORTED;
+            }
+        }
     }
 
     /* POST DMA cleanup using stashed addresses (runs on every non-NOTREADY


### PR DESCRIPTION
### Problem

`wh_Client_RngGenerateResponse` validated the server-reported size against the inline cap (`WH_MESSAGE_CRYPTO_RNG_MAX_INLINE_SZ`) and the caller's buffer, but never against `res_len` — the length of the frame actually received. A truncated or malformed OK response could set `sz` past what the frame delivered, making the client `memcpy` stale comm-buffer bytes and hand them back as random data. Every other inline-copy handler in `wh_client_crypto.c` (AES-CTR/ECB/CBC/GCM, ECC, Curve25519, Ed25519, RSA, CMAC) already performed this check; RNG was the last one missing it.

The DMA variant copies nothing inline, so it had no read exposure, but it equally never confirmed that a success reply was backed by a full response frame.

### Fix (`src/wh_client_crypto.c`)

- **`wh_Client_RngGenerateResponse`** derives `hdr_sz` from the generic response header plus `whMessageCrypto_RngResponse` and rejects when `res_len < hdr_sz || res->sz > (res_len - hdr_sz)`. The first term also prevents the unsigned underflow in the second.
- **`wh_Client_RngGenerateDmaResponse`** rejects a success reply whose frame is shorter than that same header pair. This is defense in depth, not an out-of-bounds fix: no field of the DMA response is read inline today, so the check pins the frame to the protocol contract for future readers. Error replies legitimately carry only the generic header and are unaffected, since the check sits behind the rc gate.

Addressed by f_5460. This PR is now **source-only**.

### Tests

**The test added by the earlier revision has been removed.** It was
`test-refactor/misc/wh_test_client_malformed_resp.c` (319 lines), which paired a
real client with a raw `whCommServer` so it could emit frames a real server never
emits. Per review, a test reachable only through a fake transport or a hand-built
packet is testing the harness, not the fix, so it and its `wh_test_list.c` entry
are dropped. This also removes the add/add conflict with #473/#474/#475/#476,
which each created the same file.

No replacement test is added here: the guard rejects a frame shape the normal
`wh_Client_*` API cannot produce against a conforming server, so there is no
client-driven case that reaches it.

### Verification

- `test-refactor`: default 37 passed / 25 skipped / 0 failed of 62 · `DMA=1` 41/21/0 · `SHE=1` 43/19/0
- Legacy `test/` suite clean.
- Clean under `-std=c90 -Werror -Wall -Wextra`.
- The guard itself was previously negative-controlled: removing only
  `res_len < hdr_sz ||` lets the short-frame case through, since the subtraction
  underflows and the copy proceeds.
