### PR TITLE
Add 32-bit CI job, fix sign-compare warnings in POSIX flash port

### DIFF
--- a/.github/workflows/build-and-test-refactor.yml
+++ b/.github/workflows/build-and-test-refactor.yml
@@ -158,3 +158,64 @@ jobs:
 
     - name: Show ccache stats
       run: ccache -s
+
+  # 32-bit build, where size_t/off_t/ssize_t are 32 bits wide. Every supported
+  # wolfHSM port is 32-bit, so request-size overflow and width-mismatch bugs
+  # are only visible here. Linux only: gcc-multilib has no macOS equivalent.
+  build-32bit:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+    - uses: actions/checkout@v4
+
+    # List host info
+    - name: Host info
+      run: uname -a
+
+    # 32-bit libc and startup files for -m32
+    - name: Install 32-bit toolchain
+      run: sudo apt-get update && sudo apt-get install -y gcc-multilib
+
+    # List compiler version
+    - name: List compiler version
+      run: gcc --version
+
+    # pull and build wolfssl
+    - name: Checkout wolfssl
+      uses: actions/checkout@v4
+      with:
+        repository: wolfssl/wolfssl
+        path: wolfssl
+
+    # Compiler cache; PR runs restore without saving. Own config-hash so the
+    # -m32 objects get a separate cache namespace from the 64-bit build job
+    - name: Set up ccache
+      uses: ./.github/actions/ccache-setup
+      with:
+        workflow-id: build-and-test-refactor
+        config-hash: m32
+        read-only: ${{ github.event_name == 'pull_request' }}
+
+    # Build and test standard build at 32-bit
+    - name: Build and test refactor 32-bit
+      run: cd test-refactor/posix && make clean && make -j ARCHFLAGS=-m32 WOLFSSL_DIR=../../wolfssl && make run ARCHFLAGS=-m32 WOLFSSL_DIR=../../wolfssl
+
+    # Build and test SHE and DMA at 32-bit, exercising the request size
+    # guards and the DMA handlers at the narrower width
+    - name: Build and test refactor 32-bit SHE DMA
+      run: cd test-refactor/posix && make clean && make -j ARCHFLAGS=-m32 SHE=1 DMA=1 WOLFSSL_DIR=../../wolfssl && make run ARCHFLAGS=-m32 SHE=1 DMA=1 WOLFSSL_DIR=../../wolfssl
+
+    # Build and test without crypto at 32-bit, which selects a different
+    # source set and skips the wolfSSL sources entirely
+    - name: Build and test refactor 32-bit NOCRYPTO
+      run: cd test-refactor/posix && make clean && make -j ARCHFLAGS=-m32 NOCRYPTO=1 WOLFSSL_DIR=../../wolfssl && make run ARCHFLAGS=-m32 NOCRYPTO=1 WOLFSSL_DIR=../../wolfssl
+
+    # The test-refactor harness wires every NVM test to the RAM simulator, so
+    # the legacy suite is the only one that runs the POSIX flash file backend
+    - name: Build and test legacy suite 32-bit
+      run: cd test && make clean && make -j ARCHFLAGS=-m32 WOLFSSL_DIR=../wolfssl && make run ARCHFLAGS=-m32 WOLFSSL_DIR=../wolfssl
+
+    - name: Show ccache stats
+      run: ccache -s

--- a/port/posix/posix_flash_file.c
+++ b/port/posix/posix_flash_file.c
@@ -23,6 +23,7 @@
  */
 
 #include <stddef.h>     /* For NULL */
+#include <stdint.h>     /* For uint64_t, UINT32_MAX */
 #include <fcntl.h>      /* For O_xxxx */
 #include <sys/types.h>  /* For off_t, stat */
 #include <sys/stat.h>   /* For fstat */
@@ -41,24 +42,26 @@ enum {
 };
 
 /** Local declarations */
-#define MAX_OFFSET(_context) ((_context)->partition_size * 2)
+/* Computed in 64 bits so the doubling cannot wrap and the comparisons against
+ * it stay unsigned on platforms with a 32-bit off_t */
+#define MAX_OFFSET(_context) ((uint64_t)(_context)->partition_size * 2)
 
 /* Helper for pwrite like memset.  Write the byte in c to filedes for size
- * bytes starting at offset */
-static ssize_t pfill(int filedes, int c, size_t size, off_t offset);
+ * bytes starting at offset.  Returns 0 on success, -1 on error */
+static int pfill(int filedes, int c, size_t size, off_t offset);
 
 /** Local implementations */
-static ssize_t pfill(int filedes, int c, size_t size, off_t offset)
+static int pfill(int filedes, int c, size_t size, off_t offset)
 {
-    int rc = 0;
+    ssize_t rc = 0;
     uint8_t data = (uint8_t)c;
     size_t count = 0;
     while (count < size) {
         rc = pwrite(filedes, &data, sizeof(data), offset + count);
-        if (rc != sizeof(data)) return rc;
+        if (rc != (ssize_t)sizeof(data)) return -1;
         count += sizeof(data);
     }
-    return size;
+    return 0;
 }
 
 
@@ -69,6 +72,7 @@ int posixFlashFile_Init(   void* c,
     const posixFlashFileConfig* config = cf;
     struct stat st = {0};
     off_t file_size = 0;
+    uint64_t max_offset = 0;
 
     int ret = 0;
     int rc = 0;
@@ -87,23 +91,34 @@ int posixFlashFile_Init(   void* c,
         context->partition_size = config->partition_size;
         context->erased_byte = config->erased_byte;
 
+        max_offset = MAX_OFFSET(context);
+
+        /* The flash interface addresses with uint32_t offsets and seeks with
+         * off_t, so reject a partition whose doubled size exceeds either */
+        if ((max_offset > UINT32_MAX) ||
+            ((uint64_t)(off_t)max_offset != max_offset)) {
+            posixFlashFile_Cleanup(context);
+            return WH_ERROR_BADARGS;
+        }
+
         rc = fstat(context->fd_p1 - 1, &st);
         if (rc == 0) {
             file_size = st.st_size;
 
-            if (file_size < MAX_OFFSET(context)) {
+            if ((uint64_t)file_size < max_offset) {
                 /* Write ERASE_BYTE to fill up to the storage size */
                 rc = pfill( context->fd_p1 - 1,
                             context->erased_byte,
-                            MAX_OFFSET(context) - file_size,
+                            (size_t)(max_offset - (uint64_t)file_size),
                             file_size);
                 if (rc < 0) {
                     /* Error while writing */
                     ret = WH_ERROR_ABORTED;
                 }
-            } else if (file_size > MAX_OFFSET(context)) {
+            } else if ((uint64_t)file_size > max_offset) {
+                /* max_offset is below file_size here, so it fits an off_t */
                 rc = ftruncate( context->fd_p1 - 1,
-                                MAX_OFFSET(context));
+                                (off_t)max_offset);
                 if (rc < 0) {
                     /* Error while truncating */
                     ret = WH_ERROR_ABORTED;
@@ -179,7 +194,7 @@ int posixFlashFile_Read(   void* c,
 {
     posixFlashFileContext* context = c;
     if (    (context == NULL) ||
-            (offset + size > MAX_OFFSET(context))){
+            ((uint64_t)offset + size > MAX_OFFSET(context))){
         return WH_ERROR_BADARGS;
     }
 
@@ -193,7 +208,7 @@ int posixFlashFile_Read(   void* c,
                         (void*) data,
                         (size_t) size,
                         (off_t) offset);
-    if (rc != size) {
+    if ((rc < 0) || ((size_t)rc != (size_t)size)) {
         /* Error while reading */
         return WH_ERROR_ABORTED;
     }
@@ -205,7 +220,7 @@ int posixFlashFile_Program(void* c,
 {
     posixFlashFileContext* context = c;
     if (    (context == NULL) ||
-            (offset + size > MAX_OFFSET(context))){
+            ((uint64_t)offset + size > MAX_OFFSET(context))){
         return WH_ERROR_BADARGS;
     }
 
@@ -224,7 +239,7 @@ int posixFlashFile_Program(void* c,
                             (void*) data,
                             (size_t) size,
                             (off_t) offset);
-    if (rc != size) {
+    if ((rc < 0) || ((size_t)rc != (size_t)size)) {
         /* Error while writing */
         return WH_ERROR_ABORTED;
     }
@@ -238,11 +253,12 @@ int posixFlashFile_Verify( void* c,
 {
     posixFlashFileContext* context = c;
     uint8_t buffer[PFF_VERIFY_BUFFER_LEN];
+    /* offset + size is bounded below MAX_OFFSET (<= UINT32_MAX by Init) */
     uint32_t end_offset = offset + size;
     uint32_t data_offset = 0;
 
     if (    (context == NULL) ||
-            (offset + size > MAX_OFFSET(context))){
+            ((uint64_t)offset + size > MAX_OFFSET(context))){
         return WH_ERROR_BADARGS;
     }
 
@@ -278,7 +294,7 @@ int posixFlashFile_Erase(void* c,
 {
     posixFlashFileContext* context = c;
     if (    (context == NULL) ||
-            (offset + size > MAX_OFFSET(context))){
+            ((uint64_t)offset + size > MAX_OFFSET(context))){
         return WH_ERROR_BADARGS;
     }
 
@@ -292,11 +308,11 @@ int posixFlashFile_Erase(void* c,
         return WH_ERROR_LOCKED;
     }
 
-    ssize_t rc = pfill( context->fd_p1 - 1,
-                        context->erased_byte,
-                        (size_t) size,
-                        (off_t) offset);
-    if (rc != size) {
+    int rc = pfill( context->fd_p1 - 1,
+                    context->erased_byte,
+                    (size_t) size,
+                    (off_t) offset);
+    if (rc != 0) {
         /* Error while writing */
         return WH_ERROR_ABORTED;
     }
@@ -310,11 +326,12 @@ int posixFlashFile_BlankCheck(void* c,
     posixFlashFileContext* context = c;
     uint8_t buffer[PFF_BLANKCHECK_BUFFER_LEN];
     uint8_t erased[PFF_BLANKCHECK_BUFFER_LEN];
+    /* offset + size is bounded below MAX_OFFSET (<= UINT32_MAX by Init) */
     uint32_t end_offset = offset + size;
     uint32_t this_size = 0;
 
     if (    (context == NULL) ||
-            (offset + size > MAX_OFFSET(context))){
+            ((uint64_t)offset + size > MAX_OFFSET(context))){
         return WH_ERROR_BADARGS;
     }
 

--- a/test/wh_test_nvm_flash.c
+++ b/test/wh_test_nvm_flash.c
@@ -717,6 +717,27 @@ int whTest_NvmFlash_PosixFileSim(void)
     return 0;
 }
 
+/* Exercise the guard that rejects a partition whose doubled size cannot be
+ * addressed by the uint32_t flash interface. MAX_OFFSET here is 0x100000000,
+ * which exceeds UINT32_MAX on every platform, so the rejection is portable. */
+static int whTest_NvmFlash_PosixOversizedPartition(void)
+{
+    const whFlashCb       myCb[1]              = {POSIX_FLASH_FILE_CB};
+    posixFlashFileContext myHalFlashContext[1] = {0};
+    posixFlashFileConfig  myHalFlashConfig[1]  = {{
+          .filename       = "myNvmOversized.bin",
+          .partition_size = 0x80000000u, /* doubled = 0x100000000 */
+          .erased_byte    = (~(uint8_t)0),
+    }};
+
+    /* Init must reject the partition; nothing is left open to clean up */
+    WH_TEST_ASSERT_RETURN(WH_ERROR_BADARGS ==
+            myCb->Init(myHalFlashContext, myHalFlashConfig));
+
+    unlink(myHalFlashConfig[0].filename);
+    return 0;
+}
+
 #endif
 
 
@@ -731,6 +752,9 @@ int whTest_NvmFlash(void)
 #if defined(WOLFHSM_CFG_TEST_POSIX)
     WH_TEST_PRINT("Testing NVM flash with POSIX file sim...\n");
     WH_TEST_ASSERT(0 == whTest_NvmFlash_PosixFileSim());
+
+    WH_TEST_PRINT("Testing POSIX oversized-partition rejection...\n");
+    WH_TEST_ASSERT(0 == whTest_NvmFlash_PosixOversizedPartition());
 #endif
 
     return 0;


### PR DESCRIPTION
### Problem
No CI job builds or runs wolfHSM at 32-bit width, yet every supported port is
32-bit. The AES `needed_size` overflow class #487 only triggers at 32 bits, so it was
invisible to every gate. Adding a 32-bit job also surfaced width bugs in the
POSIX flash port that a 64-bit host silently hides.

### Fix (`port/posix/posix_flash_file.c`)
- **sign-compare:** 5 `off_t`/`ssize_t`-vs-`uint32_t` comparisons that fail
  `-Werror` at 32 bits. The `rc != size` byte-count checks became
  `(rc < 0) || ((size_t)rc != (size_t)size)`.
- **`MAX_OFFSET`:** now computed in `uint64_t` so the doubling can't wrap and the
  `_Init` comparisons stay unsigned at every width — avoids a signed narrowing
  that could take a large `partition_size` into `ftruncate(<negative>)`.
- **`pfill()`:** returns an `int` status (`0`/`-1`) instead of a `size_t` count
  cast to `ssize_t`, which aliased negative above 2 GiB and tripped the new
  `rc < 0` guard.

### CI (`.github/workflows/build-and-test-refactor.yml`)
New ubuntu-only `build-32bit` job (`gcc-multilib`), parallel to the 64-bit matrix:

| Step | Why |
|---|---|
| refactor default / `SHE=1 DMA=1` | size guards + DMA handlers at 32-bit |
| legacy `test/` suite | only harness that runs `POSIX_FLASH_FILE_CB`; refactor uses the RAM sim |
| `NOCRYPTO=1` | distinct source set, skips wolfSSL |

`ARCHFLAGS` is passed to `make run` too, so a stale rebuild can't switch arch mid-step.

### Verification
64-bit and 32-bit (i386/QEMU) match exactly: default 43/26/0, `SHE+DMA` 53/16/0,
`NOCRYPTO` 16/53/0, legacy suite exit 0. Zero warnings, `-Werror` intact —
including the legacy tree's `-Wpointer-arith`, never compiled at 32-bit before.
Built against wolfSSL master tip, so no upstream `-Werror` relaxation is needed.
The legacy run executes `posixFlashFile_*` for the first time at 32-bit width;
a negative control (neutered `pfill()`) aborts that suite, confirming the step gates.