### PR TITLE
Validate crypto keygen responses against the received frame length

### DIFF
--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -3861,6 +3861,14 @@ static int _Ed25519MakeKey(whClientContext* ctx, whKeyId* inout_key_id,
     ret =
         _getCryptoResponse(dataPtr, WC_PK_TYPE_ED25519_KEYGEN, (uint8_t**)&res);
     if (ret >= 0) {
+        const size_t hdr_sz =
+            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
+
+        /* Defensive bound: res->outSz must fit within the received frame */
+        if (res_len < hdr_sz || res->outSz > (res_len - hdr_sz)) {
+            return WH_ERROR_ABORTED;
+        }
+
         key_id = (whKeyId)res->keyId;
         if (inout_key_id != NULL) {
             *inout_key_id = key_id;
@@ -3873,11 +3881,6 @@ static int _Ed25519MakeKey(whClientContext* ctx, whKeyId* inout_key_id,
             if (res->outSz > 0) {
                 uint8_t* out   = (uint8_t*)(res + 1);
                 uint16_t outSz = (uint16_t)res->outSz;
-                if (outSz + sizeof(whMessageCrypto_GenericResponseHeader) +
-                        sizeof(*res) >
-                    WOLFHSM_CFG_COMM_DATA_LEN) {
-                    return WH_ERROR_ABORTED;
-                }
                 ret = wh_Crypto_Ed25519DeserializeKeyDer(out, outSz, key);
             }
             else {


### PR DESCRIPTION
### Problem
`_Ed25519MakeKey()` validated the server-declared `res->outSz` against
`WOLFHSM_CFG_COMM_DATA_LEN` — the compile-time size of the comm buffer —
rather than against the number of bytes actually received. A malicious or
malfunctioning server could return a short frame (e.g. generic header only)
while declaring a large `outSz`; the client then deserialized stale
comm-buffer bytes as Ed25519 key material. The same frame also left
`res->keyId` and `res->outSz` read from beyond the received data.

### Fix (`src/wh_client_crypto.c`)
Bound the response against `res_len`, the length reported by
`wh_Client_RecvResponse()`, before any field of the response struct is read:

```c
const size_t hdr_sz =
    sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);

/* Defensive bound: res->outSz must fit within the received frame */
if (res_len < hdr_sz || res->outSz > (res_len - hdr_sz)) {
    return WH_ERROR_ABORTED;
}
```

- **`res_len < hdr_sz`** rejects frames too short to hold the response struct,
  and is evaluated first so the subtraction cannot wrap.
- **Placed ahead of the field reads**, so `res->keyId` is no longer read from a
  frame that never arrived. The removed check sat inside
  `if (key != NULL) { if (res->outSz > 0) {`, so it never ran on the
  cache-only path.

This matches the equivalent checks already on `main` in `_HkdfMakeKey()` and
`_CmacKdfMakeKey()`.

Closes f-5461.

### Verification
- Rebased onto `main`. Builds clean under `-Werror -Wall -Wextra`.
- `test-refactor` suite: 45 passed, 26 skipped, 0 failed of 71.