### PR TITLE
Implement HMAC-SHA3 benchmarks (224/256/384/512)

### DIFF
--- a/benchmark/bench_modules/wh_bench_mod_all.h
+++ b/benchmark/bench_modules/wh_bench_mod_all.h
@@ -202,10 +202,28 @@ int wh_Bench_Mod_HmacSha256(whClientContext* client, whBenchOpContext* ctx,
 int wh_Bench_Mod_HmacSha256Dma(whClientContext* client, whBenchOpContext* ctx,
                                int id, void* params);
 
+int wh_Bench_Mod_HmacSha3224(whClientContext* client, whBenchOpContext* ctx,
+                             int id, void* params);
+
+int wh_Bench_Mod_HmacSha3224Dma(whClientContext* client, whBenchOpContext* ctx,
+                                int id, void* params);
+
 int wh_Bench_Mod_HmacSha3256(whClientContext* client, whBenchOpContext* ctx,
                              int id, void* params);
 
 int wh_Bench_Mod_HmacSha3256Dma(whClientContext* client, whBenchOpContext* ctx,
+                                int id, void* params);
+
+int wh_Bench_Mod_HmacSha3384(whClientContext* client, whBenchOpContext* ctx,
+                             int id, void* params);
+
+int wh_Bench_Mod_HmacSha3384Dma(whClientContext* client, whBenchOpContext* ctx,
+                                int id, void* params);
+
+int wh_Bench_Mod_HmacSha3512(whClientContext* client, whBenchOpContext* ctx,
+                             int id, void* params);
+
+int wh_Bench_Mod_HmacSha3512Dma(whClientContext* client, whBenchOpContext* ctx,
                                 int id, void* params);
 
 /*

--- a/benchmark/bench_modules/wh_bench_mod_hmac.c
+++ b/benchmark/bench_modules/wh_bench_mod_hmac.c
@@ -22,14 +22,15 @@
 #if !defined(WOLFHSM_CFG_NO_CRYPTO) && defined(WOLFHSM_CFG_BENCH_ENABLE)
 #include "wolfssl/wolfcrypt/hmac.h"
 #include "wolfssl/wolfcrypt/sha256.h"
+#include "wolfssl/wolfcrypt/sha3.h"
 
 #if !defined(NO_HMAC)
-
-#if !defined(NO_SHA256)
 
 static const uint8_t key[] =
     "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 static const size_t keyLen = sizeof(key) - 1; /* -1 for null terminator */
+
+#if !defined(NO_SHA256)
 
 int _benchHmacSha256(whClientContext* client, whBenchOpContext* ctx, int id,
                      int useDma)
@@ -151,25 +152,206 @@ int wh_Bench_Mod_HmacSha256Dma(whClientContext* client, whBenchOpContext* ctx,
 
 #if defined(WOLFSSL_SHA3)
 
-int wh_Bench_Mod_HmacSha3256(whClientContext* client, whBenchOpContext* ctx,
+/* The four SHA3 HMAC variants differ only in the wolfCrypt macType passed to
+ * wc_HmacSetKey(), so a single helper serves all of them. The digest buffer is
+ * sized for the largest variant. */
+static int _benchHmacSha3(whClientContext* client, whBenchOpContext* ctx,
+                          int id, int useDma, int macType)
+{
+    int            ret = 0;
+    Hmac           hmac[1];
+    uint8_t        out[WC_SHA3_512_DIGEST_SIZE]; /* largest digest */
+    int            i               = 0;
+    int            hmacInitialized = 0;
+    const uint8_t* in;
+    size_t         inLen;
+
+    (void)wh_Client_SetDmaMode(client, useDma);
+
+#if defined(WOLFHSM_CFG_DMA)
+    if (useDma) {
+        in    = WH_BENCH_DMA_BUFFER;
+        inLen = WOLFHSM_CFG_BENCH_DMA_BUFFER_SIZE;
+    }
+    else
+#endif
+    {
+        in    = WH_BENCH_DATA_IN_BUFFER;
+        inLen = WOLFHSM_CFG_BENCH_DATA_BUFFER_SIZE;
+#if defined(WOLFHSM_CFG_BENCH_INIT_DATA_BUFFERS)
+        memset(WH_BENCH_DATA_IN_BUFFER, 0xAA, inLen);
+#endif
+    }
+
+    ret = wh_Bench_SetDataSize(ctx, id, inLen);
+    if (ret != 0) {
+        WH_BENCH_PRINTF("Failed to wh_Bench_SetDataSize %d\n", ret);
+        return ret;
+    }
+
+    for (i = 0; i < WOLFHSM_CFG_BENCH_CRYPT_ITERS; i++) {
+        int benchStartRet;
+        int benchStopRet;
+        int initRet;
+        int setKeyRet;
+        int updateRet;
+        int finalRet;
+
+        /* Defer error checking until after all operations are complete */
+        benchStartRet = wh_Bench_StartOp(ctx, id);
+        initRet       = wc_HmacInit(hmac, NULL, WH_CLIENT_DEVID(client));
+        setKeyRet     = wc_HmacSetKey(hmac, macType, key, (word32)keyLen);
+        updateRet     = wc_HmacUpdate(hmac, in, inLen);
+        finalRet      = wc_HmacFinal(hmac, out);
+        benchStopRet  = wh_Bench_StopOp(ctx, id);
+
+        /* Check for errors after all operations are complete */
+        if (benchStartRet != 0) {
+            WH_BENCH_PRINTF("Failed to wh_Bench_StartOp: %d\n", benchStartRet);
+            ret = benchStartRet;
+            break;
+        }
+        if (initRet != 0) {
+            WH_BENCH_PRINTF("Failed to wc_HmacInit %d\n", initRet);
+            ret = initRet;
+            break;
+        }
+
+        hmacInitialized = 1;
+
+        if (setKeyRet != 0) {
+            WH_BENCH_PRINTF("Failed to wc_HmacSetKey %d\n", setKeyRet);
+            ret = setKeyRet;
+            break;
+        }
+        if (updateRet != 0) {
+            WH_BENCH_PRINTF("Failed to wc_HmacUpdate %d\n", updateRet);
+            ret = updateRet;
+            break;
+        }
+        if (finalRet != 0) {
+            WH_BENCH_PRINTF("Failed to wc_HmacFinal %d\n", finalRet);
+            ret = finalRet;
+            break;
+        }
+        if (benchStopRet != 0) {
+            WH_BENCH_PRINTF("Failed to wh_Bench_StopOp: %d\n", benchStopRet);
+            ret = benchStopRet;
+            break;
+        }
+    }
+
+    /* Only free HMAC if it was initialized */
+    if (hmacInitialized) {
+        (void)wc_HmacFree(hmac);
+    }
+
+    return ret;
+}
+
+#ifndef WOLFSSL_NOSHA3_224
+
+int wh_Bench_Mod_HmacSha3224(whClientContext* client, whBenchOpContext* ctx,
                              int id, void* params)
 {
+    (void)params;
+    return _benchHmacSha3(client, ctx, id, 0, WC_SHA3_224);
+}
+
+int wh_Bench_Mod_HmacSha3224Dma(whClientContext* client, whBenchOpContext* ctx,
+                                int id, void* params)
+{
+#if defined(WOLFHSM_CFG_DMA)
+    (void)params;
+    return _benchHmacSha3(client, ctx, id, 1, WC_SHA3_224);
+#else
     (void)client;
     (void)ctx;
     (void)id;
     (void)params;
     return WH_ERROR_NOTIMPL;
+#endif
+}
+
+#endif /* !WOLFSSL_NOSHA3_224 */
+
+#ifndef WOLFSSL_NOSHA3_256
+
+int wh_Bench_Mod_HmacSha3256(whClientContext* client, whBenchOpContext* ctx,
+                             int id, void* params)
+{
+    (void)params;
+    return _benchHmacSha3(client, ctx, id, 0, WC_SHA3_256);
 }
 
 int wh_Bench_Mod_HmacSha3256Dma(whClientContext* client, whBenchOpContext* ctx,
                                 int id, void* params)
 {
+#if defined(WOLFHSM_CFG_DMA)
+    (void)params;
+    return _benchHmacSha3(client, ctx, id, 1, WC_SHA3_256);
+#else
     (void)client;
     (void)ctx;
     (void)id;
     (void)params;
     return WH_ERROR_NOTIMPL;
+#endif
 }
+
+#endif /* !WOLFSSL_NOSHA3_256 */
+
+#ifndef WOLFSSL_NOSHA3_384
+
+int wh_Bench_Mod_HmacSha3384(whClientContext* client, whBenchOpContext* ctx,
+                             int id, void* params)
+{
+    (void)params;
+    return _benchHmacSha3(client, ctx, id, 0, WC_SHA3_384);
+}
+
+int wh_Bench_Mod_HmacSha3384Dma(whClientContext* client, whBenchOpContext* ctx,
+                                int id, void* params)
+{
+#if defined(WOLFHSM_CFG_DMA)
+    (void)params;
+    return _benchHmacSha3(client, ctx, id, 1, WC_SHA3_384);
+#else
+    (void)client;
+    (void)ctx;
+    (void)id;
+    (void)params;
+    return WH_ERROR_NOTIMPL;
+#endif
+}
+
+#endif /* !WOLFSSL_NOSHA3_384 */
+
+#ifndef WOLFSSL_NOSHA3_512
+
+int wh_Bench_Mod_HmacSha3512(whClientContext* client, whBenchOpContext* ctx,
+                             int id, void* params)
+{
+    (void)params;
+    return _benchHmacSha3(client, ctx, id, 0, WC_SHA3_512);
+}
+
+int wh_Bench_Mod_HmacSha3512Dma(whClientContext* client, whBenchOpContext* ctx,
+                                int id, void* params)
+{
+#if defined(WOLFHSM_CFG_DMA)
+    (void)params;
+    return _benchHmacSha3(client, ctx, id, 1, WC_SHA3_512);
+#else
+    (void)client;
+    (void)ctx;
+    (void)id;
+    (void)params;
+    return WH_ERROR_NOTIMPL;
+#endif
+}
+
+#endif /* !WOLFSSL_NOSHA3_512 */
 
 #endif /* WOLFSSL_SHA3 */
 

--- a/benchmark/wh_bench.c
+++ b/benchmark/wh_bench.c
@@ -169,8 +169,22 @@ typedef enum BenchModuleIdx {
     BENCH_MODULE_IDX_HMAC_SHA2_256_DMA,
 #endif /* !(NO_SHA256) */
 #if defined(WOLFSSL_SHA3)
+#if !defined(WOLFSSL_NOSHA3_224)
+    BENCH_MODULE_IDX_HMAC_SHA3_224,
+    BENCH_MODULE_IDX_HMAC_SHA3_224_DMA,
+#endif /* !WOLFSSL_NOSHA3_224 */
+#if !defined(WOLFSSL_NOSHA3_256)
     BENCH_MODULE_IDX_HMAC_SHA3_256,
     BENCH_MODULE_IDX_HMAC_SHA3_256_DMA,
+#endif /* !WOLFSSL_NOSHA3_256 */
+#if !defined(WOLFSSL_NOSHA3_384)
+    BENCH_MODULE_IDX_HMAC_SHA3_384,
+    BENCH_MODULE_IDX_HMAC_SHA3_384_DMA,
+#endif /* !WOLFSSL_NOSHA3_384 */
+#if !defined(WOLFSSL_NOSHA3_512)
+    BENCH_MODULE_IDX_HMAC_SHA3_512,
+    BENCH_MODULE_IDX_HMAC_SHA3_512_DMA,
+#endif /* !WOLFSSL_NOSHA3_512 */
 #endif /* WOLFSSL_SHA3 */
 #endif /* !(NO_HMAC) */
 
@@ -401,8 +415,22 @@ static BenchModule g_benchModules[] = {
     [BENCH_MODULE_IDX_HMAC_SHA2_256_DMA]       = {"HMAC-SHA2-256-DMA",            wh_Bench_Mod_HmacSha256Dma,         BENCH_THROUGHPUT_XBPS, 0, NULL},
 #endif /* !(NO_SHA256) */
 #if defined(WOLFSSL_SHA3)
-    [BENCH_MODULE_IDX_HMAC_SHA3_256]           = {"HMAC-SHA3-256",                wh_Bench_Mod_HmacSha3256,           BENCH_THROUGHPUT_NONE, 0, NULL},
-    [BENCH_MODULE_IDX_HMAC_SHA3_256_DMA]       = {"HMAC-SHA3-256-DMA",            wh_Bench_Mod_HmacSha3256Dma,        BENCH_THROUGHPUT_NONE, 0, NULL},
+#if !defined(WOLFSSL_NOSHA3_224)
+    [BENCH_MODULE_IDX_HMAC_SHA3_224]           = {"HMAC-SHA3-224",                wh_Bench_Mod_HmacSha3224,           BENCH_THROUGHPUT_XBPS, 0, NULL},
+    [BENCH_MODULE_IDX_HMAC_SHA3_224_DMA]       = {"HMAC-SHA3-224-DMA",            wh_Bench_Mod_HmacSha3224Dma,        BENCH_THROUGHPUT_XBPS, 0, NULL},
+#endif /* !WOLFSSL_NOSHA3_224 */
+#if !defined(WOLFSSL_NOSHA3_256)
+    [BENCH_MODULE_IDX_HMAC_SHA3_256]           = {"HMAC-SHA3-256",                wh_Bench_Mod_HmacSha3256,           BENCH_THROUGHPUT_XBPS, 0, NULL},
+    [BENCH_MODULE_IDX_HMAC_SHA3_256_DMA]       = {"HMAC-SHA3-256-DMA",            wh_Bench_Mod_HmacSha3256Dma,        BENCH_THROUGHPUT_XBPS, 0, NULL},
+#endif /* !WOLFSSL_NOSHA3_256 */
+#if !defined(WOLFSSL_NOSHA3_384)
+    [BENCH_MODULE_IDX_HMAC_SHA3_384]           = {"HMAC-SHA3-384",                wh_Bench_Mod_HmacSha3384,           BENCH_THROUGHPUT_XBPS, 0, NULL},
+    [BENCH_MODULE_IDX_HMAC_SHA3_384_DMA]       = {"HMAC-SHA3-384-DMA",            wh_Bench_Mod_HmacSha3384Dma,        BENCH_THROUGHPUT_XBPS, 0, NULL},
+#endif /* !WOLFSSL_NOSHA3_384 */
+#if !defined(WOLFSSL_NOSHA3_512)
+    [BENCH_MODULE_IDX_HMAC_SHA3_512]           = {"HMAC-SHA3-512",                wh_Bench_Mod_HmacSha3512,           BENCH_THROUGHPUT_XBPS, 0, NULL},
+    [BENCH_MODULE_IDX_HMAC_SHA3_512_DMA]       = {"HMAC-SHA3-512-DMA",            wh_Bench_Mod_HmacSha3512Dma,        BENCH_THROUGHPUT_XBPS, 0, NULL},
+#endif /* !WOLFSSL_NOSHA3_512 */
 #endif /* WOLFSSL_SHA3 */
 #endif /* !(NO_HMAC) */
 


### PR DESCRIPTION
# Summary

Implements the HMAC-SHA3 benchmarks in
`benchmark/bench_modules/wh_bench_mod_hmac.c`, which were stubs returning
`WH_ERROR_NOTIMPL` and silently `-> SKIPPED`. Covers all four variants
(224/256/384/512), DMA and non-DMA. Entries switched from
`BENCH_THROUGHPUT_NONE` to `XBPS` so throughput is reported.

wolfHSM has no HMAC server handler, so the ipad/opad construction runs
client-side; only the inner SHA3 compressions are offloaded. Same as the
existing HMAC-SHA2-256 benchmark — the number is HMAC as seen by the client.

## Test

`make DMA=1`: all eight rows report; previously two were `SKIPPED` and six
did not exist. `make` (non-DMA): the four non-DMA rows report.

Not verified: digest correctness. Unlike SHA3, the repository has no HMAC
test coverage at all, so nothing backs these values beyond the SHA3 KATs
covering the inner hash.