### PR TITLE
benchmark: time ML-KEM encaps/decaps as one round trip

### DIFF
--- a/benchmark/bench_modules/wh_bench_mod_mlkem.c
+++ b/benchmark/bench_modules/wh_bench_mod_mlkem.c
@@ -78,6 +78,64 @@ static int _benchMlKemKeyGen(whClientContext* client, whBenchOpContext* ctx,
     return ret;
 }
 
+/*
+ * Evict the cached benchmark key. Returns inRet, unless the eviction itself
+ * failed while inRet was OK, in which case the eviction error is reported.
+ */
+static int _benchMlKemEvictKey(whClientContext* client, whKeyId keyId,
+                               int inRet)
+{
+    int ret;
+
+    if (WH_KEYID_ISERASED(keyId)) {
+        return inRet;
+    }
+
+    ret = wh_Client_KeyEvict(client, keyId);
+    if (ret != WH_ERROR_OK) {
+        WH_BENCH_PRINTF("Failed to evict ML-KEM key %d\n", ret);
+        if (inRet == WH_ERROR_OK) {
+            return ret;
+        }
+    }
+    return inRet;
+}
+
+/*
+ * Generate the benchmark key into the server key cache and bind its ID to the
+ * client key struct, so the timed operations reference it by ID rather than
+ * taking the implicit-import path on every iteration.
+ *
+ * The DMA rows use this same call: wh_Client_MlKemMakeCacheKeyDma is the DMA
+ * form of MakeCacheKeyAndExportPublic, and the timed operations need only the
+ * key ID and the parameter set wc_MlKemKey_Init already applied.
+ */
+static int _benchMlKemCacheKey(whClientContext* client, int securityLevel,
+                               MlKemKey* key, whKeyId* outKeyId)
+{
+    int     ret;
+    char    keyLabel[] = "bench-mlkem-key";
+    whKeyId keyId      = WH_KEYID_ERASED;
+
+    ret = wh_Client_MlKemMakeCacheKey(client, securityLevel, &keyId,
+                                      WH_NVM_FLAGS_USAGE_ANY,
+                                      (uint16_t)strlen(keyLabel),
+                                      (uint8_t*)keyLabel);
+    if (ret != WH_ERROR_OK) {
+        WH_BENCH_PRINTF("Failed ML-KEM cache keygen %d\n", ret);
+        return ret;
+    }
+
+    ret = wh_Client_MlKemSetKeyId(key, keyId);
+    if (ret != WH_ERROR_OK) {
+        WH_BENCH_PRINTF("Failed to wh_Client_MlKemSetKeyId %d\n", ret);
+        return _benchMlKemEvictKey(client, keyId, ret);
+    }
+
+    *outKeyId = keyId;
+    return WH_ERROR_OK;
+}
+
 static int _benchMlKemEncaps(whClientContext* client, whBenchOpContext* ctx,
                              int id, int securityLevel, int useDma)
 {
@@ -86,6 +144,7 @@ static int _benchMlKemEncaps(whClientContext* client, whBenchOpContext* ctx,
     MlKemKey key[1];
     byte     ct[WC_ML_KEM_MAX_CIPHER_TEXT_SIZE];
     byte     ss[WC_ML_KEM_SS_SZ];
+    whKeyId  keyId = WH_KEYID_ERASED;
 
     (void)wh_Client_SetDmaMode(client, useDma);
 
@@ -95,17 +154,8 @@ static int _benchMlKemEncaps(whClientContext* client, whBenchOpContext* ctx,
         return ret;
     }
 
-#ifdef WOLFHSM_CFG_DMA
-    if (useDma) {
-        ret = wh_Client_MlKemMakeExportKeyDma(client, securityLevel, key);
-    }
-    else
-#endif /* WOLFHSM_CFG_DMA */
-    {
-        ret = wh_Client_MlKemMakeExportKey(client, securityLevel, key);
-    }
+    ret = _benchMlKemCacheKey(client, securityLevel, key, &keyId);
     if (ret != WH_ERROR_OK) {
-        WH_BENCH_PRINTF("Failed ML-KEM key setup %d\n", ret);
         wc_MlKemKey_Free(key);
         return ret;
     }
@@ -146,7 +196,8 @@ static int _benchMlKemEncaps(whClientContext* client, whBenchOpContext* ctx,
     }
 
     wc_MlKemKey_Free(key);
-    return ret;
+
+    return _benchMlKemEvictKey(client, keyId, ret);
 }
 
 static int _benchMlKemDecaps(whClientContext* client, whBenchOpContext* ctx,
@@ -160,6 +211,7 @@ static int _benchMlKemDecaps(whClientContext* client, whBenchOpContext* ctx,
     byte     ssDec[WC_ML_KEM_SS_SZ];
     word32   ctLen = sizeof(ct);
     word32   ssEncLen = sizeof(ssEnc);
+    whKeyId  keyId = WH_KEYID_ERASED;
 
     (void)wh_Client_SetDmaMode(client, useDma);
 
@@ -169,17 +221,8 @@ static int _benchMlKemDecaps(whClientContext* client, whBenchOpContext* ctx,
         return ret;
     }
 
-#ifdef WOLFHSM_CFG_DMA
-    if (useDma) {
-        ret = wh_Client_MlKemMakeExportKeyDma(client, securityLevel, key);
-    }
-    else
-#endif /* WOLFHSM_CFG_DMA */
-    {
-        ret = wh_Client_MlKemMakeExportKey(client, securityLevel, key);
-    }
+    ret = _benchMlKemCacheKey(client, securityLevel, key, &keyId);
     if (ret != WH_ERROR_OK) {
-        WH_BENCH_PRINTF("Failed ML-KEM key setup %d\n", ret);
         wc_MlKemKey_Free(key);
         return ret;
     }
@@ -198,7 +241,7 @@ static int _benchMlKemDecaps(whClientContext* client, whBenchOpContext* ctx,
     if (ret != WH_ERROR_OK) {
         WH_BENCH_PRINTF("Failed ML-KEM setup encapsulate %d\n", ret);
         wc_MlKemKey_Free(key);
-        return ret;
+        return _benchMlKemEvictKey(client, keyId, ret);
     }
 
     for (i = 0; i < WOLFHSM_CFG_BENCH_PK_ITERS && ret == WH_ERROR_OK; i++) {
@@ -241,7 +284,8 @@ static int _benchMlKemDecaps(whClientContext* client, whBenchOpContext* ctx,
     }
 
     wc_MlKemKey_Free(key);
-    return ret;
+
+    return _benchMlKemEvictKey(client, keyId, ret);
 }
 
 #define WH_DEFINE_MLKEM_BENCH_NON_DMA_FNS(_Suffix, _Level)                    \

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -1031,6 +1031,12 @@ static int _MlDsaKeyCacheExportEnforce(whServerContext* ctx, whKeyId keyId,
 #endif /* WOLFSSL_HAVE_MLDSA */
 
 #ifdef WOLFSSL_HAVE_MLKEM
+/* The cache import below always requests a max-size slot, so a build whose big
+ * cache buffer cannot hold one has no working ML-KEM cache keygen or import. */
+WH_UTILS_STATIC_ASSERT(
+    WOLFHSM_CFG_SERVER_KEYCACHE_BIG_BUFSIZE >= WC_ML_KEM_MAX_PRIVATE_KEY_SIZE,
+    "WOLFHSM_CFG_SERVER_KEYCACHE_BIG_BUFSIZE too small for ML-KEM private key");
+
 int wh_Server_MlKemKeyCacheImport(whServerContext* ctx, MlKemKey* key,
                                   whKeyId keyId, whNvmFlags flags,
                                   uint16_t label_len, uint8_t* label)

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -15425,6 +15425,102 @@ static int whTestCrypto_MlKemDmaClient(whClientContext* ctx, int devId,
             }
         }
 
+        /* Positive path: a key referenced by its cached ID rather than
+         * implicitly imported, driven through the DMA encaps/decaps calls.
+         * This is what the ML-KEM benchmark rows do. */
+        if (ret == 0) {
+            MlKemKey      cachedKey[1];
+            whKeyId       cachedKeyId    = WH_KEYID_ERASED;
+            int           cachedInited   = 0;
+            int           cachedCached   = 0;
+            word32        cachedCtLen    = sizeof(ct);
+            word32        cachedSsEncLen = sizeof(ssEnc);
+            word32        cachedSsDecLen = sizeof(ssDec);
+            const uint8_t cachedLabel[]  = "mlkem-dma-byid";
+
+            memset(ct, 0, sizeof(ct));
+            memset(ssEnc, 0, sizeof(ssEnc));
+            memset(ssDec, 0, sizeof(ssDec));
+
+            ret = wh_Client_MlKemMakeCacheKey(
+                ctx, levels[i], &cachedKeyId, WH_NVM_FLAGS_USAGE_ANY,
+                (uint16_t)strlen((const char*)cachedLabel),
+                (uint8_t*)cachedLabel);
+            if (ret != 0) {
+                WH_ERROR_PRINT("Failed ML-KEM DMA by-id cache keygen level=%d "
+                               "ret=%d\n",
+                               levels[i], ret);
+            }
+            else {
+                cachedCached = 1;
+            }
+            if (ret == 0) {
+                ret = wc_MlKemKey_Init(cachedKey, levels[i], NULL, devId);
+                if (ret != 0) {
+                    WH_ERROR_PRINT("Failed init ML-KEM DMA by-id key level=%d "
+                                   "ret=%d\n",
+                                   levels[i], ret);
+                }
+                else {
+                    cachedInited = 1;
+                }
+            }
+            if (ret == 0) {
+                ret = wh_Client_MlKemSetKeyId(cachedKey, cachedKeyId);
+                if (ret != 0) {
+                    WH_ERROR_PRINT("Failed ML-KEM DMA by-id set key id "
+                                   "level=%d ret=%d\n",
+                                   levels[i], ret);
+                }
+            }
+            if (ret == 0) {
+                ret = wh_Client_MlKemEncapsulateDma(ctx, cachedKey, ct,
+                                                    &cachedCtLen, ssEnc,
+                                                    &cachedSsEncLen);
+                if (ret != 0) {
+                    WH_ERROR_PRINT("Failed ML-KEM DMA by-id encapsulate "
+                                   "level=%d ret=%d\n",
+                                   levels[i], ret);
+                }
+            }
+            if (ret == 0) {
+                ret = wh_Client_MlKemDecapsulateDma(ctx, cachedKey, ct,
+                                                    cachedCtLen, ssDec,
+                                                    &cachedSsDecLen);
+                if (ret != 0) {
+                    WH_ERROR_PRINT("Failed ML-KEM DMA by-id decapsulate "
+                                   "level=%d ret=%d\n",
+                                   levels[i], ret);
+                }
+                else if ((cachedSsEncLen != cachedSsDecLen) ||
+                         (memcmp(ssEnc, ssDec, cachedSsEncLen) != 0)) {
+                    WH_ERROR_PRINT("ML-KEM DMA by-id shared secret mismatch "
+                                   "level=%d\n",
+                                   levels[i]);
+                    ret = -1;
+                }
+            }
+            /* The key must still be cached: a by-id operation must not take
+             * the implicit-import path, which evicts after every call. */
+            if (ret == 0) {
+                ret = wh_Client_KeyEvict(ctx, cachedKeyId);
+                if (ret != 0) {
+                    WH_ERROR_PRINT("ML-KEM DMA by-id key was not left cached "
+                                   "level=%d ret=%d\n",
+                                   levels[i], ret);
+                }
+                else {
+                    cachedCached = 0;
+                }
+            }
+            if (cachedCached) {
+                (void)wh_Client_KeyEvict(ctx, cachedKeyId);
+            }
+            if (cachedInited) {
+                wc_MlKemKey_Free(cachedKey);
+            }
+        }
+
         if (keyCached) {
             int evictRet = wh_Client_KeyEvict(ctx, keyId);
             if ((evictRet != 0) && (ret == 0)) {

--- a/wolfhsm/wh_settings.h
+++ b/wolfhsm/wh_settings.h
@@ -319,7 +319,7 @@
 /* Size in bytes of each big key cache buffer  */
 #ifndef WOLFHSM_CFG_SERVER_KEYCACHE_BIG_BUFSIZE
 #if defined(WOLFSSL_HAVE_MLDSA) || defined(WOLFSSL_HAVE_XMSS) || \
-    defined(WOLFSSL_HAVE_LMS)
+    defined(WOLFSSL_HAVE_LMS) || defined(WOLFSSL_HAVE_MLKEM)
 #define WOLFHSM_CFG_SERVER_KEYCACHE_BIG_BUFSIZE 8192
 #else
 /* Sane default to hold ASN.1 RSA 4096 public+private key */


### PR DESCRIPTION
## What

The ML-KEM benchmark rows created their key with `wh_Client_MlKemMakeExportKey`, which returns the key to the client without caching it server-side, leaving `key->devCtx` empty. Every `wh_Client_MlKem{Encapsulate,Decapsulate}` in the timed loop therefore took the implicit-import path: ship the whole private key to the server (1632 bytes for ML-KEM-512, up to 3168 for ML-KEM-1024), run the operation with the evict flag set, leave the cache empty for the next iteration.

That is two round trips per measurement instead of one, and the extra one carries a payload larger than anything the operation itself sends. ML-KEM was the only module doing this - AES, CMAC, ECC, RSA and ML-DSA all cache their key once before the loop and reference it by ID - so the ML-KEM rows were reported against a different amount of transport work than the rows they sit next to.

This generates the key straight into the server cache with `wh_Client_MlKemMakeCacheKey`, binds the ID to the client key struct, and evicts once after the loop. Key setup was already outside the timed section, so nothing moves in or out of the measurement.

The KEY-GEN rows keep `wh_Client_MlKemMakeExportKey` deliberately - those measure generating a key and getting it back, which is what the ECC and ML-DSA key generation rows measure too.

## Second commit

Making the bench rows use a cached key exposed a sizing gap. `wh_Server_MlKemKeyCacheImport` always requests a `WC_ML_KEM_MAX_PRIVATE_KEY_SIZE` (3168) slot at every security level, but `WOLFHSM_CFG_SERVER_KEYCACHE_BIG_BUFSIZE` defaults to 8192 only when ML-DSA, XMSS or LMS is enabled, and to 1200 otherwise. An ML-KEM-only build got a buffer less than half the size every cache keygen and import needs, failing at run time with `WH_ERROR_BUFFER_SIZE` and nothing at build time to say why.

- Added `WOLFSSL_HAVE_MLKEM` to the big-buffer condition.
- Added the compile-time assert ML-DSA already carries next to its own cache import, so an undersized override fails to build with a message naming the setting.
- Added a positive cached-key-by-ID DMA encaps/decaps test. That combination had no coverage: the only place a cached-by-ID key met the DMA calls was the negative usage-policy case, and the positive DMA test used a key whose `devCtx` was still erased, so it exercised the implicit-import path instead.

## Testing

| Check | Result |
|---|---|
| `wh_test` full suite, `DMA=1` and plain | pass |
| POSIX benchmark, `DMA=1` and plain | pass, all 18 ML-KEM rows |
| Builds, both configs | clean at `-std=c90 -Werror -Wall -Wextra` |
| Undersized `BIG_BUFSIZE` | new assert fires, names the setting |

Round trips were measured with a probe on `client->comm->seq` around the timed loop. The ten iterations of a default run (`WOLFHSM_CFG_BENCH_PK_ITERS`) advanced it by twenty before and by ten after, at all three security levels, on both the inline and the DMA path, encapsulation and decapsulation alike.

The new test was checked against a deliberate break: removing the `wh_Client_MlKemSetKeyId` call makes it fail rather than pass quietly.

## Notes

The gain is invisible on a POSIX in-process transport, where a round trip is a memcpy, and is the whole story on a real IPC boundary. On a real target, where each round trip costs tens of microseconds, this improves ML-KEM benchmark results substantially.

The DMA rows share the non-DMA setup call deliberately. `wh_Client_MlKemMakeCacheKeyDma` is the DMA form of `wh_Client_MlKemMakeCacheKeyAndExportPublic`, not of `wh_Client_MlKemMakeCacheKey`: it requires a public key out, which the timed operations do not need.
