### PR TITLE
Bound AES DMA response frames in the crypto client

### DIFF
--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -709,14 +709,23 @@ int wh_Client_AesCtrDmaResponse(whClientContext* ctx, Aes* aes)
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_CTR, (uint8_t**)&res);
         if (ret == WH_ERROR_OK) {
-            uint8_t* res_iv =
-                (uint8_t*)res + sizeof(whMessageCrypto_AesCtrDmaResponse);
-            uint8_t* res_tmp = res_iv + AES_IV_SIZE;
-            aes->left        = res->left;
-            memcpy((uint8_t*)aes->reg, res_iv, AES_IV_SIZE);
-            memcpy((uint8_t*)aes->tmp, res_tmp, AES_BLOCK_SIZE);
-            WH_DEBUG_CLIENT_VERBOSE("AesCtr DMA res: left=%u\n",
-                                    (unsigned int)res->left);
+            /* Trailing payload is: reg (AES_IV_SIZE) + tmp (AES_BLOCK_SIZE) */
+            const uint32_t hdr_sz =
+                sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res) +
+                AES_IV_SIZE + AES_BLOCK_SIZE;
+            if (res_len < hdr_sz) {
+                ret = WH_ERROR_ABORTED;
+            }
+            else {
+                uint8_t* res_iv =
+                    (uint8_t*)res + sizeof(whMessageCrypto_AesCtrDmaResponse);
+                uint8_t* res_tmp = res_iv + AES_IV_SIZE;
+                aes->left        = res->left;
+                memcpy((uint8_t*)aes->reg, res_iv, AES_IV_SIZE);
+                memcpy((uint8_t*)aes->tmp, res_tmp, AES_BLOCK_SIZE);
+                WH_DEBUG_CLIENT_VERBOSE("AesCtr DMA res: left=%u\n",
+                                        (unsigned int)res->left);
+            }
         }
     }
 
@@ -1026,7 +1035,14 @@ int wh_Client_AesEcbDmaResponse(whClientContext* ctx, Aes* aes)
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_ECB, (uint8_t**)&res);
         if (ret == WH_ERROR_OK) {
-            WH_DEBUG_CLIENT_VERBOSE("AesEcb DMA res: ok\n");
+            const uint32_t hdr_sz =
+                sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
+            if (res_len < hdr_sz) {
+                ret = WH_ERROR_ABORTED;
+            }
+            else {
+                WH_DEBUG_CLIENT_VERBOSE("AesEcb DMA res: ok\n");
+            }
         }
     }
 
@@ -1362,10 +1378,19 @@ int wh_Client_AesCbcDmaResponse(whClientContext* ctx, Aes* aes)
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_CBC, (uint8_t**)&res);
         if (ret == WH_ERROR_OK) {
-            uint8_t* res_iv =
-                (uint8_t*)res + sizeof(whMessageCrypto_AesCbcDmaResponse);
-            memcpy((uint8_t*)aes->reg, res_iv, AES_IV_SIZE);
-            WH_DEBUG_CLIENT_VERBOSE("AesCbc DMA res: ok\n");
+            /* Trailing payload is the updated IV (AES_IV_SIZE) */
+            const uint32_t hdr_sz =
+                sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res) +
+                AES_IV_SIZE;
+            if (res_len < hdr_sz) {
+                ret = WH_ERROR_ABORTED;
+            }
+            else {
+                uint8_t* res_iv =
+                    (uint8_t*)res + sizeof(whMessageCrypto_AesCbcDmaResponse);
+                memcpy((uint8_t*)aes->reg, res_iv, AES_IV_SIZE);
+                WH_DEBUG_CLIENT_VERBOSE("AesCbc DMA res: ok\n");
+            }
         }
     }
 
@@ -1759,19 +1784,27 @@ int wh_Client_AesGcmDmaResponse(whClientContext* ctx, Aes* aes,
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_GCM, (uint8_t**)&res);
         if (ret == WH_ERROR_OK) {
-            if (enc_tag != NULL && res->authTagSz > 0) {
-                if (res->authTagSz > tag_len) {
-                    ret = WH_ERROR_ABORTED;
-                }
-                else {
-                    uint8_t* res_tag =
-                        (uint8_t*)res +
-                        sizeof(whMessageCrypto_AesGcmDmaResponse);
-                    memcpy(enc_tag, res_tag, res->authTagSz);
-                }
+            /* Trailing payload is the auth tag (res->authTagSz) */
+            const uint32_t hdr_sz =
+                sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
+            if (res_len < hdr_sz || res->authTagSz > (res_len - hdr_sz)) {
+                ret = WH_ERROR_ABORTED;
             }
-            WH_DEBUG_CLIENT_VERBOSE("AesGcm DMA res: tagsz=%u\n",
-                                    (unsigned int)res->authTagSz);
+            else {
+                if (enc_tag != NULL && res->authTagSz > 0) {
+                    if (res->authTagSz > tag_len) {
+                        ret = WH_ERROR_ABORTED;
+                    }
+                    else {
+                        uint8_t* res_tag =
+                            (uint8_t*)res +
+                            sizeof(whMessageCrypto_AesGcmDmaResponse);
+                        memcpy(enc_tag, res_tag, res->authTagSz);
+                    }
+                }
+                WH_DEBUG_CLIENT_VERBOSE("AesGcm DMA res: tagsz=%u\n",
+                                        (unsigned int)res->authTagSz);
+            }
         }
     }
 


### PR DESCRIPTION
### Problem

The four AES DMA response handlers in `wh_client_crypto.c` overlaid their
response struct on the comm buffer without validating the length
`wh_Client_RecvResponse` reported. The comm client reuses one buffer for
request and response, so a short reply leaves the tail holding the client's
own outbound request bytes:

- **`AesCtrDmaResponse`** restores `aes->reg` and `aes->tmp` from
  `AES_IV_SIZE + AES_BLOCK_SIZE` bytes read past the struct.
- **`AesCbcDmaResponse`** restores the chaining IV the same way.
- **`AesGcmDmaResponse`** copies `res->authTagSz` tag bytes from past the
  struct into the caller's buffer, bounded only by the caller's `tag_len`.
- **`AesEcbDmaResponse`** parses the header only, but overlays unchecked.

A malicious or malfunctioning server returns stale data instead of an error;
for CTR/CBC that silently corrupts cipher state, for GCM it hands the caller
a tag built from its own request bytes.

Follow-up to #457, continuing the `wh_Client_RecvResponse` audit. This is the
AES DMA family; CMAC, LMS/XMSS DMA, ML-KEM DMA and `EccCheckPubKey` follow in
separate PRs.

### Fix (`src/wh_client_crypto.c`)

Each handler now bounds `res_len` before parsing:

| Handler | Required size beyond the generic response header |
|---|---|
| `AesCtrDmaResponse` | `sizeof(*res) + AES_IV_SIZE + AES_BLOCK_SIZE` |
| `AesEcbDmaResponse` | `sizeof(*res)` |
| `AesCbcDmaResponse` | `sizeof(*res) + AES_IV_SIZE` |
| `AesGcmDmaResponse` | `sizeof(*res)`, plus `res->authTagSz` against the remainder |

Each size matches exactly what the server emits (`*outSize` in
`_HandleAes*Dma`). Two placement rules the DMA paths impose:

- The check sits **inside** the `rc == WH_ERROR_OK` branch. The DMA
  dispatcher sends a header-only frame when a handler fails, so an
  unconditional bound would convert every real server error into
  `WH_ERROR_ABORTED`.
- It **assigns** `ret` rather than returning early, so the DMA `*_POST`
  unmapping at the bottom of each function still runs.

GCM keeps its pre-existing `authTagSz > tag_len` branch — that bounds the
caller's buffer, which is a different limit from the received frame. This PR is
now **source-only**.

### Tests

**The test added by the earlier revision has been removed.** It was
`test-refactor/misc/wh_test_client_malformed_resp.c` (480 lines), built on a
scripted transport client callback that echoed the request's comm header and
replied with a crafted frame whose reported length varied independently of the
body. Per review, a test reachable only through a fake transport or a hand-built
packet is testing the harness, not the fix, so it and its `wh_test_list.c` entry
are dropped. This also removes the add/add conflict with #463/#473/#474/#476,
which each created the same file.

No replacement test is added: a conforming server always emits the exact sizes
in the table above, so the normal `wh_Client_*` API has no path to these guards.

### Verification

- `test-refactor`: default 37 passed / 25 skipped / 0 failed of 62 · `DMA=1` 41/21/0 · `SHE=1` 43/19/0
- Legacy `test/` suite clean.
- Clean under `-std=c90 -Werror -Wall -Wextra`.
- The four guards plus GCM's tag clause were previously mutation-checked
  (neuter, `<` → `>`, ±1, `>` → `>=`, and a hoist above the `rc` check):
  10/10 killed while the test existed.
