### PR TITLE
Fix 32-bit size_t overflow in AES needed_size checks and two SHE size guards

### DIFF
--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -2823,8 +2823,9 @@ static int _HandleAesCtr(whServerContext* ctx, uint16_t magic, int devId,
     uint32_t key_len     = req.keyLen;
     uint32_t len         = req.sz;
     uint32_t left        = req.left;
-    uint64_t needed_size = sizeof(whMessageCrypto_AesCtrRequest) + len +
-                           key_len + AES_IV_SIZE + AES_BLOCK_SIZE;
+    uint64_t needed_size = (uint64_t)sizeof(whMessageCrypto_AesCtrRequest) +
+                           (uint64_t)len + (uint64_t)key_len +
+                           (uint64_t)AES_IV_SIZE + (uint64_t)AES_BLOCK_SIZE;
     if (needed_size != inSize) {
         return WH_ERROR_BADARGS;
     }
@@ -2966,8 +2967,9 @@ static int _HandleAesCtrDma(whServerContext* ctx, uint16_t magic, int devId,
     uint32_t keyLen      = req.keySz;
     uint32_t len         = req.input.sz;
     uint32_t left        = req.left;
-    uint64_t needed_size = sizeof(whMessageCrypto_AesCtrDmaRequest) + keyLen +
-                           AES_IV_SIZE + AES_BLOCK_SIZE;
+    uint64_t needed_size = (uint64_t)sizeof(whMessageCrypto_AesCtrDmaRequest) +
+                           (uint64_t)keyLen + (uint64_t)AES_IV_SIZE +
+                           (uint64_t)AES_BLOCK_SIZE;
     if (needed_size != inSize) {
         return WH_ERROR_BADARGS;
     }
@@ -3153,8 +3155,8 @@ static int _HandleAesEcb(whServerContext* ctx, uint16_t magic, int devId,
     uint32_t enc     = req.enc;
     uint32_t key_len = req.keyLen;
     uint32_t len     = req.sz;
-    uint64_t needed_size =
-        sizeof(whMessageCrypto_AesEcbRequest) + len + key_len;
+    uint64_t needed_size = (uint64_t)sizeof(whMessageCrypto_AesEcbRequest) +
+                           (uint64_t)len + (uint64_t)key_len;
     if (needed_size != inSize) {
         return WH_ERROR_BADARGS;
     }
@@ -3272,7 +3274,8 @@ static int _HandleAesEcbDma(whServerContext* ctx, uint16_t magic, int devId,
 
     uint32_t keyLen      = req.keySz;
     uint32_t len         = req.input.sz;
-    uint64_t needed_size = sizeof(whMessageCrypto_AesEcbDmaRequest) + keyLen;
+    uint64_t needed_size =
+        (uint64_t)sizeof(whMessageCrypto_AesEcbDmaRequest) + (uint64_t)keyLen;
     if (needed_size != inSize) {
         return WH_ERROR_BADARGS;
     }
@@ -3435,8 +3438,9 @@ static int _HandleAesCbc(whServerContext* ctx, uint16_t magic, int devId,
     uint32_t enc         = req.enc;
     uint32_t key_len     = req.keyLen;
     uint32_t len         = req.sz;
-    uint64_t needed_size = sizeof(whMessageCrypto_AesCbcRequest) + len +
-                           key_len + AES_BLOCK_SIZE;
+    uint64_t needed_size = (uint64_t)sizeof(whMessageCrypto_AesCbcRequest) +
+                           (uint64_t)len + (uint64_t)key_len +
+                           (uint64_t)AES_BLOCK_SIZE;
     if (needed_size != inSize) {
         return WH_ERROR_BADARGS;
     }
@@ -3558,8 +3562,8 @@ static int _HandleAesCbcDma(whServerContext* ctx, uint16_t magic, int devId,
     uint32_t enc         = req.enc;
     uint32_t keyLen      = req.keySz;
     uint32_t len         = req.input.sz;
-    uint64_t needed_size = sizeof(whMessageCrypto_AesCbcDmaRequest) + keyLen +
-                           AES_IV_SIZE;
+    uint64_t needed_size = (uint64_t)sizeof(whMessageCrypto_AesCbcDmaRequest) +
+                           (uint64_t)keyLen + (uint64_t)AES_IV_SIZE;
     if (needed_size != inSize) {
         return WH_ERROR_BADARGS;
     }
@@ -3730,9 +3734,10 @@ static int _HandleAesGcm(whServerContext* ctx, uint16_t magic, int devId,
     uint32_t tag_len     = req.authTagSz;
     whKeyId  key_id      = wh_KeyId_TranslateFromClient(
              WH_KEYTYPE_CRYPTO, ctx->comm->client_id, req.keyId);
-    uint64_t needed_size = sizeof(whMessageCrypto_AesGcmRequest) + len +
-                           key_len + iv_len + authin_len +
-                           ((enc == 0) ? tag_len : 0);
+    uint64_t needed_size = (uint64_t)sizeof(whMessageCrypto_AesGcmRequest) +
+                           (uint64_t)len + (uint64_t)key_len +
+                           (uint64_t)iv_len + (uint64_t)authin_len +
+                           (uint64_t)((enc == 0) ? tag_len : 0);
     if (needed_size != inSize) {
         return WH_ERROR_BADARGS;
     }
@@ -3885,8 +3890,9 @@ static int _HandleAesGcmDma(whServerContext* ctx, uint16_t magic, int devId,
     uint32_t len         = req.input.sz;
     uint32_t ivLen       = req.ivSz;
     uint32_t tagLen      = req.authTagSz;
-    uint64_t needed_size = sizeof(whMessageCrypto_AesGcmDmaRequest) + keyLen +
-                           ivLen + (enc != 0 ? 0 : tagLen);
+    uint64_t needed_size = (uint64_t)sizeof(whMessageCrypto_AesGcmDmaRequest) +
+                           (uint64_t)keyLen + (uint64_t)ivLen +
+                           (uint64_t)(enc != 0 ? 0 : tagLen);
     if (needed_size != inSize) {
         return WH_ERROR_BADARGS;
     }

--- a/src/wh_server_she.c
+++ b/src/wh_server_she.c
@@ -331,7 +331,9 @@ static int _SecureBootUpdate(whServerContext* server, uint16_t magic,
     if (ret == 0) {
         /* the bootloader chunk is after the fixed fields */
         in = (uint8_t*)req_packet + sizeof(req);
-        if (req_size < (sizeof(req) + req.sz)) {
+        /* Guard against 32-bit size_t overflow: check req.sz alone first */
+        if (req.sz > WOLFHSM_CFG_COMM_DATA_LEN ||
+            req_size < (sizeof(req) + req.sz)) {
             ret = WH_ERROR_BUFFER_SIZE;
         }
     }
@@ -1523,7 +1525,9 @@ static int _GenerateMac(whServerContext* server, uint16_t magic,
     }
 
     if (ret == 0) {
-        if (req_size < (sizeof(req) + req.sz)) {
+        /* Guard against 32-bit size_t overflow: check req.sz alone first */
+        if (req.sz > WOLFHSM_CFG_COMM_DATA_LEN ||
+            req_size < (sizeof(req) + req.sz)) {
             ret = WH_ERROR_BUFFER_SIZE;
         }
     }


### PR DESCRIPTION
### Problem
Every AES request handler validates its packet with a `needed_size` sum:

    uint64_t needed_size = sizeof(whMessageCrypto_AesEcbRequest) + len + key_len;
    if (needed_size != inSize) { return WH_ERROR_BADARGS; }

`sizeof` is `size_t` and `len`/`key_len` are `uint32_t`, so on a **32-bit target
every operand is 32-bit and the sum wraps before the widening assignment** — the
`uint64_t` declaration buys nothing. `inSize` is `uint16_t`, so a client picks
`len` such that the wrapped sum equals a small legitimate packet size, the guard
passes, and `len` reaches `wc_AesEcbEncrypt(..., (word32)len)` unmodified: a
~4 GB read/write off a small buffer. Reachable **pre-auth**
(`wh_Server_HandleRequestMessage`), and **every supported port is 32-bit** — the
64-bit POSIX build where this cannot trigger is only CI. Pre-auth memory
corruption on every real target.

Closes findings F-4325 / F-4327 / F-4328 / F-4331.

### Fix (`src/wh_server_crypto.c`, `src/wh_server_she.c`)
Cast every operand to `uint64_t` so the sum is 64-bit at any word size, at **all
8** `needed_size` sites — the 4 reported handlers plus `_HandleAesGcm` (the worst
site, 5 attacker-controlled addends, unreported) and the 4 DMA variants. Also
guards the **2 unreported SHE sites** (`_GenerateMac`, `_SecureBootUpdate` in
`src/wh_server_she.c`) with the same `> WOLFHSM_CFG_COMM_DATA_LEN` overflow check
their 5 neighbours already carry. No behavior change on 64-bit; added lines only.
This PR is now **source-only**.

### Tests

**The tests added by the earlier revision have been removed.** They were
`test-refactor/server/wh_test_crypto_reqsize.c` (280 lines,
`whTest_CryptoReqSize`) and two sub-tests appended to
`whTest_SheReqSizeChecking`, all of which hand-built wrap-crafted request packets
and fed them to server handlers directly. Per review, a test that hand-builds a
packet and calls a server handler is testing the harness, not the fix, so both
are dropped along with the `wh_test_list.c` entry. This also removes the add/add
conflict with #466, which created the same file.

No replacement test is added: reaching the wrap requires a `len` value no
`wh_Client_*` call will send, so the overflow is not expressible through the
normal client API. The 32-bit CI job in #491 covers this bug class at the
compiler/config level instead, which is the durable check.

### Verification
- `test-refactor`: default 43 passed / 26 skipped / 0 failed of 69 · `DMA=1` 47/22/0 · `SHE=1` 49/20/0
- Legacy `test/` suite clean.
- Clean under `-std=c90 -Werror -Wall -Wextra`.
- **32-bit (i386/QEMU) negative control, run while the test existed:** with the
  fix `whTest_CryptoReqSize` passed; reverting only the two source files made the
  same binary **SIGSEGV** on the ~4 GB read — the actual exploit path.

Note: the `wh_test_list.c` revert also restored the 9-line brace-style
reformat of `whTestsServer[]` that this PR had carried incidentally.

Not in this PR: a permanent 32-bit CI job — that is #491.
