### PR TITLE
Bound CMAC response payloads against the received frame

### DIFF
--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -5229,9 +5229,17 @@ int wh_Client_CmacGenerateResponse(whClientContext* ctx, Cmac* cmac,
     ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, (uint8_t**)&res);
     /* wolfCrypt allows positive error codes on success */
     if (ret >= 0) {
-        /* Restore state from response (server has finalized; buffer/digest
-         * carry the post-finalization state). */
-        ret = wh_Crypto_CmacAesRestoreStateFromMsg(cmac, &res->resumeState);
+        const uint32_t hdr_sz =
+            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
+        /* The MAC bytes the response claims must be in the received frame */
+        if (res_len < hdr_sz || res->outSz > (res_len - hdr_sz)) {
+            ret = WH_ERROR_ABORTED;
+        }
+        if (ret >= 0) {
+            /* Restore state from response (server has finalized; buffer/digest
+             * carry the post-finalization state). */
+            ret = wh_Crypto_CmacAesRestoreStateFromMsg(cmac, &res->resumeState);
+        }
         if (ret >= 0) {
             ret = _CmacValidateTagLen(*outMacLen);
         }
@@ -5349,10 +5357,17 @@ int wh_Client_CmacUpdateResponse(whClientContext* ctx, Cmac* cmac)
 
     ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, (uint8_t**)&res);
     if (ret >= 0) {
-        /* Restore full state from server. The server may leave a partial
-         * (or whole) block in its buffer after wc_CmacUpdate (CMAC's last
-         * block has special handling), so we round-trip the whole state. */
-        ret = wh_Crypto_CmacAesRestoreStateFromMsg(cmac, &res->resumeState);
+        /* No trailing payload on update, but the state must be in the frame */
+        if (res_len < sizeof(whMessageCrypto_GenericResponseHeader) +
+                          sizeof(*res)) {
+            ret = WH_ERROR_ABORTED;
+        }
+        if (ret >= 0) {
+            /* Restore full state from server. The server may leave a partial
+             * (or whole) block in its buffer after wc_CmacUpdate (CMAC's last
+             * block has special handling), so we round-trip the whole state. */
+            ret = wh_Crypto_CmacAesRestoreStateFromMsg(cmac, &res->resumeState);
+        }
     }
     return ret;
 }
@@ -5439,9 +5454,17 @@ int wh_Client_CmacFinalResponse(whClientContext* ctx, Cmac* cmac,
 
     ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, (uint8_t**)&res);
     if (ret >= 0) {
-        /* Restore final state from response (server's bufferSz is 0 after
-         * Final). */
-        ret = wh_Crypto_CmacAesRestoreStateFromMsg(cmac, &res->resumeState);
+        const uint32_t hdr_sz =
+            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
+        /* The MAC bytes the response claims must be in the received frame */
+        if (res_len < hdr_sz || res->outSz > (res_len - hdr_sz)) {
+            ret = WH_ERROR_ABORTED;
+        }
+        if (ret >= 0) {
+            /* Restore final state from response (server's bufferSz is 0 after
+             * Final). */
+            ret = wh_Crypto_CmacAesRestoreStateFromMsg(cmac, &res->resumeState);
+        }
         if (ret >= 0) {
             ret = _CmacValidateTagLen(*outMacLen);
         }
@@ -5680,7 +5703,18 @@ int wh_Client_CmacGenerateDmaResponse(whClientContext* ctx, Cmac* cmac,
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, (uint8_t**)&res);
         if (ret >= 0) {
-            ret = wh_Crypto_CmacAesRestoreStateFromMsg(cmac, &res->resumeState);
+            const uint32_t hdr_sz =
+                sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
+            /* The MAC bytes the response claims must be in the received
+             * frame. A failed server request replies with the generic header
+             * only, so this bound stays inside the success branch. */
+            if (respSz < hdr_sz || res->outSz > (respSz - hdr_sz)) {
+                ret = WH_ERROR_ABORTED;
+            }
+            if (ret >= 0) {
+                ret = wh_Crypto_CmacAesRestoreStateFromMsg(cmac,
+                                                           &res->resumeState);
+            }
             if (ret >= 0) {
                 ret = _CmacValidateTagLen(*outMacLen);
             }
@@ -5825,9 +5859,18 @@ int wh_Client_CmacDmaUpdateResponse(whClientContext* ctx, Cmac* cmac)
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, (uint8_t**)&res);
         if (ret >= 0) {
-            /* Restore full state from server (includes any partial/whole
-             * block left in the server's wc_CmacUpdate buffer). */
-            ret = wh_Crypto_CmacAesRestoreStateFromMsg(cmac, &res->resumeState);
+            /* No trailing payload on update, but the state must be in the
+             * frame */
+            if (respSz < sizeof(whMessageCrypto_GenericResponseHeader) +
+                             sizeof(*res)) {
+                ret = WH_ERROR_ABORTED;
+            }
+            if (ret >= 0) {
+                /* Restore full state from server (includes any partial/whole
+                 * block left in the server's wc_CmacUpdate buffer). */
+                ret = wh_Crypto_CmacAesRestoreStateFromMsg(cmac,
+                                                           &res->resumeState);
+            }
         }
     }
 
@@ -5914,7 +5957,15 @@ int wh_Client_CmacDmaFinalResponse(whClientContext* ctx, Cmac* cmac,
 
     ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, (uint8_t**)&res);
     if (ret >= 0) {
-        ret = wh_Crypto_CmacAesRestoreStateFromMsg(cmac, &res->resumeState);
+        const uint32_t hdr_sz =
+            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
+        /* The MAC bytes the response claims must be in the received frame */
+        if (respSz < hdr_sz || res->outSz > (respSz - hdr_sz)) {
+            ret = WH_ERROR_ABORTED;
+        }
+        if (ret >= 0) {
+            ret = wh_Crypto_CmacAesRestoreStateFromMsg(cmac, &res->resumeState);
+        }
         if (ret >= 0) {
             ret = _CmacValidateTagLen(*outMacLen);
         }


### PR DESCRIPTION
### Problem

`wh_Client_RecvResponse` reports the received payload length but never validates
it against the message being parsed. The comm client reuses one buffer for
request and response, so a short reply leaves the tail holding the client's own
outbound request bytes.

None of the six CMAC response handlers bounded the frame. `CmacGenerateResponse`,
`CmacFinalResponse`, `CmacGenerateDmaResponse` and `CmacDmaFinalResponse` do
`memcpy(outMac, res + 1, *outMacLen)` over trailing bytes the frame may not
carry, landing stale data in the caller's MAC buffer; the two Update handlers
restore CMAC state from an unvalidated struct. A malicious or malfunctioning
server returns a MAC the client silently accepts.

This is one of the follow-up requested on #457.

### Fix (`src/wh_client_crypto.c`)

Every CMAC response goes through `_getCryptoResponse()`, which has already
consumed `rc`, so the bound is the combined form guarded by the left operand:

```c
const uint32_t hdr_sz =
    sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
if (res_len < hdr_sz || res->outSz > (res_len - hdr_sz)) {
    ret = WH_ERROR_ABORTED;
}
```

| Handler | Form |
|---|---|
| `CmacGenerateResponse` | `hdr_sz` + `res->outSz` |
| `CmacFinalResponse` | `hdr_sz` + `res->outSz` |
| `CmacGenerateDmaResponse` | `hdr_sz` + `res->outSz` |
| `CmacDmaFinalResponse` | `hdr_sz` + `res->outSz` |
| `CmacUpdateResponse` | fixed size, no trailing payload |
| `CmacDmaUpdateResponse` | fixed size, no trailing payload |

- **Inside the success branch.** Both crypto dispatchers reply with the generic
  header alone when a handler fails, so an unconditional bound would convert
  every legitimate error reply into `WH_ERROR_ABORTED` and hide the server's
  `rc`.
- **Before the state restore.** `wh_Crypto_CmacAesRestoreStateFromMsg()` read
  `res->resumeState` ahead of any bound; it now sits under the new guard.
- The pre-existing clamp (`res->outSz < *outMacLen`) is untouched — it bounds
  the caller's buffer, a different bound from the frame.

`_CmacKdfMakeKey` is KDF-via-CMAC and is covered by #467, not here. This PR is
now **source-only**.

### Tests

**The test added by the earlier revision has been removed.** It was
`test-refactor/misc/wh_test_client_malformed_resp.c` (564 lines), built on a
scripted transport client callback that echoed the request's comm header and
reported a frame length independent of the body it wrote. Per review, a test
reachable only through a fake transport or a hand-built packet is testing the
harness, not the fix, so it and its `wh_test_list.c` entry are dropped. This also
removes the add/add conflict with #463/#473/#475/#476, which each created the
same file.

No replacement test is added: a conforming server always sends a frame that
satisfies these bounds, so the normal `wh_Client_*` API has no path to them.

### Verification

- `test-refactor`: default 37 passed / 25 skipped / 0 failed of 62 · `DMA=1` 41/21/0 · `SHE=1` 43/19/0
- Legacy `test/` suite clean.
- Clean under `-std=c90 -Werror -Wall -Wextra`.
- All six guards were previously mutation-checked (`>` → `<`, `>` → `>=`,
  dropping the header clause, neutering the body): 24/24 mutants caught while
  the test existed.
