### PR TITLE
Validate inSize before translating fixed crypto requests

### DIFF
--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -1390,12 +1390,14 @@ static int _HandleEccKeyGen(whServerContext* ctx, uint16_t magic, int devId,
                             const void* cryptoDataIn, uint16_t inSize,
                             void* cryptoDataOut, uint16_t* outSize)
 {
-    (void)inSize;
-
     int                               ret = WH_ERROR_OK;
     ecc_key                           key[1];
     whMessageCrypto_EccKeyGenRequest  req;
     whMessageCrypto_EccKeyGenResponse res;
+
+    if (inSize < sizeof(whMessageCrypto_EccKeyGenRequest)) {
+        return WH_ERROR_BADARGS;
+    }
 
     /* Translate request */
     ret = wh_MessageCrypto_TranslateEccKeyGenRequest(
@@ -2436,12 +2438,14 @@ static int _HandleCurve25519KeyGen(whServerContext* ctx, uint16_t magic,
                                    uint16_t inSize, void* cryptoDataOut,
                                    uint16_t* outSize)
 {
-    (void)inSize;
-
     int                                      ret = WH_ERROR_OK;
     curve25519_key                           key[1];
     whMessageCrypto_Curve25519KeyGenRequest  req;
     whMessageCrypto_Curve25519KeyGenResponse res;
+
+    if (inSize < sizeof(whMessageCrypto_Curve25519KeyGenRequest)) {
+        return WH_ERROR_BADARGS;
+    }
 
     /* Translate request */
     ret = wh_MessageCrypto_TranslateCurve25519KeyGenRequest(
@@ -2685,12 +2689,14 @@ static int _HandleEd25519KeyGen(whServerContext* ctx, uint16_t magic, int devId,
                                 const void* cryptoDataIn, uint16_t inSize,
                                 void* cryptoDataOut, uint16_t* outSize)
 {
-    (void)inSize;
-
     int                                   ret = WH_ERROR_OK;
     ed25519_key                           key[1];
     whMessageCrypto_Ed25519KeyGenRequest  req;
     whMessageCrypto_Ed25519KeyGenResponse res;
+
+    if (inSize < sizeof(whMessageCrypto_Ed25519KeyGenRequest)) {
+        return WH_ERROR_BADARGS;
+    }
 
     ret = wh_MessageCrypto_TranslateEd25519KeyGenRequest(
         magic, (const whMessageCrypto_Ed25519KeyGenRequest*)cryptoDataIn, &req);
@@ -5181,12 +5187,14 @@ static int _HandleMlDsaKeyGen(whServerContext* ctx, uint16_t magic, int devId,
     (void)outSize;
     return WH_ERROR_NOHANDLER;
 #else
-    (void)inSize;
-
     int                                 ret = WH_ERROR_OK;
     wc_MlDsaKey                         key[1];
     whMessageCrypto_MlDsaKeyGenRequest  req;
     whMessageCrypto_MlDsaKeyGenResponse res;
+
+    if (inSize < sizeof(whMessageCrypto_MlDsaKeyGenRequest)) {
+        return WH_ERROR_BADARGS;
+    }
 
     /* Translate the request */
     ret = wh_MessageCrypto_TranslateMlDsaKeyGenRequest(
@@ -5315,12 +5323,14 @@ static int _HandleMlDsaSign(whServerContext* ctx, uint16_t magic, int devId,
     (void)outSize;
     return WH_ERROR_NOHANDLER;
 #else
-    (void)inSize;
-
     int                                 ret;
     wc_MlDsaKey                         key[1];
     whMessageCrypto_MlDsaSignRequest    req;
     whMessageCrypto_MlDsaSignResponse   res;
+
+    if (inSize < sizeof(whMessageCrypto_MlDsaSignRequest)) {
+        return WH_ERROR_BADARGS;
+    }
 
     /* Translate the request */
     ret = wh_MessageCrypto_TranslateMlDsaSignRequest(
@@ -5339,11 +5349,7 @@ static int _HandleMlDsaSign(whServerContext* ctx, uint16_t magic, int devId,
     uint32_t options     = req.options;
     int      evict       = !!(options & WH_MESSAGE_CRYPTO_MLDSA_SIGN_OPTIONS_EVICT);
 
-    /* Validate input length against available data to prevent buffer overread
-     */
-    if (inSize < sizeof(whMessageCrypto_MlDsaSignRequest)) {
-        return WH_ERROR_BADARGS;
-    }
+    /* Validate the declared lengths against the remaining payload */
     word32 available_data = inSize - sizeof(whMessageCrypto_MlDsaSignRequest);
     if (in_len > available_data) {
         return WH_ERROR_BADARGS;
@@ -5420,6 +5426,10 @@ static int _HandleMlDsaVerify(whServerContext* ctx, uint16_t magic, int devId,
     whMessageCrypto_MlDsaVerifyRequest  req;
     whMessageCrypto_MlDsaVerifyResponse res;
 
+    if (inSize < sizeof(whMessageCrypto_MlDsaVerifyRequest)) {
+        return WH_ERROR_BADARGS;
+    }
+
     /* Translate the request */
     ret = wh_MessageCrypto_TranslateMlDsaVerifyRequest(
         magic, (whMessageCrypto_MlDsaVerifyRequest*)cryptoDataIn, &req);
@@ -5440,9 +5450,6 @@ static int _HandleMlDsaVerify(whServerContext* ctx, uint16_t magic, int devId,
     int evict = !!(options & WH_MESSAGE_CRYPTO_MLDSA_VERIFY_OPTIONS_EVICT);
 
     /* Validate lengths against available payload (overflow-safe) */
-    if (inSize < sizeof(whMessageCrypto_MlDsaVerifyRequest)) {
-        return WH_ERROR_BADARGS;
-    }
     uint32_t available = inSize - sizeof(whMessageCrypto_MlDsaVerifyRequest);
     if ((sig_len > available) || (hash_len > available) ||
         (sig_len > (available - hash_len))) {


### PR DESCRIPTION
## Summary

Four server crypto handlers translated their fixed request struct out of
`cryptoDataIn` without first proving the request was long enough to hold it.
Two more validated the length only *after* translating.

`wh_Server_HandleCryptoRequest` validates the generic header, then passes the
remaining length straight through:

```c
uint16_t cryptoInSize =
    req_size - sizeof(whMessageCrypto_GenericResponseHeader);
```

A request carrying only the generic header yields `cryptoInSize == 0`, but the
handler still reads a full struct. Since crypto requests are processed in place
in a buffer that retains the previous message, it consumes bytes left over from
an earlier request as key generation parameters.

Addressed by f_5463.

## Changes

`_HandleEccKeyGen`, `_HandleCurve25519KeyGen`, `_HandleEd25519KeyGen` and
`_HandleMlDsaKeyGen` gain the guard `_HandleRsaKeyGen` already used:

```c
if (inSize < sizeof(whMessageCrypto_XxxKeyGenRequest)) {
    return WH_ERROR_BADARGS;
}
```

`_HandleMlDsaSign` and `_HandleMlDsaVerify` keep their existing check, moved
ahead of the translate call.

Every other fixed-struct handler already validated `inSize` first, including
ECDH and Curve25519 shared secret. Impact is stale-parameter use, not a read
past the comm buffer. No API or wire format changes. This PR is now
**source-only**.

## Tests

**The test added by the earlier revision has been removed.** It was
`test-refactor/server/wh_test_crypto_reqsize.c` (449 lines,
`whTest_CryptoReqSize`), which called `wh_Server_HandleCryptoRequest` directly
with hand-built truncated buffers. Per review, a test that hand-builds a request
packet and calls a server handler is testing the harness, not the fix, so it and
its `wh_test_list.c` entry are dropped. This also removes the add/add conflict
with #487, which created the same file.

No replacement test is added: `wh_Client_*` always sends a full request struct,
so a truncated crypto request is not reachable through the normal client API.
The reproducer that motivated the fix (a header-only request replayed over a
retained buffer) is inherently a crafted frame.

## Verification

- `test-refactor`: default 37 passed / 25 skipped / 0 failed of 62 · `DMA=1` 41/21/0 · `SHE=1` 43/19/0
- Legacy `test/` suite clean.
- Clean under `-std=c90 -Werror -Wall -Wextra`, including reduced algorithm
  configs.
- The four keygen guards were previously reproducer-verified: against `main` the
  truncated requests were accepted (`ECC keygen accepted truncated request of 12
  bytes`) and the fix rejects them.
