### PR TITLE
test: cover the DMA allow list upper boundary

### DIFF
--- a/test-refactor/misc/wh_test_dma.c
+++ b/test-refactor/misc/wh_test_dma.c
@@ -56,6 +56,17 @@ static int _whTest_DmaAllowListBasic(void)
         (void*)((uintptr_t)0x10000), 0x1000);
     WH_TEST_ASSERT_RETURN(rc == WH_ERROR_OK);
 
+    /* [addr, addr+size): exact fit is allowed, one more byte is not */
+    rc = wh_Dma_CheckMemOperAgainstAllowList(
+        &allowList, WH_DMA_OPER_CLIENT_READ_PRE,
+        (void*)((uintptr_t)0x10000), 0x10000);
+    WH_TEST_ASSERT_RETURN(rc == WH_ERROR_OK);
+
+    rc = wh_Dma_CheckMemOperAgainstAllowList(
+        &allowList, WH_DMA_OPER_CLIENT_READ_PRE,
+        (void*)((uintptr_t)0x10000), 0x10001);
+    WH_TEST_ASSERT_RETURN(rc == WH_ERROR_ACCESS);
+
     rc = wh_Dma_CheckMemOperAgainstAllowList(
         &allowList, WH_DMA_OPER_CLIENT_READ_PRE,
         (void*)((uintptr_t)0x30000), 0x1000);

--- a/test/wh_test_dma.c
+++ b/test/wh_test_dma.c
@@ -277,6 +277,20 @@ static int whTest_DmaAllowListBasic(void)
         (void*)((uintptr_t)0x10000), 0x1000);
     WH_TEST_ASSERT_RETURN(rc == WH_ERROR_OK);
 
+    /* An allow list entry covers [addr, addr + size). A request that fills the
+     * entry exactly is therefore allowed, and one more byte is not. */
+    WH_TEST_PRINT("  Testing exact-fit allow list acceptance...\n");
+    rc = wh_Dma_CheckMemOperAgainstAllowList(
+        &allowList, WH_DMA_OPER_CLIENT_READ_PRE,
+        (void*)((uintptr_t)0x10000), 0x10000);
+    WH_TEST_ASSERT_RETURN(rc == WH_ERROR_OK);
+
+    WH_TEST_PRINT("  Testing one-byte overrun rejection...\n");
+    rc = wh_Dma_CheckMemOperAgainstAllowList(
+        &allowList, WH_DMA_OPER_CLIENT_READ_PRE,
+        (void*)((uintptr_t)0x10000), 0x10001);
+    WH_TEST_ASSERT_RETURN(rc == WH_ERROR_ACCESS);
+
     WH_TEST_PRINT("  Testing basic allow list rejection...\n");
     rc = wh_Dma_CheckMemOperAgainstAllowList(
         &allowList, WH_DMA_OPER_CLIENT_READ_PRE,


### PR DESCRIPTION
## Summary

`_checkAddrAgainstAllowList` accepts a request when `endAddr <= allowListEndAddr`
(`src/wh_dma.c:82`). An allow list entry covers the half-open range
`[addr, addr + size)`, so a request that fills an entry exactly is legal.

No test sent such a request. The basic test used a 0x1000 request against a
0x10000 entry, and the overflow tests stop at the earlier wrap guard, so the
upper bound was never exercised. Changing `<=` to `<` broke no test, yet it
would make the server reject every client that maps one full allowed region.

Adds two cases to the basic allow list test in both suites:

- a request that fills the entry exactly must return `WH_ERROR_OK`
- a request of one more byte must return `WH_ERROR_ACCESS`

The pair fixes both sides of the bound. The first catches a tightened
comparison (`<=` to `<`); the second catches a loosened one (`+ 1`), which the
existing out-of-range case at 0x30000 does not.

No production code changes. Both `test/` and `test-refactor/` are updated
because each runs in its own CI workflow and the migration compares their
coverage.