### PR TITLE
Bound KDF response output size against received frame

### DIFF
--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -4839,6 +4839,14 @@ static int _HkdfMakeKey(whClientContext* ctx, int hashType, whKeyId keyIdIn,
         }
 
         if (ret == WH_ERROR_OK) {
+            const size_t hdr_sz =
+                sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
+            /* Defensive bound: res->outSz must fit within the actual received
+             * frame */
+            if (res_len < hdr_sz || res->outSz > (res_len - hdr_sz)) {
+                return WH_ERROR_ABORTED;
+            }
+
             /* Key is cached on server or is ephemeral */
             key_id = (whKeyId)(res->keyIdOut);
 
@@ -5001,6 +5009,14 @@ static int _CmacKdfMakeKey(whClientContext* ctx, whKeyId saltKeyId,
     }
 
     if (ret == WH_ERROR_OK) {
+        const size_t hdr_sz =
+            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
+        /* Defensive bound: res->outSz must fit within the actual received
+         * frame */
+        if (res_len < hdr_sz || res->outSz > (res_len - hdr_sz)) {
+            return WH_ERROR_ABORTED;
+        }
+
         key_id = (whKeyId)(res->keyIdOut);
 
         if (inout_key_id != NULL) {


### PR DESCRIPTION
## Problem
`_HkdfMakeKey` and `_CmacKdfMakeKey` copied `res->outSz` bytes out of the comm
buffer after checking the declared size only against the caller's output
buffer. Neither used `res_len`, the number of bytes actually received, so a
malformed or compromised server response could declare more output than the
frame carried. The client would then read past the end of the received
response and hand the caller data that was never derived key material. Every
other variable-length response handler in `wh_client_crypto.c` already
performs this check (`wh_Client_EccSignResponse`, `_EccSharedSecretResponse`,
`wh_Client_AesGcmResponse`, `wh_Client_MlKemDecapsulate`, and others).

With a conforming server the server-side `outSz > max_size` guard prevents
this, so the impact is confined to malformed or compromised server responses,
matching the threat model of the other findings in this class.

Addressed by f_6201.

## Changes
- Validate `res->outSz` against the received frame length in `_HkdfMakeKey`
  and `_CmacKdfMakeKey`, before the response is consumed. Matches the existing
  `hdr_sz` idiom used by the other response handlers in this file.
- Apply the check unconditionally rather than only on the export path. The
  cache path reports `outSz == 0`, so a conforming response passes either way,
  and a truncated frame is malformed regardless of whether the caller asked
  for output.

This PR is now **source-only** — a 16-line guard, no test changes.

## Tests

**The test added by the earlier revision has been removed.** It was
`test-refactor/misc/wh_test_client_respbounds.c` (269 lines), which stood a stub
client transport in for the server, echoing the request header and replying with
a frame that overstated the output size. Per review, a test reachable only
through a fake transport or a hand-built packet is testing the harness, not the
fix, so it and its `wh_test_list.c` entry are dropped.

No replacement test is added: the server-side `outSz > max_size` guard means a
conforming server never emits a frame these checks reject, so the normal
`wh_Client_*` API has no path to them.

## Verification
- `test-refactor`: default 37 passed / 25 skipped / 0 failed of 62 · `DMA=1` 41/21/0 · `SHE=1` 43/19/0
- Legacy `test/` suite clean.
- Clean under `-std=c90 -Werror -Wall -Wextra`.
- Both branches of the guard were previously confirmed by negative control:
  before the fix the client returned `WH_ERROR_OK` and copied 256 bytes of
  adjacent comm-buffer contents into the caller's key buffer, and with only the
  second half of the guard the short-frame case still slipped through, since
  `res_len - hdr_sz` underflows when `res_len` is smaller.
