### PR TITLE
Validate response payload sizes in wh_client.c handlers

### DIFF
--- a/src/wh_client.c
+++ b/src/wh_client.c
@@ -584,7 +584,8 @@ int wh_Client_CommCloseResponse(whClientContext* c)
     if (rc == 0) {
         /* Validate response */
         if (    (resp_group != WH_MESSAGE_GROUP_COMM) ||
-                (resp_action != WH_MESSAGE_COMM_ACTION_CLOSE) ){
+                (resp_action != WH_MESSAGE_COMM_ACTION_CLOSE) ||
+                (resp_size != 0) ){
             /* Invalid message */
             rc = WH_ERROR_ABORTED;
         } else {
@@ -867,7 +868,12 @@ int wh_Client_KeyCacheResponse(whClientContext* c, uint16_t* keyId)
     ret = wh_Client_RecvResponse(c, &group, &action, &size,
                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
-        if (resp->rc != 0) {
+        /* Defensive bound: the response fields must fit within the actual
+         * received frame */
+        if (size < sizeof(*resp)) {
+            ret = WH_ERROR_ABORTED;
+        }
+        else if (resp->rc != 0) {
             ret = resp->rc;
         }
         else {
@@ -955,7 +961,12 @@ int wh_Client_KeyCacheRandomResponse(whClientContext* c, uint16_t* outKeyId)
     ret = wh_Client_RecvResponse(c, &group, &action, &size,
                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
-        if (resp->rc != 0) {
+        /* Defensive bound: the response fields must fit within the actual
+         * received frame */
+        if (size < sizeof(*resp)) {
+            ret = WH_ERROR_ABORTED;
+        }
+        else if (resp->rc != 0) {
             ret = resp->rc;
         }
         else {
@@ -1025,7 +1036,12 @@ int wh_Client_KeyEvictResponse(whClientContext* c)
                                  (uint8_t*)&resp);
 
     if (ret == 0) {
-        if (resp.rc != 0) {
+        /* Defensive bound: the response fields must fit within the actual
+         * received frame */
+        if (size < sizeof(resp)) {
+            ret = WH_ERROR_ABORTED;
+        }
+        else if (resp.rc != 0) {
             ret = resp.rc;
         }
     }
@@ -1088,8 +1104,16 @@ int wh_Client_KeyExportResponse(whClientContext* c, uint8_t* label,
     ret = wh_Client_RecvResponse(c, &group, &action, &size,
                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
-        if (resp->rc != 0) {
+        /* Defensive bounds: the fixed fields, then the key material, must fit
+         * within the actual received frame */
+        if (size < sizeof(*resp)) {
+            ret = WH_ERROR_ABORTED;
+        }
+        else if (resp->rc != 0) {
             ret = resp->rc;
+        }
+        else if (resp->len > (size - sizeof(*resp))) {
+            ret = WH_ERROR_ABORTED;
         }
         else {
             if (out == NULL) {
@@ -1174,8 +1198,16 @@ int wh_Client_KeyExportPublicResponse(whClientContext* c, uint8_t* label,
     ret = wh_Client_RecvResponse(c, &group, &action, &size,
                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
-        if (resp->rc != 0) {
+        /* Defensive bounds: the fixed fields, then the key material, must fit
+         * within the actual received frame */
+        if (size < sizeof(*resp)) {
+            ret = WH_ERROR_ABORTED;
+        }
+        else if (resp->rc != 0) {
             ret = resp->rc;
+        }
+        else if (resp->len > (size - sizeof(*resp))) {
+            ret = WH_ERROR_ABORTED;
         }
         else {
             if (out == NULL) {
@@ -1252,7 +1284,12 @@ int wh_Client_KeyCommitResponse(whClientContext* c)
     ret = wh_Client_RecvResponse(c, &group, &action, &size,
                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
-        if (resp->rc != 0) {
+        /* Defensive bound: the response fields must fit within the actual
+         * received frame */
+        if (size < sizeof(*resp)) {
+            ret = WH_ERROR_ABORTED;
+        }
+        else if (resp->rc != 0) {
             ret = resp->rc;
         }
     }
@@ -1309,7 +1346,12 @@ int wh_Client_KeyEraseResponse(whClientContext* c)
     ret = wh_Client_RecvResponse(c, &group, &action, &size,
                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
-        if (resp->rc != 0) {
+        /* Defensive bound: the response fields must fit within the actual
+         * received frame */
+        if (size < sizeof(*resp)) {
+            ret = WH_ERROR_ABORTED;
+        }
+        else if (resp->rc != 0) {
             ret = resp->rc;
         }
     }
@@ -1366,7 +1408,12 @@ int wh_Client_KeyRevokeResponse(whClientContext* c)
     ret = wh_Client_RecvResponse(c, &group, &action, &size,
                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == 0) {
-        if (resp->rc != 0) {
+        /* Defensive bound: the response fields must fit within the actual
+         * received frame */
+        if (size < sizeof(*resp)) {
+            ret = WH_ERROR_ABORTED;
+        }
+        else if (resp->rc != 0) {
             ret = resp->rc;
         }
     }
@@ -1425,7 +1472,12 @@ int wh_Client_CounterInitResponse(whClientContext* c, uint32_t* counter)
     ret = wh_Client_RecvResponse(c, &group, &action, &size,
                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
-        if (resp->rc != 0) {
+        /* Defensive bound: the response fields must fit within the actual
+         * received frame */
+        if (size < sizeof(*resp)) {
+            ret = WH_ERROR_ABORTED;
+        }
+        else if (resp->rc != 0) {
             ret = resp->rc;
         }
         else if (counter != NULL) {
@@ -1504,7 +1556,12 @@ int wh_Client_CounterIncrementResponse(whClientContext* c, uint32_t* counter)
     ret = wh_Client_RecvResponse(c, &group, &action, &size,
                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
-        if (resp->rc != 0) {
+        /* Defensive bound: the response fields must fit within the actual
+         * received frame */
+        if (size < sizeof(*resp)) {
+            ret = WH_ERROR_ABORTED;
+        }
+        else if (resp->rc != 0) {
             ret = resp->rc;
         }
         else if (counter != NULL) {
@@ -1565,7 +1622,12 @@ int wh_Client_CounterReadResponse(whClientContext* c, uint32_t* counter)
     ret = wh_Client_RecvResponse(c, &group, &action, &size,
                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
-        if (resp->rc != 0) {
+        /* Defensive bound: the response fields must fit within the actual
+         * received frame */
+        if (size < sizeof(*resp)) {
+            ret = WH_ERROR_ABORTED;
+        }
+        else if (resp->rc != 0) {
             ret = resp->rc;
         }
         else {
@@ -1626,7 +1688,12 @@ int wh_Client_CounterDestroyResponse(whClientContext* c)
     ret = wh_Client_RecvResponse(c, &group, &action, &size,
                                  WOLFHSM_CFG_COMM_DATA_LEN, (uint8_t*)resp);
     if (ret == WH_ERROR_OK) {
-        if (resp->rc != 0) {
+        /* Defensive bound: the response fields must fit within the actual
+         * received frame */
+        if (size < sizeof(*resp)) {
+            ret = WH_ERROR_ABORTED;
+        }
+        else if (resp->rc != 0) {
             ret = resp->rc;
         }
     }


### PR DESCRIPTION
### Problem

`wh_Client_RecvResponse()` reports the received payload length but never validates it against the message the caller overlays on the comm buffer. The comm client reuses one buffer for request and response, and `wh_CommClient_RecvResponse()` copies only `payload_size` bytes — skipping the copy entirely when the caller passes the comm data pointer itself — so a short reply leaves the tail holding the client's own outbound request bytes.

A truncated response therefore reads back as a stale `rc == 0` with a garbage `id`/`counter`. In the key-export paths it is worse: `resp->len` is read from request bytes, and `memcpy(out, packOut, resp->len)` reads past the received frame, copying comm-buffer contents out to the caller as key material.

### Fix (`src/wh_client.c`)

| Handlers | Change |
|---|---|
| `KeyExportResponse`, `KeyExportPublicResponse` | `size < sizeof(*resp)` → `rc` → `resp->len > (size - sizeof(*resp))` |
| 6 keystore + 4 counter fixed-size responses | `size < sizeof(*resp)` before reading `rc` |
| `CommCloseResponse` | `resp_size != 0` |

Where `rc` lives inside the struct being validated, the checks split across a branch chain so the subtraction is guarded by a preceding sibling branch:

```c
if (size < sizeof(*resp))                        { ret = WH_ERROR_ABORTED; }
else if (resp->rc != 0)                          { ret = resp->rc; }
else if (resp->len > (size - sizeof(*resp)))     { ret = WH_ERROR_ABORTED; }
```

Rebased onto #496, which added a bounded `data_size` to `wh_Client_RecvResponse()`. That fixes the separate stack-overflow issue an earlier revision of this PR addressed by receiving into `wh_CommClient_GetDataPtr()`, so those four handlers are dropped here and keep upstream's stack structs — except `KeyEvictResponse`, which still needs `size < sizeof(resp)` since its struct is uninitialized. Follow-up to #457, which applied this check to `wh_client_she.c`. `KeyExportDmaResponse` and the public-DMA path already validated an exact size and are unchanged. Source-only.

### Tests

**The test added by an earlier revision has been removed.** It was `test-refactor/misc/wh_test_client_malformed_resp.c` (503 lines), which drove the client against a raw `whCommServer` so a reply could carry the correct kind and sequence while declaring a malformed size. Per review, a test reachable only through a fake transport or a hand-built packet is testing the harness, not the fix, so it and its `wh_test_list.c` entry are dropped. This also removes the add/add conflict with #463/#474/#475/#476, which each created the same file.

No replacement test is added: a conforming server cannot produce the truncated or oversized frames these guards reject, so the normal `wh_Client_*` API has no path to them.

### Verification

- `test-refactor`: default 45 passed / 26 skipped / 0 failed of 71 · `DMA=1` 49/22/0 · `SHE=1` 51/20/0
- Legacy `test/` suite clean.
- Clean under `-std=c90 -Werror -Wall -Wextra -Wpointer-arith`.
- Every guard was previously mutation-checked (deleted, `>` → `>=`, `>` → `<`); each mutation failed the suite while the test existed.