### PR TITLE
CI runtime: disable selected workflows from draft PRs

### DIFF
--- a/.github/workflows/build-and-bench.yml
+++ b/.github/workflows/build-and-bench.yml
@@ -7,6 +7,7 @@ on:
     # Weekly ccache reseed; also keeps caches from 7-day eviction
     - cron: '0 6 * * 1'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ '*' ]
 
 concurrency:
@@ -19,6 +20,7 @@ permissions:
 jobs:
   build:
 
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/build-and-run-examples.yml
+++ b/.github/workflows/build-and-run-examples.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ 'master', 'main', 'release/**' ]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ '*' ]
 
 concurrency:
@@ -22,6 +23,7 @@ jobs:
             debug: [ '', 'DEBUG_VERBOSE=1' ]
             test: [ '', '--test' ]
             auth: [ '', 'AUTH=1' ]
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
 

--- a/.github/workflows/build-and-test-clientonly.yml
+++ b/.github/workflows/build-and-test-clientonly.yml
@@ -7,6 +7,7 @@ on:
     # Weekly ccache reseed; also keeps caches from 7-day eviction
     - cron: '0 6 * * 1'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ '*' ]
 
 concurrency:
@@ -21,6 +22,7 @@ jobs:
     strategy:
         matrix:
             transport: [ 'tcp', 'tls' ]
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/build-and-test-refactor.yml
+++ b/.github/workflows/build-and-test-refactor.yml
@@ -7,6 +7,7 @@ on:
     # Weekly ccache reseed; also keeps caches from 7-day eviction
     - cron: '0 6 * * 1'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ '*' ]
 
 concurrency:
@@ -22,7 +23,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # Exclude macOS for draft PRs due to its small pool
+        os: >-
+          ${{ (github.event_name == 'pull_request' &&
+          github.event.pull_request.draft) &&
+          fromJSON('["ubuntu-latest"]') ||
+          fromJSON('["ubuntu-latest", "macos-latest"]') }}
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45

--- a/.github/workflows/build-and-test-stress.yml
+++ b/.github/workflows/build-and-test-stress.yml
@@ -7,6 +7,7 @@ on:
     # Weekly ccache reseed; also keeps caches from 7-day eviction
     - cron: '0 6 * * 1'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ '*' ]
 
 concurrency:
@@ -19,6 +20,7 @@ permissions:
 jobs:
   build:
 
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/build-and-test-whnvmtool.yml
+++ b/.github/workflows/build-and-test-whnvmtool.yml
@@ -7,6 +7,7 @@ on:
     # Weekly ccache reseed; also keeps caches from 7-day eviction
     - cron: '0 6 * * 1'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ '*' ]
 
 concurrency:
@@ -19,6 +20,7 @@ permissions:
 jobs:
   build:
 
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/build-and-test-wolfssl-lib.yml
+++ b/.github/workflows/build-and-test-wolfssl-lib.yml
@@ -10,6 +10,7 @@ on:
     # Weekly ccache reseed; also keeps caches from 7-day eviction
     - cron: '0 6 * * 1'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ '*' ]
 
 concurrency:
@@ -21,6 +22,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,9 +23,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # Exclude macOS for draft PRs due to its small pool
+        os: >-
+          ${{ (github.event_name == 'pull_request' &&
+          github.event.pull_request.draft) &&
+          fromJSON('["ubuntu-latest"]') ||
+          fromJSON('["ubuntu-latest", "macos-latest"]') }}
 
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,7 @@ on:
     # Weekly ccache reseed; also keeps caches from 7-day eviction
     - cron: '0 6 * * 1'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ '*' ]
 
 concurrency:
@@ -24,6 +25,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
 
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
 

--- a/.github/workflows/code-coverage-refactor.yml
+++ b/.github/workflows/code-coverage-refactor.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ 'master', 'main', 'release/**' ]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ '*' ]
 
 concurrency:
@@ -15,6 +16,7 @@ permissions:
 
 jobs:
   coverage:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ 'master', 'main', 'release/**' ]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ '*' ]
 
 concurrency:
@@ -15,6 +16,7 @@ permissions:
 
 jobs:
   coverage:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:


### PR DESCRIPTION
Prevent the following workflows from running on draft PRs.

```
**Skipped on draft PRs** (runs when marked ready):

| Workflow                                    | Job(s)                    |
|---------------------------------------------|---------------------------|
| Build and Test                              | all                       |
| Build and Test Refactor                     | build (macos-latest) only |
| Build and Run Examples                      | all                       |
| Build and Test Client-Only                  | all                       |
| Multi-threaded Stress Test                  | all                       |
| whnvmtool build and test                    | all                       |
| Build with installed wolfSSL (WOLFSSL_LIB)  | all                       |
| Benchmark                                   | all                       |
| Code Coverage                               | all                       |
| Code Coverage Refactor                      | all                       |
```

For drafts, the workflows that actually run are:

* Build and Test Refactor (ubuntu-latest): ~18 min
* Clang Format Check 
* Static Analysis
~24 runner-min total.

This is another good-citizen change. Runner minutes per push drops from approx 140 to 25. Today draft PRs take up approx 18-25% of runner minutes.

Remaining tests are kicked off as soon as the PR is marked ready.