### PR TITLE
CI: reorganize workflow matrices

### DIFF
--- a/.github/workflows/build-and-run-examples.yml
+++ b/.github/workflows/build-and-run-examples.yml
@@ -19,13 +19,9 @@ jobs:
     strategy:
         matrix:
             transport: [ 'tcp', 'shm', 'dma', 'tls', 'psk' ]
-            asan: [ 'ASAN=1', 'ASAN=0' ]
-            debug: [ '', 'DEBUG_VERBOSE=1' ]
-            test: [ '', '--test' ]
-            auth: [ '', 'AUTH=1' ]
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v4
@@ -37,56 +33,61 @@ jobs:
         repository: wolfssl/wolfssl
         path: wolfssl
 
-    - name: Set TLS Environment Variable
+    # One job per transport; the flag combos run as a loop because a
+    # matrix job per combo spends about half its time on runner setup.
+    # The --test variants reuse the same binaries, so each of the 8
+    # flag builds serves two client runs.
+    - name: Build and run examples (all flag combos)
       run: |
-        if [ "${{ matrix.transport }}" = "tls" ] || [ "${{ matrix.transport }}" = "psk" ]; then
-          echo "TLS=1" >> $GITHUB_ENV
+        WS="$(pwd)"
+        SERVER_DIR="$WS/examples/posix/wh_posix_server"
+        CLIENT_DIR="$WS/examples/posix/wh_posix_client"
+        TRANSPORT="${{ matrix.transport }}"
+        if [ "$TRANSPORT" = "tls" ] || [ "$TRANSPORT" = "psk" ]; then
+          TLS=1
         else
-          echo "TLS=0" >> $GITHUB_ENV
+          TLS=0
         fi
-
-    # Build examples
-    - name: Build POSIX server
-      run: |
-        if [ "${{ matrix.transport }}" = "dma" ]; then
-          cd examples/posix/wh_posix_server && ${{ matrix.asan }} ${{ matrix.debug }} ${{ matrix.auth }} DMA=1 DEMO_KEK=1 make -j WOLFSSL_DIR=../../../wolfssl
-        else
-          cd examples/posix/wh_posix_server && ${{ matrix.asan }} ${{ matrix.debug }} ${{ matrix.auth }} TLS=${{ env.TLS }} DEMO_KEK=1 make -j WOLFSSL_DIR=../../../wolfssl
-        fi
-
-    - name: Build POSIX client
-      run: |
-        if [ "${{ matrix.transport }}" = "dma" ]; then
-          cd examples/posix/wh_posix_client && ${{ matrix.asan }} ${{ matrix.debug }} ${{ matrix.auth }} DMA=1 make -j WOLFSSL_DIR=../../../wolfssl
-        else
-          cd examples/posix/wh_posix_client && ${{ matrix.asan }} ${{ matrix.debug }} ${{ matrix.auth }} TLS=${{ env.TLS }} make -j WOLFSSL_DIR=../../../wolfssl
-        fi
-
-    # Start the server in the background
-    - name: Run POSIX server
-      run: |
-        cd examples/posix/wh_posix_server
-        if [ "${{ matrix.transport }}" = "psk" ]; then
-          echo "test_password" | ./Build/wh_posix_server.elf --type ${{ matrix.transport }} &
-        else
-          ./Build/wh_posix_server.elf --type ${{ matrix.transport }} &
-        fi
-        POSIX_SERVER_PID=$!
-        echo "POSIX_SERVER_PID=$POSIX_SERVER_PID" >> $GITHUB_ENV
-
-    # Run the client that connects to the server
-    - name: Run POSIX client
-      run: |
-        cd examples/posix/wh_posix_client
-        if [ "${{ matrix.transport }}" = "psk" ]; then
-          echo "test_password" | ./Build/wh_posix_client.elf --type ${{ matrix.transport }} ${{ matrix.test }}
-        else
-          ./Build/wh_posix_client.elf --type ${{ matrix.transport }} ${{ matrix.test }}
-        fi
-
-    # Optional: Kill the server process if it doesn't exit on its own
-    - name: Cleanup POSIX server
-      if: always()
-      run: kill $POSIX_SERVER_PID || true
-
-
+        for ASAN in ASAN=1 ASAN=0; do
+        for DEBUG in "" DEBUG_VERBOSE=1; do
+        for AUTH in "" AUTH=1; do
+          echo "::group::build $TRANSPORT $ASAN $DEBUG $AUTH"
+          make -C "$SERVER_DIR" clean
+          make -C "$CLIENT_DIR" clean
+          if [ "$TRANSPORT" = "dma" ]; then
+            env $ASAN $DEBUG $AUTH DMA=1 DEMO_KEK=1 \
+              make -C "$SERVER_DIR" -j WOLFSSL_DIR=../../../wolfssl
+            env $ASAN $DEBUG $AUTH DMA=1 \
+              make -C "$CLIENT_DIR" -j WOLFSSL_DIR=../../../wolfssl
+          else
+            env $ASAN $DEBUG $AUTH TLS=$TLS DEMO_KEK=1 \
+              make -C "$SERVER_DIR" -j WOLFSSL_DIR=../../../wolfssl
+            env $ASAN $DEBUG $AUTH TLS=$TLS \
+              make -C "$CLIENT_DIR" -j WOLFSSL_DIR=../../../wolfssl
+          fi
+          echo "::endgroup::"
+          for TEST in "" --test; do
+            echo "::group::run $TRANSPORT $ASAN $DEBUG $AUTH test='$TEST'"
+            rm -f "$SERVER_DIR"/*.bin
+            cd "$SERVER_DIR"
+            if [ "$TRANSPORT" = "psk" ]; then
+              echo "test_password" | ./Build/wh_posix_server.elf --type "$TRANSPORT" &
+            else
+              ./Build/wh_posix_server.elf --type "$TRANSPORT" &
+            fi
+            SERVER_PID=$!
+            sleep 1
+            cd "$CLIENT_DIR"
+            if [ "$TRANSPORT" = "psk" ]; then
+              echo "test_password" | ./Build/wh_posix_client.elf --type "$TRANSPORT" $TEST
+            else
+              ./Build/wh_posix_client.elf --type "$TRANSPORT" $TEST
+            fi
+            kill $SERVER_PID 2>/dev/null || true
+            wait $SERVER_PID 2>/dev/null || true
+            cd "$WS"
+            echo "::endgroup::"
+          done
+        done
+        done
+        done

--- a/.github/workflows/build-and-test-refactor.yml
+++ b/.github/workflows/build-and-test-refactor.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         # ubuntu runs the configs as parallel groups to shorten the
-        # critical path. macos runs only the light group: it is there to
+        # critical path. macos runs only the base group: it is there to
         # catch platform and compiler differences, not to repeat every
         # config ubuntu already covers, and its org-wide runner pool is
         # much smaller. That same small pool is why macos is dropped
@@ -35,12 +35,12 @@ jobs:
           fromJSON('[{"os":"ubuntu-latest","group":"pq-dma"},
           {"os":"ubuntu-latest","group":"wolfcrypt"},
           {"os":"ubuntu-latest","group":"threadsafe"},
-          {"os":"ubuntu-latest","group":"light"}]') ||
+          {"os":"ubuntu-latest","group":"base"}]') ||
           fromJSON('[{"os":"ubuntu-latest","group":"pq-dma"},
           {"os":"ubuntu-latest","group":"wolfcrypt"},
           {"os":"ubuntu-latest","group":"threadsafe"},
-          {"os":"ubuntu-latest","group":"light"},
-          {"os":"macos-latest","group":"light"}]') }}
+          {"os":"ubuntu-latest","group":"base"},
+          {"os":"macos-latest","group":"base"}]') }}
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
@@ -72,7 +72,7 @@ jobs:
 
     # Build and test standard build
     - name: Build and test refactor
-      if: matrix.group == 'light'
+      if: matrix.group == 'base'
       run: cd test-refactor/posix && make clean && make -j WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test standard build, with DMA and ASAN enabled
@@ -108,7 +108,7 @@ jobs:
 
     # Build and test debug build with ASAN and NOCRYPTO
     - name: Build and test refactor ASAN DEBUG NOCRYPTO
-      if: matrix.group == 'light'
+      if: matrix.group == 'base'
       run: cd test-refactor/posix && make clean && make -j DEBUG=1 ASAN=1 NOCRYPTO=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test debug build with ASAN and DMA
@@ -141,12 +141,12 @@ jobs:
 
     # Build and test with DEBUG=1
     - name: Build and test refactor with DEBUG
-      if: matrix.group == 'light'
+      if: matrix.group == 'base'
       run: cd test-refactor/posix && make clean && make -j DEBUG=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test with DEBUG_VERBOSE=1 (includes DEBUG)
     - name: Build and test refactor with DEBUG_VERBOSE
-      if: matrix.group == 'light'
+      if: matrix.group == 'base'
       run: cd test-refactor/posix && make clean && make -j DEBUG_VERBOSE=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test in multithreaded mode with everything enabled
@@ -173,22 +173,22 @@ jobs:
 
     # Build and test with AUTH=1
     - name: Build and test refactor with AUTH
-      if: matrix.group == 'light'
+      if: matrix.group == 'base'
       run: cd test-refactor/posix && make clean && make -j AUTH=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test with AUTH=1 and ASAN
     - name: Build and test refactor with AUTH ASAN
-      if: matrix.group == 'light'
+      if: matrix.group == 'base'
       run: cd test-refactor/posix && make clean && make -j AUTH=1 ASAN=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test with AUTH=1 and THREADSAFE
     - name: Build and test refactor with AUTH THREADSAFE ASAN
-      if: matrix.group == 'light'
+      if: matrix.group == 'base'
       run: cd test-refactor/posix && make clean && make -j AUTH=1 THREADSAFE=1 ASAN=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test with AUTH=1 and NOCRYPTO=1 (auth on, crypto off)
     - name: Build and test refactor with AUTH NOCRYPTO
-      if: matrix.group == 'light'
+      if: matrix.group == 'base'
       run: cd test-refactor/posix && make clean && make -j AUTH=1 NOCRYPTO=1 WOLFSSL_DIR=../../wolfssl && make run
 
     - name: Show ccache stats

--- a/.github/workflows/build-and-test-refactor.yml
+++ b/.github/workflows/build-and-test-refactor.yml
@@ -23,12 +23,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Exclude macOS for draft PRs due to its small pool
-        os: >-
+        # ubuntu runs the configs as parallel groups to shorten the
+        # critical path. macos runs only the light group: it is there to
+        # catch platform and compiler differences, not to repeat every
+        # config ubuntu already covers, and its org-wide runner pool is
+        # much smaller. That same small pool is why macos is dropped
+        # from draft PRs.
+        include: >-
           ${{ (github.event_name == 'pull_request' &&
           github.event.pull_request.draft) &&
-          fromJSON('["ubuntu-latest"]') ||
-          fromJSON('["ubuntu-latest", "macos-latest"]') }}
+          fromJSON('[{"os":"ubuntu-latest","group":"pq-dma"},
+          {"os":"ubuntu-latest","group":"wolfcrypt"},
+          {"os":"ubuntu-latest","group":"threadsafe"},
+          {"os":"ubuntu-latest","group":"light"}]') ||
+          fromJSON('[{"os":"ubuntu-latest","group":"pq-dma"},
+          {"os":"ubuntu-latest","group":"wolfcrypt"},
+          {"os":"ubuntu-latest","group":"threadsafe"},
+          {"os":"ubuntu-latest","group":"light"},
+          {"os":"macos-latest","group":"light"}]') }}
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
@@ -60,100 +72,123 @@ jobs:
 
     # Build and test standard build
     - name: Build and test refactor
+      if: matrix.group == 'light'
       run: cd test-refactor/posix && make clean && make -j WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test standard build, with DMA and ASAN enabled
     - name: Build and test refactor DMA ASAN
+      if: matrix.group == 'pq-dma'
       run: cd test-refactor/posix && make clean && make -j DMA=1 ASAN=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test with LMS and XMSS both in verify-only mode
     - name: Build and test refactor DMA ASAN LMS/XMSS verify-only
+      if: matrix.group == 'pq-dma'
       run: cd test-refactor/posix && make clean && make -j DMA=1 ASAN=1 LMS_VERIFY_ONLY=1 XMSS_VERIFY_ONLY=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test mixed: LMS verify-only, XMSS full (exercises shared gating)
     - name: Build and test refactor DMA ASAN LMS verify-only XMSS full
+      if: matrix.group == 'pq-dma'
       run: cd test-refactor/posix && make clean && make -j DMA=1 ASAN=1 LMS_VERIFY_ONLY=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test with ML-DSA in verify-only mode
     - name: Build and test refactor DMA ASAN MLDSA verify-only
+      if: matrix.group == 'pq-dma'
       run: cd test-refactor/posix && make clean && make -j DMA=1 ASAN=1 MLDSA_VERIFY_ONLY=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test ASAN build, with wolfCrypt tests enabled.
     - name: Build and test refactor ASAN TESTWOLFCRYPT
+      if: matrix.group == 'wolfcrypt'
       run: cd test-refactor/posix && make clean && make -j ASAN=1 TESTWOLFCRYPT=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test ASAN build, with wolfCrypt tests enabled and using the DMA devId.
     # LMS/XMSS verify-only; full PQ runs in DMA ASAN and THREADSAFE everything
     - name: Build and test refactor ASAN TESTWOLFCRYPT TESTWOLFCRYPT_DMA
+      if: matrix.group == 'wolfcrypt'
       run: cd test-refactor/posix && make clean && make -j ASAN=1 TESTWOLFCRYPT=1 TESTWOLFCRYPT_DMA=1 DMA=1 LMS_VERIFY_ONLY=1 XMSS_VERIFY_ONLY=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test debug build with ASAN and NOCRYPTO
     - name: Build and test refactor ASAN DEBUG NOCRYPTO
+      if: matrix.group == 'light'
       run: cd test-refactor/posix && make clean && make -j DEBUG=1 ASAN=1 NOCRYPTO=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test debug build with ASAN and DMA
     # LMS/XMSS verify-only; full PQ runs in DMA ASAN and THREADSAFE everything
     - name: Build and test refactor ASAN DEBUG DMA
+      if: matrix.group == 'wolfcrypt'
       run: cd test-refactor/posix && make clean && make -j DEBUG=1 ASAN=1 DMA=1 LMS_VERIFY_ONLY=1 XMSS_VERIFY_ONLY=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test with SHE and ASAN
     - name: Build and test refactor ASAN SHE
+      if: matrix.group == 'wolfcrypt'
       run: cd test-refactor/posix && make clean && make -j SHE=1 ASAN=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test with per-client crypto affinity enabled (runs the crypto
     # affinity unit test, gated behind WOLFHSM_CFG_CRYPTO_AFFINITY)
     - name: Build and test refactor CRYPTO_AFFINITY ASAN
+      if: matrix.group == 'wolfcrypt'
       run: cd test-refactor/posix && make clean && make -j CRYPTO_AFFINITY=1 ASAN=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test crypto affinity alongside DMA (exercises HW-devId path)
     # LMS/XMSS verify-only; full PQ runs in DMA ASAN and THREADSAFE everything
     - name: Build and test refactor CRYPTO_AFFINITY DMA ASAN
+      if: matrix.group == 'wolfcrypt'
       run: cd test-refactor/posix && make clean && make -j CRYPTO_AFFINITY=1 DMA=1 ASAN=1 LMS_VERIFY_ONLY=1 XMSS_VERIFY_ONLY=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test with global SHE keys (all SHE slots shared across clients)
     - name: Build and test refactor ASAN SHE_GLOBAL
+      if: matrix.group == 'wolfcrypt'
       run: cd test-refactor/posix && make clean && make -j SHE_GLOBAL=1 ASAN=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test with DEBUG=1
     - name: Build and test refactor with DEBUG
+      if: matrix.group == 'light'
       run: cd test-refactor/posix && make clean && make -j DEBUG=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test with DEBUG_VERBOSE=1 (includes DEBUG)
     - name: Build and test refactor with DEBUG_VERBOSE
+      if: matrix.group == 'light'
       run: cd test-refactor/posix && make clean && make -j DEBUG_VERBOSE=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test in multithreaded mode with everything enabled
     - name: Build and test refactor with THREADSAFE and everything
+      if: matrix.group == 'threadsafe'
       run: cd test-refactor/posix && make clean && make -j THREADSAFE=1 DMA=1 SHE=1 ASAN=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Same, with global SHE keys
     - name: Build and test refactor with THREADSAFE and everything and SHE_GLOBAL
+      if: matrix.group == 'threadsafe'
       run: cd test-refactor/posix && make clean && make -j THREADSAFE=1 DMA=1 SHE_GLOBAL=1 ASAN=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test in multithreaded mode with everything enabled and wolfCrypt tests
     # LMS/XMSS verify-only; full PQ runs in DMA ASAN and THREADSAFE everything
     - name: Build and test refactor with THREADSAFE and TESTWOLFCRYPT and everything
+      if: matrix.group == 'threadsafe'
       run: cd test-refactor/posix && make clean && make -j THREADSAFE=1 TESTWOLFCRYPT=1 DMA=1 SHE=1 ASAN=1 LMS_VERIFY_ONLY=1 XMSS_VERIFY_ONLY=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test in multithreaded mode with everything enabled and wolfCrypt tests with dma
     # LMS/XMSS verify-only; full PQ runs in DMA ASAN and THREADSAFE everything
     - name: Build and test refactor with THREADSAFE and TESTWOLFCRYPT with DMA
+      if: matrix.group == 'threadsafe'
       run: cd test-refactor/posix && make clean && make -j THREADSAFE=1 TESTWOLFCRYPT=1 TESTWOLFCRYPT_DMA=1 DMA=1 SHE=1 ASAN=1 LMS_VERIFY_ONLY=1 XMSS_VERIFY_ONLY=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test with AUTH=1
     - name: Build and test refactor with AUTH
+      if: matrix.group == 'light'
       run: cd test-refactor/posix && make clean && make -j AUTH=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test with AUTH=1 and ASAN
     - name: Build and test refactor with AUTH ASAN
+      if: matrix.group == 'light'
       run: cd test-refactor/posix && make clean && make -j AUTH=1 ASAN=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test with AUTH=1 and THREADSAFE
     - name: Build and test refactor with AUTH THREADSAFE ASAN
+      if: matrix.group == 'light'
       run: cd test-refactor/posix && make clean && make -j AUTH=1 THREADSAFE=1 ASAN=1 WOLFSSL_DIR=../../wolfssl && make run
 
     # Build and test with AUTH=1 and NOCRYPTO=1 (auth on, crypto off)
     - name: Build and test refactor with AUTH NOCRYPTO
+      if: matrix.group == 'light'
       run: cd test-refactor/posix && make clean && make -j AUTH=1 NOCRYPTO=1 WOLFSSL_DIR=../../wolfssl && make run
 
     - name: Show ccache stats

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,12 +23,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Exclude macOS for draft PRs due to its small pool
-        os: >-
+        # ubuntu runs the configs as parallel groups to shorten the
+        # critical path. macos runs only the light group: it is there to
+        # catch platform and compiler differences, not to repeat every
+        # config ubuntu already covers, and its org-wide runner pool is
+        # much smaller. That same small pool is why macos is dropped
+        # from draft PRs.
+        include: >-
           ${{ (github.event_name == 'pull_request' &&
           github.event.pull_request.draft) &&
-          fromJSON('["ubuntu-latest"]') ||
-          fromJSON('["ubuntu-latest", "macos-latest"]') }}
+          fromJSON('[{"os":"ubuntu-latest","group":"pq-dma"},
+          {"os":"ubuntu-latest","group":"wolfcrypt"},
+          {"os":"ubuntu-latest","group":"threadsafe"},
+          {"os":"ubuntu-latest","group":"light"}]') ||
+          fromJSON('[{"os":"ubuntu-latest","group":"pq-dma"},
+          {"os":"ubuntu-latest","group":"wolfcrypt"},
+          {"os":"ubuntu-latest","group":"threadsafe"},
+          {"os":"ubuntu-latest","group":"light"},
+          {"os":"macos-latest","group":"light"}]') }}
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
@@ -60,108 +72,133 @@ jobs:
 
     # Build and test standard build
     - name: Build and test
+      if: matrix.group == 'light'
       run: cd test && make clean && make -j WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test standard build, with DMA and ASAN enabled
     - name: Build and test DMA ASAN
+      if: matrix.group == 'pq-dma'
       run: cd test && make clean && make -j DMA=1 ASAN=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test with LMS and XMSS both in verify-only mode
     - name: Build and test DMA ASAN LMS/XMSS verify-only
+      if: matrix.group == 'pq-dma'
       run: cd test && make clean && make -j DMA=1 ASAN=1 LMS_VERIFY_ONLY=1 XMSS_VERIFY_ONLY=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test mixed: LMS verify-only, XMSS full (exercises shared gating)
     - name: Build and test DMA ASAN LMS verify-only XMSS full
+      if: matrix.group == 'pq-dma'
       run: cd test && make clean && make -j DMA=1 ASAN=1 LMS_VERIFY_ONLY=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test with ML-DSA in verify-only mode
     - name: Build and test DMA ASAN MLDSA verify-only
+      if: matrix.group == 'pq-dma'
       run: cd test && make clean && make -j DMA=1 ASAN=1 MLDSA_VERIFY_ONLY=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test ASAN build, with wolfCrypt tests enabled.
     - name: Build and test ASAN TESTWOLFCRYPT
+      if: matrix.group == 'wolfcrypt'
       run: cd test && make clean && make -j ASAN=1 TESTWOLFCRYPT=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test ASAN build, with wolfCrypt tests enabled and using the DMA devId.
     # LMS/XMSS verify-only; full PQ runs in DMA ASAN and THREADSAFE everything
     - name: Build and test ASAN TESTWOLFCRYPT TESTWOLFCRYPT_DMA
+      if: matrix.group == 'wolfcrypt'
       run: cd test && make clean && make -j ASAN=1 TESTWOLFCRYPT=1 TESTWOLFCRYPT_DMA=1 DMA=1 LMS_VERIFY_ONLY=1 XMSS_VERIFY_ONLY=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test debug build with ASAN and NOCRYPTO
     - name: Build and test ASAN DEBUG NOCRYPTO
+      if: matrix.group == 'light'
       run: cd test && make clean && make -j DEBUG=1 ASAN=1 NOCRYPTO=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test debug build with ASAN and DMA
     # LMS/XMSS verify-only; full PQ runs in DMA ASAN and THREADSAFE everything
     - name: Build and test ASAN DEBUG DMA
+      if: matrix.group == 'wolfcrypt'
       run: cd test && make clean && make -j DEBUG=1 ASAN=1 DMA=1 LMS_VERIFY_ONLY=1 XMSS_VERIFY_ONLY=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test with SHE and ASAN
     - name: Build and test ASAN SHE
+      if: matrix.group == 'wolfcrypt'
       run: cd test && make clean && make -j SHE=1 ASAN=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test with global SHE keys (all SHE slots shared across clients)
     - name: Build and test ASAN SHE_GLOBAL
+      if: matrix.group == 'wolfcrypt'
       run: cd test && make clean && make -j SHE_GLOBAL=1 ASAN=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test with per-client crypto affinity enabled (runs the crypto
     # affinity unit test, gated behind WOLFHSM_CFG_CRYPTO_AFFINITY)
     - name: Build and test CRYPTO_AFFINITY ASAN
+      if: matrix.group == 'wolfcrypt'
       run: cd test && make clean && make -j CRYPTO_AFFINITY=1 ASAN=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test crypto affinity alongside DMA (exercises HW-devId path)
     # LMS/XMSS verify-only; full PQ runs in DMA ASAN and THREADSAFE everything
     - name: Build and test CRYPTO_AFFINITY DMA ASAN
+      if: matrix.group == 'wolfcrypt'
       run: cd test && make clean && make -j CRYPTO_AFFINITY=1 DMA=1 ASAN=1 LMS_VERIFY_ONLY=1 XMSS_VERIFY_ONLY=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test with DEBUG=1
     - name: Build and test with DEBUG
+      if: matrix.group == 'light'
       run: cd test && make clean && make -j DEBUG=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test with DEBUG_VERBOSE=1 (includes DEBUG)
     - name: Build and test with DEBUG_VERBOSE
+      if: matrix.group == 'light'
       run: cd test && make clean && make -j DEBUG_VERBOSE=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test in multithreaded mode with everything enabled
     - name: Build and test with THREADSAFE and everything
+      if: matrix.group == 'threadsafe'
       run: cd test && make clean && make -j THREADSAFE=1 DMA=1 SHE=1 ASAN=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Same, with global SHE keys
     - name: Build and test with THREADSAFE and everything and SHE_GLOBAL
+      if: matrix.group == 'threadsafe'
       run: cd test && make clean && make -j THREADSAFE=1 DMA=1 SHE_GLOBAL=1 ASAN=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test in multithreaded mode with everything enabled and wolfCrypt tests
     # LMS/XMSS verify-only; full PQ runs in DMA ASAN and THREADSAFE everything
     - name: Build and test with THREADSAFE and TESTWOLFCRYPT and everything
+      if: matrix.group == 'threadsafe'
       run: cd test && make clean && make -j THREADSAFE=1 TESTWOLFCRYPT=1 DMA=1 SHE=1 ASAN=1 LMS_VERIFY_ONLY=1 XMSS_VERIFY_ONLY=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test in multithreaded mode with everything enabled and wolfCrypt tests with dma
     # LMS/XMSS verify-only; full PQ runs in DMA ASAN and THREADSAFE everything
     - name: Build and test with THREADSAFE and TESTWOLFCRYPT with DMA
+      if: matrix.group == 'threadsafe'
       run: cd test && make clean && make -j THREADSAFE=1 TESTWOLFCRYPT=1 TESTWOLFCRYPT_DMA=1 DMA=1 SHE=1 ASAN=1 LMS_VERIFY_ONLY=1 XMSS_VERIFY_ONLY=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test with AUTH=1
     - name: Build and test with AUTH
+      if: matrix.group == 'light'
       run: cd test && make clean && make -j AUTH=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test with AUTH=1 and ASAN
     - name: Build and test with AUTH ASAN
+      if: matrix.group == 'light'
       run: cd test && make clean && make -j AUTH=1 ASAN=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test with AUTH=1 and THREADSAFE
     - name: Build and test with AUTH THREADSAFE ASAN
+      if: matrix.group == 'light'
       run: cd test && make clean && make -j AUTH=1 THREADSAFE=1 ASAN=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test with AUTH=1 and NOCRYPTO=1 (auth on, crypto off)
     - name: Build and test with AUTH NOCRYPTO
+      if: matrix.group == 'light'
       run: cd test && make clean && make -j AUTH=1 NOCRYPTO=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test the per-client trusted certificate verify cache
     - name: Build and test with CERT_VERIFY_CACHE ASAN
+      if: matrix.group == 'light'
       run: cd test && make clean && make -j CERT_VERIFY_CACHE=1 ASAN=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test the global (cross-client) trusted certificate verify cache
     - name: Build and test with CERT_VERIFY_CACHE_GLOBAL ASAN
+      if: matrix.group == 'light'
       run: cd test && make clean && make -j CERT_VERIFY_CACHE_GLOBAL=1 ASAN=1 WOLFSSL_DIR=../wolfssl && make run
 
     - name: Show ccache stats

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         # ubuntu runs the configs as parallel groups to shorten the
-        # critical path. macos runs only the light group: it is there to
+        # critical path. macos runs only the base group: it is there to
         # catch platform and compiler differences, not to repeat every
         # config ubuntu already covers, and its org-wide runner pool is
         # much smaller. That same small pool is why macos is dropped
@@ -35,12 +35,12 @@ jobs:
           fromJSON('[{"os":"ubuntu-latest","group":"pq-dma"},
           {"os":"ubuntu-latest","group":"wolfcrypt"},
           {"os":"ubuntu-latest","group":"threadsafe"},
-          {"os":"ubuntu-latest","group":"light"}]') ||
+          {"os":"ubuntu-latest","group":"base"}]') ||
           fromJSON('[{"os":"ubuntu-latest","group":"pq-dma"},
           {"os":"ubuntu-latest","group":"wolfcrypt"},
           {"os":"ubuntu-latest","group":"threadsafe"},
-          {"os":"ubuntu-latest","group":"light"},
-          {"os":"macos-latest","group":"light"}]') }}
+          {"os":"ubuntu-latest","group":"base"},
+          {"os":"macos-latest","group":"base"}]') }}
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
@@ -72,7 +72,7 @@ jobs:
 
     # Build and test standard build
     - name: Build and test
-      if: matrix.group == 'light'
+      if: matrix.group == 'base'
       run: cd test && make clean && make -j WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test standard build, with DMA and ASAN enabled
@@ -108,7 +108,7 @@ jobs:
 
     # Build and test debug build with ASAN and NOCRYPTO
     - name: Build and test ASAN DEBUG NOCRYPTO
-      if: matrix.group == 'light'
+      if: matrix.group == 'base'
       run: cd test && make clean && make -j DEBUG=1 ASAN=1 NOCRYPTO=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test debug build with ASAN and DMA
@@ -141,12 +141,12 @@ jobs:
 
     # Build and test with DEBUG=1
     - name: Build and test with DEBUG
-      if: matrix.group == 'light'
+      if: matrix.group == 'base'
       run: cd test && make clean && make -j DEBUG=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test with DEBUG_VERBOSE=1 (includes DEBUG)
     - name: Build and test with DEBUG_VERBOSE
-      if: matrix.group == 'light'
+      if: matrix.group == 'base'
       run: cd test && make clean && make -j DEBUG_VERBOSE=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test in multithreaded mode with everything enabled
@@ -173,32 +173,32 @@ jobs:
 
     # Build and test with AUTH=1
     - name: Build and test with AUTH
-      if: matrix.group == 'light'
+      if: matrix.group == 'base'
       run: cd test && make clean && make -j AUTH=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test with AUTH=1 and ASAN
     - name: Build and test with AUTH ASAN
-      if: matrix.group == 'light'
+      if: matrix.group == 'base'
       run: cd test && make clean && make -j AUTH=1 ASAN=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test with AUTH=1 and THREADSAFE
     - name: Build and test with AUTH THREADSAFE ASAN
-      if: matrix.group == 'light'
+      if: matrix.group == 'base'
       run: cd test && make clean && make -j AUTH=1 THREADSAFE=1 ASAN=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test with AUTH=1 and NOCRYPTO=1 (auth on, crypto off)
     - name: Build and test with AUTH NOCRYPTO
-      if: matrix.group == 'light'
+      if: matrix.group == 'base'
       run: cd test && make clean && make -j AUTH=1 NOCRYPTO=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test the per-client trusted certificate verify cache
     - name: Build and test with CERT_VERIFY_CACHE ASAN
-      if: matrix.group == 'light'
+      if: matrix.group == 'base'
       run: cd test && make clean && make -j CERT_VERIFY_CACHE=1 ASAN=1 WOLFSSL_DIR=../wolfssl && make run
 
     # Build and test the global (cross-client) trusted certificate verify cache
     - name: Build and test with CERT_VERIFY_CACHE_GLOBAL ASAN
-      if: matrix.group == 'light'
+      if: matrix.group == 'base'
       run: cd test && make clean && make -j CERT_VERIFY_CACHE_GLOBAL=1 ASAN=1 WOLFSSL_DIR=../wolfssl && make run
 
     - name: Show ccache stats


### PR DESCRIPTION
Two changes to level out the execution time per runner.

`build-and-test.yml` (and refactor version) are the long pole due to running in serial -- so these test are split into batches. Ubuntu only to not stress the limited Mac runners.

`build-and-run-examples.yml` meanwhile has the opposite problem: each test farmed out to a new runner -- so these tests are combined into batches. 

And for Mac, only ever test the base build (incl auth, asan and debug). 

Update: longest current job (macos base) is about 8 min. Assuming concurrent runners, this is the overall CI runtime