### PR TITLE
Strip server-only flags from client metadata in WH_KEY_CACHE_RANDOM

### DIFF
--- a/src/wh_server_keystore.c
+++ b/src/wh_server_keystore.c
@@ -2567,6 +2567,8 @@ int wh_Server_HandleKeyRequest(whServerContext* server, uint16_t magic,
                     WH_KEYTYPE_CRYPTO, server->comm->client_id, req.id);
                 meta->access = WH_NVM_ACCESS_ANY;
                 meta->flags  = req.flags;
+                /* clients can't set server-only flags */
+                _SanitizeClientFlags(meta);
                 meta->len    = req.sz;
                 /* truncate label if it's too large */
                 if (req.labelSz > WH_NVM_LABEL_LEN) {

--- a/test-refactor/client-server/wh_test_keywrap.c
+++ b/test-refactor/client-server/wh_test_keywrap.c
@@ -25,7 +25,8 @@
  *   _whTest_KeywrapTrustedKekPolicy - wrap-export and unwrap-and-cache must
  *                                    refuse a plain client KEK, and a client
  *                                    cannot forge WH_NVM_FLAGS_TRUSTED via the
- *                                    NVM add, HKDF cache, or key cache paths
+ *                                    NVM add, HKDF cache, key cache, or key
+ *                                    cache-random paths
  *   _whTest_KeywrapDataWrapUsage   - data wrap requires USAGE_WRAP on the KEK
  *   _whTest_KeywrapKeyUnwrapUnderflow - undersized wrapped-key blobs must
  *                                    return WH_ERROR_BADARGS, not underflow
@@ -73,6 +74,7 @@
 #define WH_TEST_KW_NVM_FORGE_ID 0x63
 #define WH_TEST_KW_NOWRAP_ID 0x64
 #define WH_TEST_KW_META_ID 0x65
+#define WH_TEST_KW_RAND_FORGE_ID 0x66
 
 /* Cache a plain software KEK with wrap usage. It is an ordinary client key:
  * good enough for KeyWrap/KeyUnwrapAndExport, never for the trusted-KEK
@@ -98,14 +100,15 @@ static int _CacheSwKek(whClientContext* client, whKeyId* outKekId)
  * WH_NVM_FLAGS_TRUSTED). Prove that (a) a plain client-cached USAGE_WRAP key is
  * refused as their KEK, and that a client cannot forge a trusted KEK by
  * setting WH_NVM_FLAGS_TRUSTED itself through (b) the checked NVM add path, (c)
- * the HKDF cache-import path, or (d) the key cache path -- the server strips
- * the flag on each, so the key is still refused */
+ * the HKDF cache-import path, (d) the key cache path, or (e) the cache-random
+ * path -- the server strips the flag on each, so the key is still refused */
 static int _whTest_KeywrapTrustedKekPolicy(whClientContext* client)
 {
     int           ret;
-    whKeyId       kekId    = WH_KEYID_ERASED;
-    whKeyId       srcKeyId = WH_TEST_KW_SRC_ID;
-    whKeyId       forgeId  = WH_TEST_KW_CACHE_FORGE_ID;
+    whKeyId       kekId       = WH_KEYID_ERASED;
+    whKeyId       srcKeyId    = WH_TEST_KW_SRC_ID;
+    whKeyId       forgeId     = WH_TEST_KW_CACHE_FORGE_ID;
+    whKeyId       randForgeId = WH_TEST_KW_RAND_FORGE_ID;
     uint8_t       srcKey[WH_TEST_KW_KEYSIZE];
     uint8_t       label[WH_NVM_LABEL_LEN] = "TrustedKek key";
     uint8_t       wrappedKey[WH_TEST_KW_WRAPPED_KEYSIZE];
@@ -261,6 +264,37 @@ static int _whTest_KeywrapTrustedKekPolicy(whClientContext* client)
     if (ret != WH_ERROR_ACCESS) {
         WH_ERROR_PRINT("trusted-kek: wrap-export with client-flagged KEK "
                        "expected ACCESS, got %d\n",
+                       ret);
+        ret = WH_ERROR_ABORTED;
+        goto cleanup;
+    }
+
+    /* (e) Same forgery through the cache-random path, where the server picks
+     * the key material. The evict must succeed too: an unstripped TRUSTED flag
+     * freezes the slot against every client op, evict included */
+    ret = wh_Client_KeyCacheRandom(
+        client, WH_NVM_FLAGS_TRUSTED | WH_NVM_FLAGS_USAGE_WRAP, label,
+        (uint16_t)sizeof(label), WH_TEST_KW_KEYSIZE, &randForgeId);
+    if (ret != WH_ERROR_OK) {
+        WH_ERROR_PRINT("trusted-kek: cache-random forged KEK failed %d\n", ret);
+        goto cleanup;
+    }
+    wrappedKeySz = sizeof(wrappedKey);
+    ret = wh_Client_KeyWrapExport(client, WC_CIPHER_AES_GCM, srcKeyId,
+                                  WH_KEYTYPE_CRYPTO, randForgeId, wrappedKey,
+                                  &wrappedKeySz);
+    if (ret != WH_ERROR_ACCESS) {
+        WH_ERROR_PRINT("trusted-kek: wrap-export with cache-random KEK "
+                       "expected ACCESS, got %d\n",
+                       ret);
+        (void)wh_Client_KeyEvict(client, randForgeId);
+        ret = WH_ERROR_ABORTED;
+        goto cleanup;
+    }
+    ret = wh_Client_KeyEvict(client, randForgeId);
+    if (ret != WH_ERROR_OK) {
+        WH_ERROR_PRINT("trusted-kek: evict cache-random KEK expected OK, got "
+                       "%d\n",
                        ret);
         ret = WH_ERROR_ABORTED;
         goto cleanup;


### PR DESCRIPTION
### Problem
`_SanitizeClientFlags()` clears `WH_NVM_FLAGS_SERVER_ONLY` (currently exactly
`WH_NVM_FLAGS_TRUSTED`) and is documented as being called "at every point where
client-supplied metadata becomes a `whNvmMetadata`". The `WH_KEY_CACHE_RANDOM`
handler broke that invariant: it assigned `meta->flags = req.flags;` straight
from the wire with no strip, and `_KeystoreCacheRandomKey()` copies the metadata
verbatim into the cache slot. A single client request could therefore mint a key
carrying `WH_NVM_FLAGS_TRUSTED`, with two consequences:

- **Permanent cache-slot lock-out.** `_KeystoreCheckPolicy()` rejects every
  client keystore op on a trusted key, including `WH_KS_OP_EVICT`. The slot is
  created uncommitted, so auto-eviction never reclaims it either — repeating
  across ids fills the whole key cache irrecoverably.
- **Client-designated trusted KEK.** `_KeywrapResolveKek()` grants trusted-KEK
  status purely on the flag, defeating the `requireTrustedKek` anti-forgery gate
  on `WH_KEY_WRAPEXPORT` and `WH_KEY_KEYUNWRAPANDCACHE`.

This was the only client-facing metadata path in the tree missing the strip.

### Fix (`src/wh_server_keystore.c`)
Added the missing `_SanitizeClientFlags(meta);` in the `WH_KEY_CACHE_RANDOM`
case, matching `WH_KEY_CACHE` and `WH_KEY_CACHE_DMA` verbatim.

The strip is deliberately **not** pushed down into the cache helpers: the
unchecked `wh_Server_KeystoreCacheKey()` is the server-internal path, and
`wh_Server_KeystoreReadKey()` (NVM read-through), `wh_server_she.c`, and the
POSIX example server's boot provisioning all require `WH_NVM_FLAGS_TRUSTED` to
survive it.

Closes f_7156.

### Tests
Extended `_whTest_KeywrapTrustedKekPolicy` in
`test-refactor/client-server/wh_test_keywrap.c` with a case (e) alongside the
existing NVM-add, HKDF-derive, and key-cache forgery cases. It asserts the
cache-random request still succeeds, that wrap-export under the resulting KEK is
refused with `WH_ERROR_ACCESS`, and — unlike cases (a)–(d), which discard the
evict result — that the slot is still evictable, covering the lock-out.

### Verification
- `test-refactor`: 43 passed, 26 skipped, 0 failed of 69. Legacy `test/` suite
  clean. Both build under `-std=c90 -Werror -Wall -Wextra`.
- Negative controls, fix reverted: wrap-export returns `0` instead of
  `WH_ERROR_ACCESS`, and evict returns `-2101` (`WH_ERROR_ACCESS`). Both new
  assertions catch the bug independently.