### PR TITLE
Unify client response size checks into _getCryptoResponse

### DIFF
--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -153,8 +153,10 @@ static uint8_t* _createCryptoRequestWithSubtype(uint8_t* reqBuf, uint16_t type,
                                                 uint16_t algoSubType,
                                                 uint32_t affinity);
 static int      _getCryptoResponse(uint8_t* respBuf, uint16_t type,
-                                   const uint16_t respLen, const uint16_t minRespLen,
-                                   uint8_t** outResponse, uint16_t* outTrailingLen);
+                                   const uint16_t respLen,
+                                   uint8_t**      outResponse,
+                                   const uint16_t minRespLen,
+                                   uint16_t*      outTrailingLen);
 
 
 /* Helper function to prepare a crypto request buffer with generic header */
@@ -179,11 +181,16 @@ static uint8_t* _createCryptoRequestWithSubtype(uint8_t* reqBuf, uint16_t type,
     return reqBuf + sizeof(whMessageCrypto_GenericRequestHeader);
 }
 
-/* Helper function to validate and extract crypto response. */
+/* Validates a crypto response frame and returns the server's return code, or
+ * WH_ERROR_ABORTED if the frame is short or holds another algorithm.
+ * outResponse points past the generic header at a body of at least minRespLen
+ * bytes. outTrailingLen, when given, reports the bytes received past that
+ * body, and is 0 unless the return code is non-negative. */
 /* TODO: add algoSubType checking */
 static int _getCryptoResponse(uint8_t* respBuf, uint16_t type,
-                              const uint16_t respLen, const uint16_t minRespLen,
-                              uint8_t** outResponse, uint16_t* outTrailingLen)
+                              const uint16_t respLen, uint8_t** outResponse,
+                              const uint16_t minRespLen,
+                              uint16_t*      outTrailingLen)
 {
     const whMessageCrypto_GenericResponseHeader* header =
         (const whMessageCrypto_GenericResponseHeader*)respBuf;
@@ -284,8 +291,8 @@ int wh_Client_RngGenerateResponse(whClientContext* ctx, uint8_t* out,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_RNG, res_len, sizeof(*res),
-                             (uint8_t**)&res, &trailSz);
+    ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_RNG, res_len,
+                             (uint8_t**)&res, sizeof(*res), &trailSz);
     if (ret == WH_ERROR_OK) {
         /* Reject a size the received message does not actually carry, or that
          * exceeds the inline cap or the caller's buffer. */
@@ -429,7 +436,7 @@ int wh_Client_RngGenerateDmaResponse(whClientContext* ctx)
 
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_RNG, respSz,
-                                 sizeof(*resp), (uint8_t**)&resp, NULL);
+                                 (uint8_t**)&resp, sizeof(*resp), NULL);
         /* On success, server has written random bytes directly to client
          * memory — nothing else to copy. */
     }
@@ -554,8 +561,8 @@ int wh_Client_AesCtrResponse(whClientContext* ctx, Aes* aes, uint8_t* out,
                                  WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_CTR, res_len,
-                                 sizeof(*res) + (2 * AES_BLOCK_SIZE),
-                                 (uint8_t**)&res, &trailSz);
+                                 (uint8_t**)&res,
+                                 sizeof(*res) + (2 * AES_BLOCK_SIZE), &trailSz);
         if (ret == WH_ERROR_OK) {
             /* Trailing payload is: output (res->sz) + reg (AES_BLOCK_SIZE)
              * + tmp (AES_BLOCK_SIZE) */
@@ -742,9 +749,9 @@ int wh_Client_AesCtrDmaResponse(whClientContext* ctx, Aes* aes)
     }
 
     if (ret == WH_ERROR_OK) {
-        ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_CTR, res_len,
-                                 sizeof(*res) + AES_IV_SIZE + AES_BLOCK_SIZE,
-                                 (uint8_t**)&res, NULL);
+        ret = _getCryptoResponse(
+            dataPtr, WC_CIPHER_AES_CTR, res_len, (uint8_t**)&res,
+            sizeof(*res) + AES_IV_SIZE + AES_BLOCK_SIZE, NULL);
         if (ret == WH_ERROR_OK) {
             /* Trailing payload is: reg (AES_IV_SIZE) + tmp (AES_BLOCK_SIZE) */
             uint8_t* res_iv =
@@ -890,7 +897,7 @@ int wh_Client_AesEcbResponse(whClientContext* ctx, Aes* aes, uint8_t* out,
                                  WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_ECB, res_len,
-                                 sizeof(*res), (uint8_t**)&res, &trailSz);
+                                 (uint8_t**)&res, sizeof(*res), &trailSz);
         if (ret == WH_ERROR_OK) {
             if (res->sz > trailSz) {
                 ret = WH_ERROR_ABORTED;
@@ -1065,7 +1072,7 @@ int wh_Client_AesEcbDmaResponse(whClientContext* ctx, Aes* aes)
 
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_ECB, res_len,
-                                 sizeof(*res), (uint8_t**)&res, NULL);
+                                 (uint8_t**)&res, sizeof(*res), NULL);
         if (ret == WH_ERROR_OK) {
             WH_DEBUG_CLIENT_VERBOSE("AesEcb DMA res: ok\n");
         }
@@ -1217,7 +1224,7 @@ int wh_Client_AesCbcResponse(whClientContext* ctx, Aes* aes, uint8_t* out,
                                  WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_CBC, res_len,
-                                 sizeof(*res) + AES_IV_SIZE, (uint8_t**)&res,
+                                 (uint8_t**)&res, sizeof(*res) + AES_IV_SIZE,
                                  &trailSz);
         if (ret == WH_ERROR_OK) {
             /* Trailing payload is: output (res->sz) + updated IV
@@ -1404,7 +1411,7 @@ int wh_Client_AesCbcDmaResponse(whClientContext* ctx, Aes* aes)
 
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_CBC, res_len,
-                                 sizeof(*res) + AES_IV_SIZE, (uint8_t**)&res,
+                                 (uint8_t**)&res, sizeof(*res) + AES_IV_SIZE,
                                  NULL);
         if (ret == WH_ERROR_OK) {
             /* Trailing payload is the updated IV (AES_IV_SIZE) */
@@ -1578,7 +1585,7 @@ int wh_Client_AesGcmResponse(whClientContext* ctx, Aes* aes, uint8_t* out,
                                  WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_GCM, res_len,
-                                 sizeof(*res), (uint8_t**)&res, &trailSz);
+                                 (uint8_t**)&res, sizeof(*res), &trailSz);
         if (ret == WH_ERROR_OK) {
             uint8_t* res_out = (uint8_t*)(res + 1);
             uint8_t* res_tag = res_out + res->sz;
@@ -1806,7 +1813,7 @@ int wh_Client_AesGcmDmaResponse(whClientContext* ctx, Aes* aes,
 
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_GCM, res_len,
-                                 sizeof(*res), (uint8_t**)&res, &trailSz);
+                                 (uint8_t**)&res, sizeof(*res), &trailSz);
         if (ret == WH_ERROR_OK) {
             /* Trailing payload is the auth tag (res->authTagSz) */
             if (res->authTagSz > trailSz) {
@@ -2061,7 +2068,7 @@ static int _EccMakeKeyResponse(whClientContext* ctx, whKeyId* out_key_id,
 
     /* Get response structure pointer; validates the generic header rc */
     ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_EC_KEYGEN, res_len,
-                             sizeof(*res), (uint8_t**)&res, &trailSz);
+                             (uint8_t**)&res, sizeof(*res), &trailSz);
     /* wolfCrypt allows positive error codes on success in some scenarios */
     if (ret >= 0) {
         whKeyId key_id = (whKeyId)(res->keyId);
@@ -2318,8 +2325,8 @@ static int _EccSharedSecretResponse(whClientContext* ctx, uint8_t* out,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_ECDH, res_len, sizeof(*res),
-                             (uint8_t**)&res, &trailSz);
+    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_ECDH, res_len, (uint8_t**)&res,
+                             sizeof(*res), &trailSz);
     if (ret >= 0) {
         uint8_t* res_out = (uint8_t*)(res + 1);
         /* Defensive bound: res->sz must fit within the actual received frame */
@@ -2555,7 +2562,7 @@ int wh_Client_EccSignResponse(whClientContext* ctx, uint8_t* sig,
     }
 
     ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_ECDSA_SIGN, res_len,
-                             sizeof(*res), (uint8_t**)&res, &trailSz);
+                             (uint8_t**)&res, sizeof(*res), &trailSz);
     if (ret >= 0) {
         uint8_t* res_sig = (uint8_t*)(res + 1);
         /* Defensive bound: res->sz must fit within the actual received frame */
@@ -2758,7 +2765,7 @@ int wh_Client_EccVerifyResponse(whClientContext* ctx, ecc_key* opt_key,
     }
 
     ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_ECDSA_VERIFY, res_len,
-                             sizeof(*res), (uint8_t**)&res, &trailSz);
+                             (uint8_t**)&res, sizeof(*res), &trailSz);
     if (ret >= 0) {
         /* Defensive bound: res->pubSz must fit within the actual received
          * frame */
@@ -2928,7 +2935,7 @@ static int _EccMakePubResponse(whClientContext* ctx, uint8_t* pubOut,
     }
 
     ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_EC_MAKE_PUB, res_len,
-                             sizeof(*res), (uint8_t**)&res, &trailSz);
+                             (uint8_t**)&res, sizeof(*res), &trailSz);
     if (ret >= 0) {
         /* Defensive bound: res->pubSz must fit within the actual received
          * frame */
@@ -3064,7 +3071,7 @@ static int _EccCheckPubKeyResponse(whClientContext* ctx)
     /* A negative rc here is the verdict on an invalid key rather than a
      * transport failure, and is handed back to wolfCrypt verbatim. */
     ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_EC_CHECK_PUB_KEY, res_len,
-                             sizeof(*res), (uint8_t**)&res, NULL);
+                             (uint8_t**)&res, sizeof(*res), NULL);
     if (ret >= 0) {
         /* A success rc must be accompanied by an affirmative body */
         if (res->ok == 0) {
@@ -3350,7 +3357,7 @@ static int _Curve25519MakeKey(whClientContext* ctx, uint16_t size,
         /* Get response structure pointer, validates generic header */
         ret =
             _getCryptoResponse(dataPtr, WC_PK_TYPE_CURVE25519_KEYGEN, data_len,
-                               sizeof(*res), (uint8_t**)&res, &trailSz);
+                               (uint8_t**)&res, sizeof(*res), &trailSz);
         /* wolfCrypt allows positive error codes on success in some scenarios */
         if (ret >= 0) {
             WH_DEBUG_CLIENT_VERBOSE("Curve25519 KeyGen Res recv:keyid:%u, len:%u, "
@@ -3543,7 +3550,7 @@ static int _Curve25519SharedSecretResponse(whClientContext* ctx, uint8_t* out,
     }
 
     ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_CURVE25519, res_len,
-                             sizeof(*res), (uint8_t**)&res, &trailSz);
+                             (uint8_t**)&res, sizeof(*res), &trailSz);
     if (ret >= 0) {
         uint8_t*     res_out = (uint8_t*)(res + 1);
         if (res->sz > trailSz) {
@@ -3868,7 +3875,7 @@ static int _Ed25519MakeKey(whClientContext* ctx, whKeyId* inout_key_id,
     }
 
     ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_ED25519_KEYGEN, res_len,
-                             sizeof(*res), (uint8_t**)&res, &trailSz);
+                             (uint8_t**)&res, sizeof(*res), &trailSz);
     if (ret >= 0) {
 
         /* Defensive bound: res->outSz must fit within the received frame */
@@ -4064,7 +4071,7 @@ int wh_Client_Ed25519Sign(whClientContext* ctx, ed25519_key* key,
 
             if (ret == WH_ERROR_OK) {
                 ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_ED25519_SIGN,
-                                         res_len, sizeof(*res), (uint8_t**)&res,
+                                         res_len, (uint8_t**)&res, sizeof(*res),
                                          &trailSz);
                 if (ret >= 0) {
                     if (res->sigSz > trailSz) {
@@ -4203,7 +4210,7 @@ int wh_Client_Ed25519Verify(whClientContext* ctx, ed25519_key* key,
 
             if (ret == WH_ERROR_OK) {
                 ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_ED25519_VERIFY,
-                                         res_len, sizeof(*res), (uint8_t**)&res,
+                                         res_len, (uint8_t**)&res, sizeof(*res),
                                          NULL);
                 if (ret >= 0) {
                     *out_res = res->res;
@@ -4336,7 +4343,7 @@ int wh_Client_Ed25519SignDma(whClientContext* ctx, ed25519_key* key,
 
             if (ret == WH_ERROR_OK) {
                 ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_ED25519_SIGN,
-                                         res_len, sizeof(*res), (uint8_t**)&res,
+                                         res_len, (uint8_t**)&res, sizeof(*res),
                                          NULL);
                 if (ret >= 0) {
                     /* DMA mode: signature was written to the caller's
@@ -4479,7 +4486,7 @@ int wh_Client_Ed25519VerifyDma(whClientContext* ctx, ed25519_key* key,
 
             if (ret == WH_ERROR_OK) {
                 ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_ED25519_VERIFY,
-                                         res_len, sizeof(*res), (uint8_t**)&res,
+                                         res_len, (uint8_t**)&res, sizeof(*res),
                                          NULL);
                 if (ret >= 0) {
                     *out_res = res->verifyResult;
@@ -4693,7 +4700,7 @@ static int _RsaMakeKeyResponse(whClientContext* ctx, whKeyId* out_key_id,
     }
 
     ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_RSA_KEYGEN, res_len,
-                             sizeof(*res), (uint8_t**)&res, &trailSz);
+                             (uint8_t**)&res, sizeof(*res), &trailSz);
     /* wolfCrypt allows positive return codes on success */
     if (ret >= 0) {
         whKeyId key_id;
@@ -4925,8 +4932,8 @@ int wh_Client_RsaFunctionResponse(whClientContext* ctx, uint8_t* out,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_RSA, res_len, sizeof(*res),
-                             (uint8_t**)&res, &trailSz);
+    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_RSA, res_len, (uint8_t**)&res,
+                             sizeof(*res), &trailSz);
     if (ret >= 0) {
         uint8_t* res_out;
 
@@ -5121,7 +5128,7 @@ int wh_Client_RsaGetSizeResponse(whClientContext* ctx, int* out_size)
     }
 
     ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_RSA_GET_SIZE, res_len,
-                             sizeof(*res), (uint8_t**)&res, NULL);
+                             (uint8_t**)&res, sizeof(*res), NULL);
     if (ret >= 0) {
         *out_size = (int)res->keySize;
     }
@@ -5318,7 +5325,7 @@ static int _HkdfMakeKey(whClientContext* ctx, int hashType, whKeyId keyIdIn,
         if (ret == WH_ERROR_OK) {
             /* Get response structure pointer, validates generic header rc */
             ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_KDF, res_len,
-                                     sizeof(*res), (uint8_t**)&res, &trailSz);
+                                     (uint8_t**)&res, sizeof(*res), &trailSz);
         }
 
         if (ret == WH_ERROR_OK) {
@@ -5489,7 +5496,7 @@ static int _CmacKdfMakeKey(whClientContext* ctx, whKeyId saltKeyId,
 
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_KDF, res_len,
-                                 sizeof(*res), (uint8_t**)&res, &trailSz);
+                                 (uint8_t**)&res, sizeof(*res), &trailSz);
     }
 
     if (ret == WH_ERROR_OK) {
@@ -5726,8 +5733,8 @@ int wh_Client_CmacGenerateResponse(whClientContext* ctx, Cmac* cmac,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, res_len, sizeof(*res),
-                             (uint8_t**)&res, &trailSz);
+    ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, res_len,
+                             (uint8_t**)&res, sizeof(*res), &trailSz);
     /* wolfCrypt allows positive error codes on success */
     if (ret >= 0) {
         /* The MAC bytes the response claims must be in the received frame */
@@ -5855,8 +5862,8 @@ int wh_Client_CmacUpdateResponse(whClientContext* ctx, Cmac* cmac)
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, res_len, sizeof(*res),
-                             (uint8_t**)&res, NULL);
+    ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, res_len,
+                             (uint8_t**)&res, sizeof(*res), NULL);
     if (ret >= 0) {
         /* Restore full state from server. The server may leave a partial
          * (or whole) block in its buffer after wc_CmacUpdate (CMAC's last
@@ -5948,8 +5955,8 @@ int wh_Client_CmacFinalResponse(whClientContext* ctx, Cmac* cmac,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, res_len, sizeof(*res),
-                             (uint8_t**)&res, &trailSz);
+    ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, res_len,
+                             (uint8_t**)&res, sizeof(*res), &trailSz);
     if (ret >= 0) {
         /* The MAC bytes the response claims must be in the received frame */
         if (res->outSz > trailSz) {
@@ -6199,7 +6206,7 @@ int wh_Client_CmacGenerateDmaResponse(whClientContext* ctx, Cmac* cmac,
 
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, respSz,
-                                 sizeof(*res), (uint8_t**)&res, &trailSz);
+                                 (uint8_t**)&res, sizeof(*res), &trailSz);
         if (ret >= 0) {
             /* The MAC bytes the response claims must be in the received
              * frame. A failed server request replies with the generic header
@@ -6355,7 +6362,7 @@ int wh_Client_CmacDmaUpdateResponse(whClientContext* ctx, Cmac* cmac)
 
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, respSz,
-                                 sizeof(*res), (uint8_t**)&res, NULL);
+                                 (uint8_t**)&res, sizeof(*res), NULL);
         if (ret >= 0) {
             /* Restore full state from server (includes any partial/whole
              * block left in the server's wc_CmacUpdate buffer). */
@@ -6446,8 +6453,8 @@ int wh_Client_CmacDmaFinalResponse(whClientContext* ctx, Cmac* cmac,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, respSz, sizeof(*res),
-                             (uint8_t**)&res, &trailSz);
+    ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, respSz,
+                             (uint8_t**)&res, sizeof(*res), &trailSz);
     if (ret >= 0) {
         /* The MAC bytes the response claims must be in the received frame */
         if (res->outSz > trailSz) {
@@ -6697,8 +6704,8 @@ int wh_Client_Sha256UpdateResponse(whClientContext* ctx, wc_Sha256* sha)
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA256, dataSz, sizeof(*res),
-                             (uint8_t**)&res, NULL);
+    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA256, dataSz,
+                             (uint8_t**)&res, sizeof(*res), NULL);
     if (ret >= 0) {
         if (res->hashType != WC_HASH_TYPE_SHA256) {
             return WH_ERROR_ABORTED;
@@ -6775,8 +6782,8 @@ int wh_Client_Sha256FinalResponse(whClientContext* ctx, wc_Sha256* sha,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA256, dataSz, sizeof(*res),
-                             (uint8_t**)&res, NULL);
+    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA256, dataSz,
+                             (uint8_t**)&res, sizeof(*res), NULL);
     if (ret >= 0) {
         if (res->hashType != WC_HASH_TYPE_SHA256) {
             return WH_ERROR_ABORTED;
@@ -6993,7 +7000,7 @@ int wh_Client_Sha256DmaUpdateResponse(whClientContext* ctx, wc_Sha256* sha)
 
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA256, respSz,
-                                 sizeof(*resp), (uint8_t**)&resp, NULL);
+                                 (uint8_t**)&resp, sizeof(*resp), NULL);
         if (ret >= 0) {
             if (resp->hashType != WC_HASH_TYPE_SHA256) {
                 ret = WH_ERROR_ABORTED;
@@ -7094,7 +7101,7 @@ int wh_Client_Sha256DmaFinalResponse(whClientContext* ctx, wc_Sha256* sha,
 
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA256, respSz,
-                                 sizeof(*resp), (uint8_t**)&resp, NULL);
+                                 (uint8_t**)&resp, sizeof(*resp), NULL);
         if (ret >= 0) {
             if (resp->hashType != WC_HASH_TYPE_SHA256) {
                 return WH_ERROR_ABORTED;
@@ -7284,8 +7291,8 @@ int wh_Client_Sha224UpdateResponse(whClientContext* ctx, wc_Sha224* sha)
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA224, dataSz, sizeof(*res),
-                             (uint8_t**)&res, NULL);
+    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA224, dataSz,
+                             (uint8_t**)&res, sizeof(*res), NULL);
     if (ret >= 0) {
         if (res->hashType != WC_HASH_TYPE_SHA224) {
             return WH_ERROR_ABORTED;
@@ -7363,8 +7370,8 @@ int wh_Client_Sha224FinalResponse(whClientContext* ctx, wc_Sha224* sha,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA224, dataSz, sizeof(*res),
-                             (uint8_t**)&res, NULL);
+    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA224, dataSz,
+                             (uint8_t**)&res, sizeof(*res), NULL);
     if (ret >= 0) {
         if (res->hashType != WC_HASH_TYPE_SHA224) {
             return WH_ERROR_ABORTED;
@@ -7569,7 +7576,7 @@ int wh_Client_Sha224DmaUpdateResponse(whClientContext* ctx, wc_Sha224* sha)
 
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA224, respSz,
-                                 sizeof(*resp), (uint8_t**)&resp, NULL);
+                                 (uint8_t**)&resp, sizeof(*resp), NULL);
         if (ret >= 0) {
             if (resp->hashType != WC_HASH_TYPE_SHA224) {
                 ret = WH_ERROR_ABORTED;
@@ -7666,7 +7673,7 @@ int wh_Client_Sha224DmaFinalResponse(whClientContext* ctx, wc_Sha224* sha,
 
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA224, respSz,
-                                 sizeof(*resp), (uint8_t**)&resp, NULL);
+                                 (uint8_t**)&resp, sizeof(*resp), NULL);
         if (ret >= 0) {
             if (resp->hashType != WC_HASH_TYPE_SHA224) {
                 return WH_ERROR_ABORTED;
@@ -7856,8 +7863,8 @@ int wh_Client_Sha384UpdateResponse(whClientContext* ctx, wc_Sha384* sha)
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA384, dataSz, sizeof(*res),
-                             (uint8_t**)&res, NULL);
+    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA384, dataSz,
+                             (uint8_t**)&res, sizeof(*res), NULL);
     if (ret >= 0) {
         if (res->hashType != WC_HASH_TYPE_SHA384) {
             return WH_ERROR_ABORTED;
@@ -7936,8 +7943,8 @@ int wh_Client_Sha384FinalResponse(whClientContext* ctx, wc_Sha384* sha,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA384, dataSz, sizeof(*res),
-                             (uint8_t**)&res, NULL);
+    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA384, dataSz,
+                             (uint8_t**)&res, sizeof(*res), NULL);
     if (ret >= 0) {
         if (res->hashType != WC_HASH_TYPE_SHA384) {
             return WH_ERROR_ABORTED;
@@ -8143,7 +8150,7 @@ int wh_Client_Sha384DmaUpdateResponse(whClientContext* ctx, wc_Sha384* sha)
 
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA384, respSz,
-                                 sizeof(*resp), (uint8_t**)&resp, NULL);
+                                 (uint8_t**)&resp, sizeof(*resp), NULL);
         if (ret >= 0) {
             if (resp->hashType != WC_HASH_TYPE_SHA384) {
                 ret = WH_ERROR_ABORTED;
@@ -8241,7 +8248,7 @@ int wh_Client_Sha384DmaFinalResponse(whClientContext* ctx, wc_Sha384* sha,
 
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA384, respSz,
-                                 sizeof(*resp), (uint8_t**)&resp, NULL);
+                                 (uint8_t**)&resp, sizeof(*resp), NULL);
         if (ret >= 0) {
             if (resp->hashType != WC_HASH_TYPE_SHA384) {
                 return WH_ERROR_ABORTED;
@@ -8430,8 +8437,8 @@ int wh_Client_Sha512UpdateResponse(whClientContext* ctx, wc_Sha512* sha)
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA512, dataSz, sizeof(*res),
-                             (uint8_t**)&res, NULL);
+    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA512, dataSz,
+                             (uint8_t**)&res, sizeof(*res), NULL);
     if (ret >= 0) {
         /* Family check, not variant match: SHA-512/t shares block size and
          * compression with SHA-512, and the client supplies the variant IV
@@ -8516,8 +8523,8 @@ int wh_Client_Sha512FinalResponse(whClientContext* ctx, wc_Sha512* sha,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA512, dataSz, sizeof(*res),
-                             (uint8_t**)&res, NULL);
+    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA512, dataSz,
+                             (uint8_t**)&res, sizeof(*res), NULL);
     if (ret >= 0) {
         /* keep hashtype before initialization */
         hashType = sha->hashType;
@@ -8746,7 +8753,7 @@ int wh_Client_Sha512DmaUpdateResponse(whClientContext* ctx, wc_Sha512* sha)
 
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA512, respSz,
-                                 sizeof(*resp), (uint8_t**)&resp, NULL);
+                                 (uint8_t**)&resp, sizeof(*resp), NULL);
         if (ret >= 0) {
             /* Family check, not variant match: SHA-512/t shares block size and
              * compression with SHA-512, and the client supplies the variant IV
@@ -8850,7 +8857,7 @@ int wh_Client_Sha512DmaFinalResponse(whClientContext* ctx, wc_Sha512* sha,
 
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA512, respSz,
-                                 sizeof(*resp), (uint8_t**)&resp, NULL);
+                                 (uint8_t**)&resp, sizeof(*resp), NULL);
         if (ret >= 0) {
             /* keep hashtype before initialization */
             hashType = sha->hashType;
@@ -9103,8 +9110,8 @@ static int _Sha3UpdateResponse(whClientContext* ctx, wc_Sha3* sha,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, v->hashType, dataSz, sizeof(*res),
-                             (uint8_t**)&res, NULL);
+    ret = _getCryptoResponse(dataPtr, v->hashType, dataSz, (uint8_t**)&res,
+                             sizeof(*res), NULL);
     if (ret >= 0) {
         memcpy(sha->s, res->resumeState.s, sizeof(sha->s));
     }
@@ -9180,8 +9187,8 @@ static int _Sha3FinalResponse(whClientContext* ctx, wc_Sha3* sha,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, v->hashType, dataSz, sizeof(*res),
-                             (uint8_t**)&res, NULL);
+    ret = _getCryptoResponse(dataPtr, v->hashType, dataSz, (uint8_t**)&res,
+                             sizeof(*res), NULL);
     if (ret >= 0) {
         memcpy(out, res->hash, v->digestSize);
         /* Reset state, preserving heap and devId. */
@@ -9552,8 +9559,8 @@ static int _Sha3DmaUpdateResponse(whClientContext* ctx, wc_Sha3* sha,
     }
 
     if (ret == WH_ERROR_OK) {
-        ret = _getCryptoResponse(dataPtr, v->hashType, respSz, sizeof(*resp),
-                                 (uint8_t**)&resp, NULL);
+        ret = _getCryptoResponse(dataPtr, v->hashType, respSz, (uint8_t**)&resp,
+                                 sizeof(*resp), NULL);
         if (ret >= 0) {
             memcpy(sha->s, resp->resumeState.s, sizeof(sha->s));
         }
@@ -9644,8 +9651,8 @@ static int _Sha3DmaFinalResponse(whClientContext* ctx, wc_Sha3* sha,
     }
 
     if (ret == WH_ERROR_OK) {
-        ret = _getCryptoResponse(dataPtr, v->hashType, respSz, sizeof(*resp),
-                                 (uint8_t**)&resp, NULL);
+        ret = _getCryptoResponse(dataPtr, v->hashType, respSz, (uint8_t**)&resp,
+                                 sizeof(*resp), NULL);
         if (ret >= 0) {
             memcpy(out, resp->hash, v->digestSize);
             savedHeap  = sha->heap;
@@ -10004,8 +10011,8 @@ static int _MlDsaMakeKey(whClientContext* ctx, int size, int level,
                     /* Get response structure pointer, validates generic header
                      * rc */
                     ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_SIG_KEYGEN,
-                                             res_len, sizeof(*res),
-                                             (uint8_t**)&res, &trailSz);
+                                             res_len, (uint8_t**)&res,
+                                             sizeof(*res), &trailSz);
                     /* wolfCrypt allows positive error codes on success in some
                      * scenarios */
                     if (ret >= 0) {
@@ -10234,8 +10241,8 @@ int wh_Client_MlDsaSign(whClientContext* ctx, const byte* in, word32 in_len,
                     /* Get response structure pointer, validates generic header
                      * rc */
                     ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_SIG_SIGN,
-                                             res_len, sizeof(*res),
-                                             (uint8_t**)&res, &trailSz);
+                                             res_len, (uint8_t**)&res,
+                                             sizeof(*res), &trailSz);
                     /* wolfCrypt allows positive error codes on success in some
                      * scenarios */
                     if (ret >= 0) {
@@ -10378,8 +10385,8 @@ int wh_Client_MlDsaVerify(whClientContext* ctx, const byte* sig, word32 sig_len,
                     /* Get response structure pointer, validates generic header
                      * rc */
                     ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_SIG_VERIFY,
-                                             res_len, sizeof(*res),
-                                             (uint8_t**)&res, NULL);
+                                             res_len, (uint8_t**)&res,
+                                             sizeof(*res), NULL);
                     /* wolfCrypt allows positive error codes on success in some
                      * scenarios */
                     if (ret >= 0) {
@@ -10577,7 +10584,7 @@ static int _MlDsaMakeKeyDma(whClientContext* ctx, int level,
              * rc */
             ret =
                 _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_SIG_KEYGEN, res_len,
-                                   sizeof(*res), (uint8_t**)&res, NULL);
+                                   (uint8_t**)&res, sizeof(*res), NULL);
             /* wolfCrypt allows positive error codes on success in some
              * scenarios */
             if (ret >= 0) {
@@ -10802,8 +10809,8 @@ int wh_Client_MlDsaSignDma(whClientContext* ctx, const byte* in, word32 in_len,
                     /* Get response structure pointer, validates generic header
                      * rc */
                     ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_SIG_SIGN,
-                                             res_len, sizeof(*res),
-                                             (uint8_t**)&res, NULL);
+                                             res_len, (uint8_t**)&res,
+                                             sizeof(*res), NULL);
                     /* wolfCrypt allows positive error codes on success in some
                      * scenarios */
                     if (ret >= 0) {
@@ -10952,8 +10959,8 @@ int wh_Client_MlDsaVerifyDma(whClientContext* ctx, const byte* sig,
                     /* Get response structure pointer, validates generic header
                      * rc */
                     ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_SIG_VERIFY,
-                                             res_len, sizeof(*res),
-                                             (uint8_t**)&res, NULL);
+                                             res_len, (uint8_t**)&res,
+                                             sizeof(*res), NULL);
                     /* wolfCrypt allows positive error codes on success in some
                      * scenarios */
                     if (ret >= 0) {
@@ -11169,7 +11176,7 @@ static int _MlKemMakeKey(whClientContext* ctx, int level,
     }
 
     ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_KEM_KEYGEN, res_len,
-                             sizeof(*res), (uint8_t**)&res, &trailSz);
+                             (uint8_t**)&res, sizeof(*res), &trailSz);
     if (ret >= 0) {
         key_id = (whKeyId)res->keyId;
         WH_DEBUG_CLIENT_VERBOSE("MlKemMakeKey: Res recv:"
@@ -11350,7 +11357,7 @@ int wh_Client_MlKemEncapsulate(whClientContext* ctx, MlKemKey* key,
 
             if (ret == WH_ERROR_OK) {
                 ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_KEM_ENCAPS,
-                                         res_len, sizeof(*res), (uint8_t**)&res,
+                                         res_len, (uint8_t**)&res, sizeof(*res),
                                          &trailSz);
                 if (ret >= 0) {
                     uint8_t*     resp_data  = (uint8_t*)(res + 1);
@@ -11477,7 +11484,7 @@ int wh_Client_MlKemDecapsulate(whClientContext* ctx, MlKemKey* key,
 
             if (ret == WH_ERROR_OK) {
                 ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_KEM_DECAPS,
-                                         res_len, sizeof(*res), (uint8_t**)&res,
+                                         res_len, (uint8_t**)&res, sizeof(*res),
                                          &trailSz);
                 if (ret >= 0) {
                     uint8_t*     resp_ss    = (uint8_t*)(res + 1);
@@ -11679,7 +11686,7 @@ static int _MlKemMakeKeyDma(whClientContext* ctx, int level,
 
     if (ret == WH_ERROR_OK) {
         ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_KEM_KEYGEN, res_len,
-                                 sizeof(*res), (uint8_t**)&res, NULL);
+                                 (uint8_t**)&res, sizeof(*res), NULL);
         if (ret >= 0) {
             key_id = (whKeyId)res->keyId;
             if (inout_key_id != NULL) {
@@ -11850,7 +11857,7 @@ int wh_Client_MlKemEncapsulateDma(whClientContext* ctx, MlKemKey* key,
 
             if (ret == WH_ERROR_OK) {
                 ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_KEM_ENCAPS,
-                                         res_len, sizeof(*res), (uint8_t**)&res,
+                                         res_len, (uint8_t**)&res, sizeof(*res),
                                          &trailSz);
                 if (ret >= 0) {
                     /* ct was transferred via DMA, ss is inline in response */
@@ -11973,7 +11980,7 @@ int wh_Client_MlKemDecapsulateDma(whClientContext* ctx, MlKemKey* key,
 
             if (ret == WH_ERROR_OK) {
                 ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_KEM_DECAPS,
-                                         res_len, sizeof(*res), (uint8_t**)&res,
+                                         res_len, (uint8_t**)&res, sizeof(*res),
                                          &trailSz);
                 if (ret >= 0) {
                     /* ss is inline in response, not via DMA */
@@ -12131,7 +12138,7 @@ int wh_Client_LmsMakeKeyDma(whClientContext* ctx, LmsKey* key,
         if (ret == WH_ERROR_OK) {
             ret = _getCryptoResponse(
                 dataPtr, WC_PK_TYPE_PQC_STATEFUL_SIG_KEYGEN, res_len,
-                sizeof(*res), (uint8_t**)&res, NULL);
+                (uint8_t**)&res, sizeof(*res), NULL);
             if (ret >= 0) {
                 key_id = (whKeyId)res->keyId;
                 if (inout_key_id != NULL) {
@@ -12237,7 +12244,7 @@ int wh_Client_LmsSignDma(whClientContext* ctx, const byte* msg, word32 msgSz,
 
         if (ret == WH_ERROR_OK) {
             ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_STATEFUL_SIG_SIGN,
-                                     res_len, sizeof(*res), (uint8_t**)&res,
+                                     res_len, (uint8_t**)&res, sizeof(*res),
                                      NULL);
             if (ret >= 0) {
                 if (res->sigLen > sigCap) {
@@ -12340,7 +12347,7 @@ int wh_Client_LmsVerifyDma(whClientContext* ctx, const byte* sig, word32 sigSz,
         if (ret == WH_ERROR_OK) {
             ret = _getCryptoResponse(
                 dataPtr, WC_PK_TYPE_PQC_STATEFUL_SIG_VERIFY, res_len,
-                sizeof(*resp), (uint8_t**)&resp, NULL);
+                (uint8_t**)&resp, sizeof(*resp), NULL);
             if (ret >= 0) {
                 *res = (int)resp->res;
                 ret  = WH_ERROR_OK;
@@ -12404,7 +12411,7 @@ int wh_Client_LmsSigsLeftDma(whClientContext* ctx, LmsKey* key)
         if (ret == WH_ERROR_OK) {
             ret = _getCryptoResponse(
                 dataPtr, WC_PK_TYPE_PQC_STATEFUL_SIG_SIGS_LEFT, res_len,
-                sizeof(*res), (uint8_t**)&res, NULL);
+                (uint8_t**)&res, sizeof(*res), NULL);
             if (ret >= 0) {
                 /* The server mirrors wc_LmsKey_SigsLeft(), which is a
                  * boolean. Normalize so the only nonzero return is 1. */
@@ -12583,7 +12590,7 @@ int wh_Client_XmssMakeKeyDma(whClientContext* ctx, XmssKey* key,
         if (ret == WH_ERROR_OK) {
             ret = _getCryptoResponse(
                 dataPtr, WC_PK_TYPE_PQC_STATEFUL_SIG_KEYGEN, res_len,
-                sizeof(*res), (uint8_t**)&res, NULL);
+                (uint8_t**)&res, sizeof(*res), NULL);
             if (ret >= 0) {
                 key_id = (whKeyId)res->keyId;
                 if (inout_key_id != NULL) {
@@ -12689,7 +12696,7 @@ int wh_Client_XmssSignDma(whClientContext* ctx, const byte* msg, word32 msgSz,
 
         if (ret == WH_ERROR_OK) {
             ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_STATEFUL_SIG_SIGN,
-                                     res_len, sizeof(*res), (uint8_t**)&res,
+                                     res_len, (uint8_t**)&res, sizeof(*res),
                                      NULL);
             if (ret >= 0) {
                 if (res->sigLen > sigCap) {
@@ -12793,7 +12800,7 @@ int wh_Client_XmssVerifyDma(whClientContext* ctx, const byte* sig,
         if (ret == WH_ERROR_OK) {
             ret = _getCryptoResponse(
                 dataPtr, WC_PK_TYPE_PQC_STATEFUL_SIG_VERIFY, res_len,
-                sizeof(*resp), (uint8_t**)&resp, NULL);
+                (uint8_t**)&resp, sizeof(*resp), NULL);
             if (ret >= 0) {
                 *res = (int)resp->res;
                 ret  = WH_ERROR_OK;
@@ -12857,7 +12864,7 @@ int wh_Client_XmssSigsLeftDma(whClientContext* ctx, XmssKey* key)
         if (ret == WH_ERROR_OK) {
             ret = _getCryptoResponse(
                 dataPtr, WC_PK_TYPE_PQC_STATEFUL_SIG_SIGS_LEFT, res_len,
-                sizeof(*res), (uint8_t**)&res, NULL);
+                (uint8_t**)&res, sizeof(*res), NULL);
             if (ret >= 0) {
                 /* The server mirrors wc_XmssKey_SigsLeft(), which is a
                  * boolean. Normalize so the only nonzero return is 1. */

--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -153,7 +153,8 @@ static uint8_t* _createCryptoRequestWithSubtype(uint8_t* reqBuf, uint16_t type,
                                                 uint16_t algoSubType,
                                                 uint32_t affinity);
 static int      _getCryptoResponse(uint8_t* respBuf, uint16_t type,
-                                   uint8_t** outResponse);
+                                   const uint16_t respLen, const uint16_t minRespLen,
+                                   uint8_t** outResponse, uint16_t* outTrailingLen);
 
 
 /* Helper function to prepare a crypto request buffer with generic header */
@@ -178,23 +179,50 @@ static uint8_t* _createCryptoRequestWithSubtype(uint8_t* reqBuf, uint16_t type,
     return reqBuf + sizeof(whMessageCrypto_GenericRequestHeader);
 }
 
-/* Helper function to validate and extract crypto response */
+/* Helper function to validate and extract crypto response. */
 /* TODO: add algoSubType checking */
 static int _getCryptoResponse(uint8_t* respBuf, uint16_t type,
-                              uint8_t** outResponse)
+                              const uint16_t respLen, const uint16_t minRespLen,
+                              uint8_t** outResponse, uint16_t* outTrailingLen)
 {
-    whMessageCrypto_GenericResponseHeader* header =
-        (whMessageCrypto_GenericResponseHeader*)respBuf;
+    const whMessageCrypto_GenericResponseHeader* header =
+        (const whMessageCrypto_GenericResponseHeader*)respBuf;
+    int rc = 0;
+
+    if (outTrailingLen != NULL) {
+        *outTrailingLen = 0;
+    }
+
+    if (respLen < sizeof(*header)) {
+        return WH_ERROR_ABORTED;
+    }
 
     if (header->algoType != type) {
         return WH_ERROR_ABORTED;
     }
 
-    if (outResponse != NULL) {
-        *outResponse = respBuf + sizeof(whMessageCrypto_GenericResponseHeader);
+    rc = header->rc;
+
+    /* The server sends the generic header alone when a handler fails, so only
+     * bound the body when the caller will read it. */
+    if (rc >= 0) {
+        if (respLen < sizeof(*header) + minRespLen) {
+            return WH_ERROR_ABORTED;
+        }
+
+        /* Bytes received past the fixed body. Callers bound their variable
+         * length payload against this instead of recomputing it. */
+        if (outTrailingLen != NULL) {
+            *outTrailingLen =
+                (uint16_t)(respLen - sizeof(*header) - minRespLen);
+        }
     }
 
-    return header->rc;
+    if (outResponse != NULL) {
+        *outResponse = respBuf + sizeof(*header);
+    }
+
+    return rc;
 }
 
 /** Implementations */
@@ -236,6 +264,7 @@ int wh_Client_RngGenerateResponse(whClientContext* ctx, uint8_t* out,
     uint16_t                     group;
     uint16_t                     action;
     uint16_t                     res_len = 0;
+    uint16_t                     trailSz = 0;
     uint8_t*                     dataPtr;
     whMessageCrypto_RngResponse* res = NULL;
 
@@ -255,13 +284,12 @@ int wh_Client_RngGenerateResponse(whClientContext* ctx, uint8_t* out,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_RNG, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_RNG, res_len, sizeof(*res),
+                             (uint8_t**)&res, &trailSz);
     if (ret == WH_ERROR_OK) {
-        const uint32_t hdr_sz =
-            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
         /* Reject a size the received message does not actually carry, or that
          * exceeds the inline cap or the caller's buffer. */
-        if (res_len < hdr_sz || res->sz > (res_len - hdr_sz) ||
+        if (res->sz > trailSz ||
             res->sz > WH_MESSAGE_CRYPTO_RNG_MAX_INLINE_SZ ||
             res->sz > *inout_size) {
             ret = WH_ERROR_ABORTED;
@@ -400,18 +428,10 @@ int wh_Client_RngGenerateDmaResponse(whClientContext* ctx)
     }
 
     if (ret == WH_ERROR_OK) {
-        ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_RNG, (uint8_t**)&resp);
+        ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_RNG, respSz,
+                                 sizeof(*resp), (uint8_t**)&resp, NULL);
         /* On success, server has written random bytes directly to client
          * memory — nothing else to copy. */
-        if (ret == WH_ERROR_OK) {
-            const uint32_t hdr_sz =
-                sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*resp);
-            /* Nothing here is read inline; the bound just holds a success rc
-             * to a full response (an error reply carries only the header). */
-            if (respSz < hdr_sz) {
-                ret = WH_ERROR_ABORTED;
-            }
-        }
     }
 
     /* POST DMA cleanup using stashed addresses (runs on every non-NOTREADY
@@ -518,6 +538,7 @@ int wh_Client_AesCtrResponse(whClientContext* ctx, Aes* aes, uint8_t* out,
     uint16_t                        group   = 0;
     uint16_t                        action  = 0;
     uint16_t                        res_len = 0;
+    uint16_t                        trailSz = 0;
     whMessageCrypto_AesCtrResponse* res;
 
     if ((ctx == NULL) || (aes == NULL) || (out == NULL)) {
@@ -532,14 +553,13 @@ int wh_Client_AesCtrResponse(whClientContext* ctx, Aes* aes, uint8_t* out,
     ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
                                  WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_OK) {
-        ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_CTR, (uint8_t**)&res);
+        ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_CTR, res_len,
+                                 sizeof(*res) + (2 * AES_BLOCK_SIZE),
+                                 (uint8_t**)&res, &trailSz);
         if (ret == WH_ERROR_OK) {
-            const uint32_t hdr_sz =
-                sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res) +
-                (2 * AES_BLOCK_SIZE);
             /* Trailing payload is: output (res->sz) + reg (AES_BLOCK_SIZE)
              * + tmp (AES_BLOCK_SIZE) */
-            if (res_len < hdr_sz || res->sz > (res_len - hdr_sz)) {
+            if (res->sz > trailSz) {
                 ret = WH_ERROR_ABORTED;
             }
             else {
@@ -722,25 +742,19 @@ int wh_Client_AesCtrDmaResponse(whClientContext* ctx, Aes* aes)
     }
 
     if (ret == WH_ERROR_OK) {
-        ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_CTR, (uint8_t**)&res);
+        ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_CTR, res_len,
+                                 sizeof(*res) + AES_IV_SIZE + AES_BLOCK_SIZE,
+                                 (uint8_t**)&res, NULL);
         if (ret == WH_ERROR_OK) {
             /* Trailing payload is: reg (AES_IV_SIZE) + tmp (AES_BLOCK_SIZE) */
-            const uint32_t hdr_sz =
-                sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res) +
-                AES_IV_SIZE + AES_BLOCK_SIZE;
-            if (res_len < hdr_sz) {
-                ret = WH_ERROR_ABORTED;
-            }
-            else {
-                uint8_t* res_iv =
-                    (uint8_t*)res + sizeof(whMessageCrypto_AesCtrDmaResponse);
-                uint8_t* res_tmp = res_iv + AES_IV_SIZE;
-                aes->left        = res->left;
-                memcpy((uint8_t*)aes->reg, res_iv, AES_IV_SIZE);
-                memcpy((uint8_t*)aes->tmp, res_tmp, AES_BLOCK_SIZE);
-                WH_DEBUG_CLIENT_VERBOSE("AesCtr DMA res: left=%u\n",
-                                        (unsigned int)res->left);
-            }
+            uint8_t* res_iv =
+                (uint8_t*)res + sizeof(whMessageCrypto_AesCtrDmaResponse);
+            uint8_t* res_tmp = res_iv + AES_IV_SIZE;
+            aes->left        = res->left;
+            memcpy((uint8_t*)aes->reg, res_iv, AES_IV_SIZE);
+            memcpy((uint8_t*)aes->tmp, res_tmp, AES_BLOCK_SIZE);
+            WH_DEBUG_CLIENT_VERBOSE("AesCtr DMA res: left=%u\n",
+                                    (unsigned int)res->left);
         }
     }
 
@@ -858,6 +872,7 @@ int wh_Client_AesEcbResponse(whClientContext* ctx, Aes* aes, uint8_t* out,
     uint16_t                        group   = 0;
     uint16_t                        action  = 0;
     uint16_t                        res_len = 0;
+    uint16_t                        trailSz = 0;
     whMessageCrypto_AesEcbResponse* res;
 
     (void)aes;
@@ -874,11 +889,10 @@ int wh_Client_AesEcbResponse(whClientContext* ctx, Aes* aes, uint8_t* out,
     ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
                                  WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_OK) {
-        ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_ECB, (uint8_t**)&res);
+        ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_ECB, res_len,
+                                 sizeof(*res), (uint8_t**)&res, &trailSz);
         if (ret == WH_ERROR_OK) {
-            const uint32_t hdr_sz =
-                sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
-            if (res_len < hdr_sz || res->sz > (res_len - hdr_sz)) {
+            if (res->sz > trailSz) {
                 ret = WH_ERROR_ABORTED;
             }
             else {
@@ -1050,16 +1064,10 @@ int wh_Client_AesEcbDmaResponse(whClientContext* ctx, Aes* aes)
     }
 
     if (ret == WH_ERROR_OK) {
-        ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_ECB, (uint8_t**)&res);
+        ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_ECB, res_len,
+                                 sizeof(*res), (uint8_t**)&res, NULL);
         if (ret == WH_ERROR_OK) {
-            const uint32_t hdr_sz =
-                sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
-            if (res_len < hdr_sz) {
-                ret = WH_ERROR_ABORTED;
-            }
-            else {
-                WH_DEBUG_CLIENT_VERBOSE("AesEcb DMA res: ok\n");
-            }
+            WH_DEBUG_CLIENT_VERBOSE("AesEcb DMA res: ok\n");
         }
     }
 
@@ -1193,6 +1201,7 @@ int wh_Client_AesCbcResponse(whClientContext* ctx, Aes* aes, uint8_t* out,
     uint16_t                        group   = 0;
     uint16_t                        action  = 0;
     uint16_t                        res_len = 0;
+    uint16_t                        trailSz = 0;
     whMessageCrypto_AesCbcResponse* res;
 
     if ((ctx == NULL) || (aes == NULL) || (out == NULL)) {
@@ -1207,14 +1216,13 @@ int wh_Client_AesCbcResponse(whClientContext* ctx, Aes* aes, uint8_t* out,
     ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
                                  WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_OK) {
-        ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_CBC, (uint8_t**)&res);
+        ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_CBC, res_len,
+                                 sizeof(*res) + AES_IV_SIZE, (uint8_t**)&res,
+                                 &trailSz);
         if (ret == WH_ERROR_OK) {
-            const uint32_t hdr_sz =
-                sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res) +
-                AES_IV_SIZE;
             /* Trailing payload is: output (res->sz) + updated IV
              * (AES_IV_SIZE) */
-            if (res_len < hdr_sz || res->sz > (res_len - hdr_sz)) {
+            if (res->sz > trailSz) {
                 ret = WH_ERROR_ABORTED;
             }
             else {
@@ -1395,21 +1403,15 @@ int wh_Client_AesCbcDmaResponse(whClientContext* ctx, Aes* aes)
     }
 
     if (ret == WH_ERROR_OK) {
-        ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_CBC, (uint8_t**)&res);
+        ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_CBC, res_len,
+                                 sizeof(*res) + AES_IV_SIZE, (uint8_t**)&res,
+                                 NULL);
         if (ret == WH_ERROR_OK) {
             /* Trailing payload is the updated IV (AES_IV_SIZE) */
-            const uint32_t hdr_sz =
-                sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res) +
-                AES_IV_SIZE;
-            if (res_len < hdr_sz) {
-                ret = WH_ERROR_ABORTED;
-            }
-            else {
-                uint8_t* res_iv =
-                    (uint8_t*)res + sizeof(whMessageCrypto_AesCbcDmaResponse);
-                memcpy((uint8_t*)aes->reg, res_iv, AES_IV_SIZE);
-                WH_DEBUG_CLIENT_VERBOSE("AesCbc DMA res: ok\n");
-            }
+            uint8_t* res_iv =
+                (uint8_t*)res + sizeof(whMessageCrypto_AesCbcDmaResponse);
+            memcpy((uint8_t*)aes->reg, res_iv, AES_IV_SIZE);
+            WH_DEBUG_CLIENT_VERBOSE("AesCbc DMA res: ok\n");
         }
     }
 
@@ -1553,6 +1555,7 @@ int wh_Client_AesGcmResponse(whClientContext* ctx, Aes* aes, uint8_t* out,
     uint16_t                        group   = 0;
     uint16_t                        action  = 0;
     uint16_t                        res_len = 0;
+    uint16_t                        trailSz = 0;
     whMessageCrypto_AesGcmResponse* res;
 
     (void)aes;
@@ -1574,15 +1577,13 @@ int wh_Client_AesGcmResponse(whClientContext* ctx, Aes* aes, uint8_t* out,
     ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
                                  WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     if (ret == WH_ERROR_OK) {
-        ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_GCM, (uint8_t**)&res);
+        ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_GCM, res_len,
+                                 sizeof(*res), (uint8_t**)&res, &trailSz);
         if (ret == WH_ERROR_OK) {
-            const uint32_t hdr_sz =
-                sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
             uint8_t* res_out = (uint8_t*)(res + 1);
             uint8_t* res_tag = res_out + res->sz;
             uint32_t trailing = (uint32_t)res->sz + (uint32_t)res->authTagSz;
-            if (res_len < hdr_sz || trailing < res->sz ||
-                trailing > (res_len - hdr_sz)) {
+            if (trailing < res->sz || trailing > trailSz) {
                 return WH_ERROR_ABORTED;
             }
 
@@ -1783,6 +1784,7 @@ int wh_Client_AesGcmDmaResponse(whClientContext* ctx, Aes* aes,
     int                                ret;
     uint8_t*                           dataPtr;
     uint16_t                           res_len = 0;
+    uint16_t                           trailSz = 0;
     whMessageCrypto_AesGcmDmaResponse* res;
 
     (void)aes;
@@ -1803,12 +1805,11 @@ int wh_Client_AesGcmDmaResponse(whClientContext* ctx, Aes* aes,
     }
 
     if (ret == WH_ERROR_OK) {
-        ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_GCM, (uint8_t**)&res);
+        ret = _getCryptoResponse(dataPtr, WC_CIPHER_AES_GCM, res_len,
+                                 sizeof(*res), (uint8_t**)&res, &trailSz);
         if (ret == WH_ERROR_OK) {
             /* Trailing payload is the auth tag (res->authTagSz) */
-            const uint32_t hdr_sz =
-                sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
-            if (res_len < hdr_sz || res->authTagSz > (res_len - hdr_sz)) {
+            if (res->authTagSz > trailSz) {
                 ret = WH_ERROR_ABORTED;
             }
             else {
@@ -2039,6 +2040,7 @@ static int _EccMakeKeyResponse(whClientContext* ctx, whKeyId* out_key_id,
     uint16_t                           group;
     uint16_t                           action;
     uint16_t                           res_len = 0;
+    uint16_t                           trailSz = 0;
     uint8_t*                           dataPtr = NULL;
     whMessageCrypto_EccKeyGenResponse* res     = NULL;
 
@@ -2058,15 +2060,14 @@ static int _EccMakeKeyResponse(whClientContext* ctx, whKeyId* out_key_id,
     }
 
     /* Get response structure pointer; validates the generic header rc */
-    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_EC_KEYGEN, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_EC_KEYGEN, res_len,
+                             sizeof(*res), (uint8_t**)&res, &trailSz);
     /* wolfCrypt allows positive error codes on success in some scenarios */
     if (ret >= 0) {
-        whKeyId      key_id = (whKeyId)(res->keyId);
-        const size_t hdr_sz =
-            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
+        whKeyId key_id = (whKeyId)(res->keyId);
         /* Defensive bound: res->len must fit within the actual received
          * frame */
-        if (res_len < hdr_sz || res->len > (res_len - hdr_sz)) {
+        if (res->len > trailSz) {
             return WH_ERROR_ABORTED;
         }
         WH_DEBUG_CLIENT_VERBOSE("EccMakeKey res: keyid:%u len:%u\n",
@@ -2298,6 +2299,7 @@ static int _EccSharedSecretResponse(whClientContext* ctx, uint8_t* out,
     uint16_t                      group;
     uint16_t                      action;
     uint16_t                      res_len = 0;
+    uint16_t                      trailSz = 0;
     uint8_t*                      dataPtr;
     whMessageCrypto_EcdhResponse* res = NULL;
 
@@ -2316,13 +2318,12 @@ static int _EccSharedSecretResponse(whClientContext* ctx, uint8_t* out,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_ECDH, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_ECDH, res_len, sizeof(*res),
+                             (uint8_t**)&res, &trailSz);
     if (ret >= 0) {
-        uint8_t*     res_out = (uint8_t*)(res + 1);
-        const size_t hdr_sz =
-            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
+        uint8_t* res_out = (uint8_t*)(res + 1);
         /* Defensive bound: res->sz must fit within the actual received frame */
-        if (res_len < hdr_sz || res->sz > (res_len - hdr_sz)) {
+        if (res->sz > trailSz) {
             return WH_ERROR_ABORTED;
         }
         if (out_key_id != NULL) {
@@ -2534,6 +2535,7 @@ int wh_Client_EccSignResponse(whClientContext* ctx, uint8_t* sig,
     uint16_t                         group;
     uint16_t                         action;
     uint16_t                         res_len = 0;
+    uint16_t                         trailSz = 0;
     uint8_t*                         dataPtr;
     whMessageCrypto_EccSignResponse* res = NULL;
 
@@ -2552,13 +2554,12 @@ int wh_Client_EccSignResponse(whClientContext* ctx, uint8_t* sig,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_ECDSA_SIGN, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_ECDSA_SIGN, res_len,
+                             sizeof(*res), (uint8_t**)&res, &trailSz);
     if (ret >= 0) {
-        uint8_t*     res_sig = (uint8_t*)(res + 1);
-        const size_t hdr_sz =
-            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
+        uint8_t* res_sig = (uint8_t*)(res + 1);
         /* Defensive bound: res->sz must fit within the actual received frame */
-        if (res_len < hdr_sz || res->sz > (res_len - hdr_sz)) {
+        if (res->sz > trailSz) {
             return WH_ERROR_ABORTED;
         }
         if (inout_sig_len != NULL) {
@@ -2737,6 +2738,7 @@ int wh_Client_EccVerifyResponse(whClientContext* ctx, ecc_key* opt_key,
     uint16_t                           group;
     uint16_t                           action;
     uint16_t                           res_len = 0;
+    uint16_t                           trailSz = 0;
     uint8_t*                           dataPtr;
     whMessageCrypto_EccVerifyResponse* res = NULL;
 
@@ -2755,13 +2757,12 @@ int wh_Client_EccVerifyResponse(whClientContext* ctx, ecc_key* opt_key,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_ECDSA_VERIFY, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_ECDSA_VERIFY, res_len,
+                             sizeof(*res), (uint8_t**)&res, &trailSz);
     if (ret >= 0) {
-        const size_t hdr_sz =
-            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
         /* Defensive bound: res->pubSz must fit within the actual received
          * frame */
-        if (res_len < hdr_sz || res->pubSz > (res_len - hdr_sz)) {
+        if (res->pubSz > trailSz) {
             return WH_ERROR_ABORTED;
         }
         *out_res = res->res;
@@ -2911,6 +2912,7 @@ static int _EccMakePubResponse(whClientContext* ctx, uint8_t* pubOut,
     uint16_t                            group;
     uint16_t                            action;
     uint16_t                            res_len = 0;
+    uint16_t                            trailSz = 0;
     uint8_t*                            dataPtr;
     whMessageCrypto_EccMakePubResponse* res = NULL;
 
@@ -2925,13 +2927,12 @@ static int _EccMakePubResponse(whClientContext* ctx, uint8_t* pubOut,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_EC_MAKE_PUB, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_EC_MAKE_PUB, res_len,
+                             sizeof(*res), (uint8_t**)&res, &trailSz);
     if (ret >= 0) {
-        const size_t hdr_sz =
-            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
         /* Defensive bound: res->pubSz must fit within the actual received
          * frame */
-        if (res_len < hdr_sz || res->pubSz > (res_len - hdr_sz)) {
+        if (res->pubSz > trailSz) {
             return WH_ERROR_ABORTED;
         }
         if (res->pubSz > (uint32_t)(*inout_pubOutSz)) {
@@ -3062,13 +3063,11 @@ static int _EccCheckPubKeyResponse(whClientContext* ctx)
 
     /* A negative rc here is the verdict on an invalid key rather than a
      * transport failure, and is handed back to wolfCrypt verbatim. */
-    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_EC_CHECK_PUB_KEY,
-                             (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_EC_CHECK_PUB_KEY, res_len,
+                             sizeof(*res), (uint8_t**)&res, NULL);
     if (ret >= 0) {
-        const size_t hdr_sz =
-            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
         /* A success rc must be accompanied by an affirmative body */
-        if ((res_len < hdr_sz) || (res->ok == 0)) {
+        if (res->ok == 0) {
             return WH_ERROR_ABORTED;
         }
     }
@@ -3296,6 +3295,7 @@ static int _Curve25519MakeKey(whClientContext* ctx, uint16_t size,
     uint16_t                                  group  = WH_MESSAGE_GROUP_CRYPTO;
     uint16_t                                  action = WC_ALGO_TYPE_PK;
     uint16_t                                  data_len = 0;
+    uint16_t                                  trailSz  = 0;
     whMessageCrypto_Curve25519KeyGenRequest*  req      = NULL;
     whMessageCrypto_Curve25519KeyGenResponse* res      = NULL;
     uint8_t*                                  dataPtr  = NULL;
@@ -3348,8 +3348,9 @@ static int _Curve25519MakeKey(whClientContext* ctx, uint16_t size,
 
     if (ret == 0) {
         /* Get response structure pointer, validates generic header */
-        ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_CURVE25519_KEYGEN,
-                                 (uint8_t**)&res);
+        ret =
+            _getCryptoResponse(dataPtr, WC_PK_TYPE_CURVE25519_KEYGEN, data_len,
+                               sizeof(*res), (uint8_t**)&res, &trailSz);
         /* wolfCrypt allows positive error codes on success in some scenarios */
         if (ret >= 0) {
             WH_DEBUG_CLIENT_VERBOSE("Curve25519 KeyGen Res recv:keyid:%u, len:%u, "
@@ -3367,9 +3368,6 @@ static int _Curve25519MakeKey(whClientContext* ctx, uint16_t size,
             if (key != NULL) {
                 uint16_t     der_size = (uint16_t)(res->len);
                 uint8_t*     key_der  = (uint8_t*)(res + 1);
-                const size_t hdr_sz =
-                    sizeof(whMessageCrypto_GenericResponseHeader) +
-                    sizeof(*res);
                 /* Set the key_id.  ERASED for EPHEMERAL, cached id otherwise. */
                 wh_Client_Curve25519SetKeyId(key, key_id);
 
@@ -3380,8 +3378,7 @@ static int _Curve25519MakeKey(whClientContext* ctx, uint16_t size,
                 if (der_size == 0) {
                     ret = WH_ERROR_ABORTED;
                 }
-                else if ((data_len < hdr_sz) ||
-                         (res->len > (data_len - hdr_sz))) {
+                else if (res->len > trailSz) {
                     ret = WH_ERROR_ABORTED;
                 }
                 else {
@@ -3526,6 +3523,7 @@ static int _Curve25519SharedSecretResponse(whClientContext* ctx, uint8_t* out,
     uint16_t                            group;
     uint16_t                            action;
     uint16_t                            res_len = 0;
+    uint16_t                            trailSz = 0;
     uint8_t*                            dataPtr;
     whMessageCrypto_Curve25519Response* res = NULL;
 
@@ -3544,12 +3542,11 @@ static int _Curve25519SharedSecretResponse(whClientContext* ctx, uint8_t* out,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_CURVE25519, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_CURVE25519, res_len,
+                             sizeof(*res), (uint8_t**)&res, &trailSz);
     if (ret >= 0) {
         uint8_t*     res_out = (uint8_t*)(res + 1);
-        const size_t hdr_sz =
-            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
-        if (res_len < hdr_sz || res->sz > (res_len - hdr_sz)) {
+        if (res->sz > trailSz) {
             return WH_ERROR_ABORTED;
         }
         if (out_key_id != NULL) {
@@ -3855,6 +3852,7 @@ static int _Ed25519MakeKey(whClientContext* ctx, whKeyId* inout_key_id,
         return ret;
     }
     uint16_t res_len = 0;
+    uint16_t trailSz = 0;
     do {
         ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
                                      WOLFHSM_CFG_COMM_DATA_LEN,
@@ -3869,14 +3867,12 @@ static int _Ed25519MakeKey(whClientContext* ctx, whKeyId* inout_key_id,
         return WH_ERROR_ABORTED;
     }
 
-    ret =
-        _getCryptoResponse(dataPtr, WC_PK_TYPE_ED25519_KEYGEN, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_ED25519_KEYGEN, res_len,
+                             sizeof(*res), (uint8_t**)&res, &trailSz);
     if (ret >= 0) {
-        const size_t hdr_sz =
-            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
 
         /* Defensive bound: res->outSz must fit within the received frame */
-        if (res_len < hdr_sz || res->outSz > (res_len - hdr_sz)) {
+        if (res->outSz > trailSz) {
             return WH_ERROR_ABORTED;
         }
 
@@ -4055,6 +4051,7 @@ int wh_Client_Ed25519Sign(whClientContext* ctx, ed25519_key* key,
             evict = 0;
 
             uint16_t res_len = 0;
+            uint16_t trailSz = 0;
             do {
                 ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
                                              WOLFHSM_CFG_COMM_DATA_LEN,
@@ -4067,12 +4064,10 @@ int wh_Client_Ed25519Sign(whClientContext* ctx, ed25519_key* key,
 
             if (ret == WH_ERROR_OK) {
                 ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_ED25519_SIGN,
-                                         (uint8_t**)&res);
+                                         res_len, sizeof(*res), (uint8_t**)&res,
+                                         &trailSz);
                 if (ret >= 0) {
-                    const uint32_t hdr_sz =
-                        sizeof(whMessageCrypto_GenericResponseHeader) +
-                        sizeof(*res);
-                    if (res_len < hdr_sz || res->sigSz > (res_len - hdr_sz)) {
+                    if (res->sigSz > trailSz) {
                         ret = WH_ERROR_ABORTED;
                     }
                 }
@@ -4208,19 +4203,10 @@ int wh_Client_Ed25519Verify(whClientContext* ctx, ed25519_key* key,
 
             if (ret == WH_ERROR_OK) {
                 ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_ED25519_VERIFY,
-                                         (uint8_t**)&res);
+                                         res_len, sizeof(*res), (uint8_t**)&res,
+                                         NULL);
                 if (ret >= 0) {
-                    const uint32_t hdr_sz =
-                        sizeof(whMessageCrypto_GenericResponseHeader) +
-                        sizeof(*res);
-                    /* Note whMessageCrypto_Ed25519VerifyResponse has no
-                     * size field */
-                    if (res_len < hdr_sz) {
-                        ret = WH_ERROR_ABORTED;
-                    }
-                    else {
-                        *out_res = res->res;
-                    }
+                    *out_res = res->res;
                 }
             }
         }
@@ -4350,17 +4336,12 @@ int wh_Client_Ed25519SignDma(whClientContext* ctx, ed25519_key* key,
 
             if (ret == WH_ERROR_OK) {
                 ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_ED25519_SIGN,
-                                         (uint8_t**)&res);
+                                         res_len, sizeof(*res), (uint8_t**)&res,
+                                         NULL);
                 if (ret >= 0) {
-                    const uint32_t hdr_sz =
-                        sizeof(whMessageCrypto_GenericResponseHeader) +
-                        sizeof(*res);
                     /* DMA mode: signature was written to the caller's
                      * buffer; only sigSz is returned inline */
-                    if (res_len < hdr_sz) {
-                        ret = WH_ERROR_ABORTED;
-                    }
-                    else if (inout_sig_len != NULL) {
+                    if (inout_sig_len != NULL) {
                         *inout_sig_len = res->sigSz;
                     }
                 }
@@ -4498,19 +4479,10 @@ int wh_Client_Ed25519VerifyDma(whClientContext* ctx, ed25519_key* key,
 
             if (ret == WH_ERROR_OK) {
                 ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_ED25519_VERIFY,
-                                         (uint8_t**)&res);
+                                         res_len, sizeof(*res), (uint8_t**)&res,
+                                         NULL);
                 if (ret >= 0) {
-                    const uint32_t hdr_sz =
-                        sizeof(whMessageCrypto_GenericResponseHeader) +
-                        sizeof(*res);
-                    /* Note whMessageCrypto_Ed25519VerifyDmaResponse has no
-                     * size field */
-                    if (res_len < hdr_sz) {
-                        ret = WH_ERROR_ABORTED;
-                    }
-                    else {
-                        *out_res = res->verifyResult;
-                    }
+                    *out_res = res->verifyResult;
                 }
             }
         }
@@ -4701,6 +4673,7 @@ static int _RsaMakeKeyResponse(whClientContext* ctx, whKeyId* out_key_id,
     uint16_t                           group;
     uint16_t                           action;
     uint16_t                           res_len = 0;
+    uint16_t                           trailSz = 0;
     uint8_t*                           dataPtr = NULL;
     whMessageCrypto_RsaKeyGenResponse* res     = NULL;
 
@@ -4719,14 +4692,13 @@ static int _RsaMakeKeyResponse(whClientContext* ctx, whKeyId* out_key_id,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_RSA_KEYGEN, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_RSA_KEYGEN, res_len,
+                             sizeof(*res), (uint8_t**)&res, &trailSz);
     /* wolfCrypt allows positive return codes on success */
     if (ret >= 0) {
-        const size_t hdr_sz =
-            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
         whKeyId key_id;
 
-        if (res_len < hdr_sz || res->len > (res_len - hdr_sz)) {
+        if (res->len > trailSz) {
             return WH_ERROR_ABORTED;
         }
 
@@ -4934,6 +4906,7 @@ int wh_Client_RsaFunctionResponse(whClientContext* ctx, uint8_t* out,
     uint16_t                     group;
     uint16_t                     action;
     uint16_t                     res_len = 0;
+    uint16_t                     trailSz = 0;
     uint8_t*                     dataPtr;
     whMessageCrypto_RsaResponse* res = NULL;
 
@@ -4952,13 +4925,12 @@ int wh_Client_RsaFunctionResponse(whClientContext* ctx, uint8_t* out,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_RSA, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_RSA, res_len, sizeof(*res),
+                             (uint8_t**)&res, &trailSz);
     if (ret >= 0) {
-        const size_t hdr_sz =
-            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
         uint8_t* res_out;
 
-        if (res_len < hdr_sz || res->outLen > (res_len - hdr_sz)) {
+        if (res->outLen > trailSz) {
             return WH_ERROR_ABORTED;
         }
 
@@ -5148,13 +5120,9 @@ int wh_Client_RsaGetSizeResponse(whClientContext* ctx, int* out_size)
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_RSA_GET_SIZE, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_RSA_GET_SIZE, res_len,
+                             sizeof(*res), (uint8_t**)&res, NULL);
     if (ret >= 0) {
-        const size_t hdr_sz =
-            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
-        if (res_len < hdr_sz) {
-            return WH_ERROR_ABORTED;
-        }
         *out_size = (int)res->keySize;
     }
     return ret;
@@ -5338,6 +5306,7 @@ static int _HkdfMakeKey(whClientContext* ctx, int hashType, whKeyId keyIdIn,
 
     if (ret == 0) {
         uint16_t res_len = 0;
+        uint16_t trailSz = 0;
         do {
             ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
                                          WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
@@ -5348,16 +5317,14 @@ static int _HkdfMakeKey(whClientContext* ctx, int hashType, whKeyId keyIdIn,
 
         if (ret == WH_ERROR_OK) {
             /* Get response structure pointer, validates generic header rc */
-            ret =
-                _getCryptoResponse(dataPtr, WC_ALGO_TYPE_KDF, (uint8_t**)&res);
+            ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_KDF, res_len,
+                                     sizeof(*res), (uint8_t**)&res, &trailSz);
         }
 
         if (ret == WH_ERROR_OK) {
-            const size_t hdr_sz =
-                sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
             /* Defensive bound: res->outSz must fit within the actual received
              * frame */
-            if (res_len < hdr_sz || res->outSz > (res_len - hdr_sz)) {
+            if (res->outSz > trailSz) {
                 return WH_ERROR_ABORTED;
             }
 
@@ -5514,21 +5481,21 @@ static int _CmacKdfMakeKey(whClientContext* ctx, whKeyId saltKeyId,
     }
 
     uint16_t res_len = 0;
+    uint16_t trailSz = 0;
     do {
         ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
                                      WOLFHSM_CFG_COMM_DATA_LEN, dataPtr);
     } while (ret == WH_ERROR_NOTREADY);
 
     if (ret == WH_ERROR_OK) {
-        ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_KDF, (uint8_t**)&res);
+        ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_KDF, res_len,
+                                 sizeof(*res), (uint8_t**)&res, &trailSz);
     }
 
     if (ret == WH_ERROR_OK) {
-        const size_t hdr_sz =
-            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
         /* Defensive bound: res->outSz must fit within the actual received
          * frame */
-        if (res_len < hdr_sz || res->outSz > (res_len - hdr_sz)) {
+        if (res->outSz > trailSz) {
             return WH_ERROR_ABORTED;
         }
 
@@ -5741,6 +5708,7 @@ int wh_Client_CmacGenerateResponse(whClientContext* ctx, Cmac* cmac,
     uint16_t                         group;
     uint16_t                         action;
     uint16_t                         res_len = 0;
+    uint16_t                         trailSz = 0;
     int                              ret;
 
     if (ctx == NULL || cmac == NULL || outMac == NULL || outMacLen == NULL) {
@@ -5758,13 +5726,12 @@ int wh_Client_CmacGenerateResponse(whClientContext* ctx, Cmac* cmac,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, res_len, sizeof(*res),
+                             (uint8_t**)&res, &trailSz);
     /* wolfCrypt allows positive error codes on success */
     if (ret >= 0) {
-        const uint32_t hdr_sz =
-            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
         /* The MAC bytes the response claims must be in the received frame */
-        if (res_len < hdr_sz || res->outSz > (res_len - hdr_sz)) {
+        if (res->outSz > trailSz) {
             ret = WH_ERROR_ABORTED;
         }
         if (ret >= 0) {
@@ -5888,19 +5855,13 @@ int wh_Client_CmacUpdateResponse(whClientContext* ctx, Cmac* cmac)
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, res_len, sizeof(*res),
+                             (uint8_t**)&res, NULL);
     if (ret >= 0) {
-        /* No trailing payload on update, but the state must be in the frame */
-        if (res_len < sizeof(whMessageCrypto_GenericResponseHeader) +
-                          sizeof(*res)) {
-            ret = WH_ERROR_ABORTED;
-        }
-        if (ret >= 0) {
-            /* Restore full state from server. The server may leave a partial
-             * (or whole) block in its buffer after wc_CmacUpdate (CMAC's last
-             * block has special handling), so we round-trip the whole state. */
-            ret = wh_Crypto_CmacAesRestoreStateFromMsg(cmac, &res->resumeState);
-        }
+        /* Restore full state from server. The server may leave a partial
+         * (or whole) block in its buffer after wc_CmacUpdate (CMAC's last
+         * block has special handling), so we round-trip the whole state. */
+        ret = wh_Crypto_CmacAesRestoreStateFromMsg(cmac, &res->resumeState);
     }
     return ret;
 }
@@ -5969,6 +5930,7 @@ int wh_Client_CmacFinalResponse(whClientContext* ctx, Cmac* cmac,
     uint16_t                         group;
     uint16_t                         action;
     uint16_t                         res_len = 0;
+    uint16_t                         trailSz = 0;
     int                              ret;
 
     if (ctx == NULL || cmac == NULL || outMac == NULL || outMacLen == NULL) {
@@ -5986,12 +5948,11 @@ int wh_Client_CmacFinalResponse(whClientContext* ctx, Cmac* cmac,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, res_len, sizeof(*res),
+                             (uint8_t**)&res, &trailSz);
     if (ret >= 0) {
-        const uint32_t hdr_sz =
-            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
         /* The MAC bytes the response claims must be in the received frame */
-        if (res_len < hdr_sz || res->outSz > (res_len - hdr_sz)) {
+        if (res->outSz > trailSz) {
             ret = WH_ERROR_ABORTED;
         }
         if (ret >= 0) {
@@ -6217,7 +6178,8 @@ int wh_Client_CmacGenerateDmaResponse(whClientContext* ctx, Cmac* cmac,
 {
     whMessageCrypto_CmacAesDmaResponse* res = NULL;
     uint8_t*                            dataPtr;
-    uint16_t                            respSz = 0;
+    uint16_t                            respSz  = 0;
+    uint16_t                            trailSz = 0;
     int                                 ret;
 
     if (ctx == NULL || cmac == NULL || outMac == NULL || outMacLen == NULL) {
@@ -6236,14 +6198,13 @@ int wh_Client_CmacGenerateDmaResponse(whClientContext* ctx, Cmac* cmac,
     }
 
     if (ret == WH_ERROR_OK) {
-        ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, (uint8_t**)&res);
+        ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, respSz,
+                                 sizeof(*res), (uint8_t**)&res, &trailSz);
         if (ret >= 0) {
-            const uint32_t hdr_sz =
-                sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
             /* The MAC bytes the response claims must be in the received
              * frame. A failed server request replies with the generic header
              * only, so this bound stays inside the success branch. */
-            if (respSz < hdr_sz || res->outSz > (respSz - hdr_sz)) {
+            if (res->outSz > trailSz) {
                 ret = WH_ERROR_ABORTED;
             }
             if (ret >= 0) {
@@ -6393,20 +6354,12 @@ int wh_Client_CmacDmaUpdateResponse(whClientContext* ctx, Cmac* cmac)
     }
 
     if (ret == WH_ERROR_OK) {
-        ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, (uint8_t**)&res);
+        ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, respSz,
+                                 sizeof(*res), (uint8_t**)&res, NULL);
         if (ret >= 0) {
-            /* No trailing payload on update, but the state must be in the
-             * frame */
-            if (respSz < sizeof(whMessageCrypto_GenericResponseHeader) +
-                             sizeof(*res)) {
-                ret = WH_ERROR_ABORTED;
-            }
-            if (ret >= 0) {
-                /* Restore full state from server (includes any partial/whole
-                 * block left in the server's wc_CmacUpdate buffer). */
-                ret = wh_Crypto_CmacAesRestoreStateFromMsg(cmac,
-                                                           &res->resumeState);
-            }
+            /* Restore full state from server (includes any partial/whole
+             * block left in the server's wc_CmacUpdate buffer). */
+            ret = wh_Crypto_CmacAesRestoreStateFromMsg(cmac, &res->resumeState);
         }
     }
 
@@ -6474,7 +6427,8 @@ int wh_Client_CmacDmaFinalResponse(whClientContext* ctx, Cmac* cmac,
 {
     whMessageCrypto_CmacAesDmaResponse* res = NULL;
     uint8_t*                            dataPtr;
-    uint16_t                            respSz = 0;
+    uint16_t                            respSz  = 0;
+    uint16_t                            trailSz = 0;
     int                                 ret;
 
     if (ctx == NULL || cmac == NULL || outMac == NULL || outMacLen == NULL) {
@@ -6492,12 +6446,11 @@ int wh_Client_CmacDmaFinalResponse(whClientContext* ctx, Cmac* cmac,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_ALGO_TYPE_CMAC, respSz, sizeof(*res),
+                             (uint8_t**)&res, &trailSz);
     if (ret >= 0) {
-        const uint32_t hdr_sz =
-            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
         /* The MAC bytes the response claims must be in the received frame */
-        if (respSz < hdr_sz || res->outSz > (respSz - hdr_sz)) {
+        if (res->outSz > trailSz) {
             ret = WH_ERROR_ABORTED;
         }
         if (ret >= 0) {
@@ -6744,12 +6697,9 @@ int wh_Client_Sha256UpdateResponse(whClientContext* ctx, wc_Sha256* sha)
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA256, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA256, dataSz, sizeof(*res),
+                             (uint8_t**)&res, NULL);
     if (ret >= 0) {
-        if (dataSz < sizeof(whMessageCrypto_GenericResponseHeader) +
-                         sizeof(*res)) {
-            return WH_ERROR_ABORTED;
-        }
         if (res->hashType != WC_HASH_TYPE_SHA256) {
             return WH_ERROR_ABORTED;
         }
@@ -6825,12 +6775,9 @@ int wh_Client_Sha256FinalResponse(whClientContext* ctx, wc_Sha256* sha,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA256, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA256, dataSz, sizeof(*res),
+                             (uint8_t**)&res, NULL);
     if (ret >= 0) {
-        if (dataSz < sizeof(whMessageCrypto_GenericResponseHeader) +
-                         sizeof(*res)) {
-            return WH_ERROR_ABORTED;
-        }
         if (res->hashType != WC_HASH_TYPE_SHA256) {
             return WH_ERROR_ABORTED;
         }
@@ -7045,14 +6992,10 @@ int wh_Client_Sha256DmaUpdateResponse(whClientContext* ctx, wc_Sha256* sha)
     }
 
     if (ret == WH_ERROR_OK) {
-        ret =
-            _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA256, (uint8_t**)&resp);
+        ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA256, respSz,
+                                 sizeof(*resp), (uint8_t**)&resp, NULL);
         if (ret >= 0) {
-            if (respSz < sizeof(whMessageCrypto_GenericResponseHeader) +
-                             sizeof(*resp)) {
-                ret = WH_ERROR_ABORTED;
-            }
-            else if (resp->hashType != WC_HASH_TYPE_SHA256) {
+            if (resp->hashType != WC_HASH_TYPE_SHA256) {
                 ret = WH_ERROR_ABORTED;
             }
             else {
@@ -7150,13 +7093,9 @@ int wh_Client_Sha256DmaFinalResponse(whClientContext* ctx, wc_Sha256* sha,
     }
 
     if (ret == WH_ERROR_OK) {
-        ret =
-            _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA256, (uint8_t**)&resp);
+        ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA256, respSz,
+                                 sizeof(*resp), (uint8_t**)&resp, NULL);
         if (ret >= 0) {
-            if (respSz < sizeof(whMessageCrypto_GenericResponseHeader) +
-                             sizeof(*resp)) {
-                return WH_ERROR_ABORTED;
-            }
             if (resp->hashType != WC_HASH_TYPE_SHA256) {
                 return WH_ERROR_ABORTED;
             }
@@ -7345,12 +7284,9 @@ int wh_Client_Sha224UpdateResponse(whClientContext* ctx, wc_Sha224* sha)
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA224, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA224, dataSz, sizeof(*res),
+                             (uint8_t**)&res, NULL);
     if (ret >= 0) {
-        if (dataSz < sizeof(whMessageCrypto_GenericResponseHeader) +
-                         sizeof(*res)) {
-            return WH_ERROR_ABORTED;
-        }
         if (res->hashType != WC_HASH_TYPE_SHA224) {
             return WH_ERROR_ABORTED;
         }
@@ -7427,12 +7363,9 @@ int wh_Client_Sha224FinalResponse(whClientContext* ctx, wc_Sha224* sha,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA224, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA224, dataSz, sizeof(*res),
+                             (uint8_t**)&res, NULL);
     if (ret >= 0) {
-        if (dataSz < sizeof(whMessageCrypto_GenericResponseHeader) +
-                         sizeof(*res)) {
-            return WH_ERROR_ABORTED;
-        }
         if (res->hashType != WC_HASH_TYPE_SHA224) {
             return WH_ERROR_ABORTED;
         }
@@ -7635,14 +7568,10 @@ int wh_Client_Sha224DmaUpdateResponse(whClientContext* ctx, wc_Sha224* sha)
     }
 
     if (ret == WH_ERROR_OK) {
-        ret =
-            _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA224, (uint8_t**)&resp);
+        ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA224, respSz,
+                                 sizeof(*resp), (uint8_t**)&resp, NULL);
         if (ret >= 0) {
-            if (respSz < sizeof(whMessageCrypto_GenericResponseHeader) +
-                             sizeof(*resp)) {
-                ret = WH_ERROR_ABORTED;
-            }
-            else if (resp->hashType != WC_HASH_TYPE_SHA224) {
+            if (resp->hashType != WC_HASH_TYPE_SHA224) {
                 ret = WH_ERROR_ABORTED;
             }
             else {
@@ -7736,13 +7665,9 @@ int wh_Client_Sha224DmaFinalResponse(whClientContext* ctx, wc_Sha224* sha,
     }
 
     if (ret == WH_ERROR_OK) {
-        ret =
-            _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA224, (uint8_t**)&resp);
+        ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA224, respSz,
+                                 sizeof(*resp), (uint8_t**)&resp, NULL);
         if (ret >= 0) {
-            if (respSz < sizeof(whMessageCrypto_GenericResponseHeader) +
-                             sizeof(*resp)) {
-                return WH_ERROR_ABORTED;
-            }
             if (resp->hashType != WC_HASH_TYPE_SHA224) {
                 return WH_ERROR_ABORTED;
             }
@@ -7931,12 +7856,9 @@ int wh_Client_Sha384UpdateResponse(whClientContext* ctx, wc_Sha384* sha)
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA384, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA384, dataSz, sizeof(*res),
+                             (uint8_t**)&res, NULL);
     if (ret >= 0) {
-        if (dataSz < sizeof(whMessageCrypto_GenericResponseHeader) +
-                         sizeof(*res)) {
-            return WH_ERROR_ABORTED;
-        }
         if (res->hashType != WC_HASH_TYPE_SHA384) {
             return WH_ERROR_ABORTED;
         }
@@ -8014,12 +7936,9 @@ int wh_Client_Sha384FinalResponse(whClientContext* ctx, wc_Sha384* sha,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA384, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA384, dataSz, sizeof(*res),
+                             (uint8_t**)&res, NULL);
     if (ret >= 0) {
-        if (dataSz < sizeof(whMessageCrypto_GenericResponseHeader) +
-                         sizeof(*res)) {
-            return WH_ERROR_ABORTED;
-        }
         if (res->hashType != WC_HASH_TYPE_SHA384) {
             return WH_ERROR_ABORTED;
         }
@@ -8223,14 +8142,10 @@ int wh_Client_Sha384DmaUpdateResponse(whClientContext* ctx, wc_Sha384* sha)
     }
 
     if (ret == WH_ERROR_OK) {
-        ret =
-            _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA384, (uint8_t**)&resp);
+        ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA384, respSz,
+                                 sizeof(*resp), (uint8_t**)&resp, NULL);
         if (ret >= 0) {
-            if (respSz < sizeof(whMessageCrypto_GenericResponseHeader) +
-                             sizeof(*resp)) {
-                ret = WH_ERROR_ABORTED;
-            }
-            else if (resp->hashType != WC_HASH_TYPE_SHA384) {
+            if (resp->hashType != WC_HASH_TYPE_SHA384) {
                 ret = WH_ERROR_ABORTED;
             }
             else {
@@ -8325,13 +8240,9 @@ int wh_Client_Sha384DmaFinalResponse(whClientContext* ctx, wc_Sha384* sha,
     }
 
     if (ret == WH_ERROR_OK) {
-        ret =
-            _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA384, (uint8_t**)&resp);
+        ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA384, respSz,
+                                 sizeof(*resp), (uint8_t**)&resp, NULL);
         if (ret >= 0) {
-            if (respSz < sizeof(whMessageCrypto_GenericResponseHeader) +
-                             sizeof(*resp)) {
-                return WH_ERROR_ABORTED;
-            }
             if (resp->hashType != WC_HASH_TYPE_SHA384) {
                 return WH_ERROR_ABORTED;
             }
@@ -8519,12 +8430,9 @@ int wh_Client_Sha512UpdateResponse(whClientContext* ctx, wc_Sha512* sha)
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA512, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA512, dataSz, sizeof(*res),
+                             (uint8_t**)&res, NULL);
     if (ret >= 0) {
-        if (dataSz < sizeof(whMessageCrypto_GenericResponseHeader) +
-                         sizeof(*res)) {
-            return WH_ERROR_ABORTED;
-        }
         /* Family check, not variant match: SHA-512/t shares block size and
          * compression with SHA-512, and the client supplies the variant IV
          * in resumeState.hash — so a server missing SHA-512/t support still
@@ -8608,12 +8516,9 @@ int wh_Client_Sha512FinalResponse(whClientContext* ctx, wc_Sha512* sha,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA512, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA512, dataSz, sizeof(*res),
+                             (uint8_t**)&res, NULL);
     if (ret >= 0) {
-        if (dataSz < sizeof(whMessageCrypto_GenericResponseHeader) +
-                         sizeof(*res)) {
-            return WH_ERROR_ABORTED;
-        }
         /* keep hashtype before initialization */
         hashType = sha->hashType;
         /* Family check, not variant match: SHA-512/t shares block size and
@@ -8840,20 +8745,16 @@ int wh_Client_Sha512DmaUpdateResponse(whClientContext* ctx, wc_Sha512* sha)
     }
 
     if (ret == WH_ERROR_OK) {
-        ret =
-            _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA512, (uint8_t**)&resp);
+        ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA512, respSz,
+                                 sizeof(*resp), (uint8_t**)&resp, NULL);
         if (ret >= 0) {
-            if (respSz < sizeof(whMessageCrypto_GenericResponseHeader) +
-                             sizeof(*resp)) {
-                ret = WH_ERROR_ABORTED;
-            }
             /* Family check, not variant match: SHA-512/t shares block size and
              * compression with SHA-512, and the client supplies the variant IV
              * in resumeState.hash — so a server missing SHA-512/t support still
              * returns a correct intermediate state. */
-            else if (resp->hashType != WC_HASH_TYPE_SHA512 &&
-                     resp->hashType != WC_HASH_TYPE_SHA512_224 &&
-                     resp->hashType != WC_HASH_TYPE_SHA512_256) {
+            if (resp->hashType != WC_HASH_TYPE_SHA512 &&
+                resp->hashType != WC_HASH_TYPE_SHA512_224 &&
+                resp->hashType != WC_HASH_TYPE_SHA512_256) {
                 ret = WH_ERROR_ABORTED;
             }
             else {
@@ -8948,13 +8849,9 @@ int wh_Client_Sha512DmaFinalResponse(whClientContext* ctx, wc_Sha512* sha,
     }
 
     if (ret == WH_ERROR_OK) {
-        ret =
-            _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA512, (uint8_t**)&resp);
+        ret = _getCryptoResponse(dataPtr, WC_HASH_TYPE_SHA512, respSz,
+                                 sizeof(*resp), (uint8_t**)&resp, NULL);
         if (ret >= 0) {
-            if (respSz < sizeof(whMessageCrypto_GenericResponseHeader) +
-                             sizeof(*resp)) {
-                return WH_ERROR_ABORTED;
-            }
             /* keep hashtype before initialization */
             hashType = sha->hashType;
             /* Family check, not variant match: SHA-512/t shares block size and
@@ -9206,12 +9103,9 @@ static int _Sha3UpdateResponse(whClientContext* ctx, wc_Sha3* sha,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, v->hashType, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, v->hashType, dataSz, sizeof(*res),
+                             (uint8_t**)&res, NULL);
     if (ret >= 0) {
-        if (dataSz <
-            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res)) {
-            return WH_ERROR_ABORTED;
-        }
         memcpy(sha->s, res->resumeState.s, sizeof(sha->s));
     }
     return ret;
@@ -9286,12 +9180,9 @@ static int _Sha3FinalResponse(whClientContext* ctx, wc_Sha3* sha,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, v->hashType, (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, v->hashType, dataSz, sizeof(*res),
+                             (uint8_t**)&res, NULL);
     if (ret >= 0) {
-        if (dataSz <
-            sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res)) {
-            return WH_ERROR_ABORTED;
-        }
         memcpy(out, res->hash, v->digestSize);
         /* Reset state, preserving heap and devId. */
         savedHeap  = sha->heap;
@@ -9661,15 +9552,10 @@ static int _Sha3DmaUpdateResponse(whClientContext* ctx, wc_Sha3* sha,
     }
 
     if (ret == WH_ERROR_OK) {
-        ret = _getCryptoResponse(dataPtr, v->hashType, (uint8_t**)&resp);
+        ret = _getCryptoResponse(dataPtr, v->hashType, respSz, sizeof(*resp),
+                                 (uint8_t**)&resp, NULL);
         if (ret >= 0) {
-            if (respSz <
-                sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*resp)) {
-                ret = WH_ERROR_ABORTED;
-            }
-            else {
-                memcpy(sha->s, resp->resumeState.s, sizeof(sha->s));
-            }
+            memcpy(sha->s, resp->resumeState.s, sizeof(sha->s));
         }
     }
 
@@ -9758,12 +9644,9 @@ static int _Sha3DmaFinalResponse(whClientContext* ctx, wc_Sha3* sha,
     }
 
     if (ret == WH_ERROR_OK) {
-        ret = _getCryptoResponse(dataPtr, v->hashType, (uint8_t**)&resp);
+        ret = _getCryptoResponse(dataPtr, v->hashType, respSz, sizeof(*resp),
+                                 (uint8_t**)&resp, NULL);
         if (ret >= 0) {
-            if (respSz <
-                sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*resp)) {
-                return WH_ERROR_ABORTED;
-            }
             memcpy(out, resp->hash, v->digestSize);
             savedHeap  = sha->heap;
             savedDevId = sha->devId;
@@ -10110,6 +9993,7 @@ static int _MlDsaMakeKey(whClientContext* ctx, int size, int level,
                    (unsigned int)req->sz, ret);
             if (ret == 0) {
                 uint16_t res_len;
+                uint16_t trailSz = 0;
                 do {
                     ret = wh_Client_RecvResponse(ctx, &group, &action, &res_len,
                                                  WOLFHSM_CFG_COMM_DATA_LEN,
@@ -10120,7 +10004,8 @@ static int _MlDsaMakeKey(whClientContext* ctx, int size, int level,
                     /* Get response structure pointer, validates generic header
                      * rc */
                     ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_SIG_KEYGEN,
-                                             (uint8_t**)&res);
+                                             res_len, sizeof(*res),
+                                             (uint8_t**)&res, &trailSz);
                     /* wolfCrypt allows positive error codes on success in some
                      * scenarios */
                     if (ret >= 0) {
@@ -10138,10 +10023,7 @@ static int _MlDsaMakeKey(whClientContext* ctx, int size, int level,
 
                         /* Update the context if provided */
                         if (key != NULL) {
-                            uint16_t     der_size = (uint16_t)(res->len);
-                            const size_t hdr_sz =
-                                sizeof(whMessageCrypto_GenericResponseHeader) +
-                                sizeof(*res);
+                            uint16_t der_size = (uint16_t)(res->len);
                             /* Set the key_id. ERASED for EPHEMERAL, cached id
                              * otherwise. */
                             wh_Client_MlDsaSetKeyId(key, key_id);
@@ -10154,8 +10036,7 @@ static int _MlDsaMakeKey(whClientContext* ctx, int size, int level,
                             if (der_size == 0) {
                                 ret = WH_ERROR_ABORTED;
                             }
-                            else if ((res_len < hdr_sz) ||
-                                     (res->len > (res_len - hdr_sz))) {
+                            else if (res->len > trailSz) {
                                 ret = WH_ERROR_ABORTED;
                             }
                             else {
@@ -10340,6 +10221,7 @@ int wh_Client_MlDsaSign(whClientContext* ctx, const byte* in, word32 in_len,
 
                 /* Response Message */
                 uint16_t res_len = 0;
+                uint16_t trailSz = 0;
 
                 /* Recv Response */
                 do {
@@ -10352,15 +10234,12 @@ int wh_Client_MlDsaSign(whClientContext* ctx, const byte* in, word32 in_len,
                     /* Get response structure pointer, validates generic header
                      * rc */
                     ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_SIG_SIGN,
-                                             (uint8_t**)&res);
+                                             res_len, sizeof(*res),
+                                             (uint8_t**)&res, &trailSz);
                     /* wolfCrypt allows positive error codes on success in some
                      * scenarios */
                     if (ret >= 0) {
-                        const uint32_t hdr_sz =
-                            sizeof(whMessageCrypto_GenericResponseHeader) +
-                            sizeof(*res);
-                        if (res_len < hdr_sz ||
-                            res->sz > (res_len - hdr_sz)) {
+                        if (res->sz > trailSz) {
                             ret = WH_ERROR_ABORTED;
                         }
                         else {
@@ -10499,21 +10378,12 @@ int wh_Client_MlDsaVerify(whClientContext* ctx, const byte* sig, word32 sig_len,
                     /* Get response structure pointer, validates generic header
                      * rc */
                     ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_SIG_VERIFY,
-                                             (uint8_t**)&res);
+                                             res_len, sizeof(*res),
+                                             (uint8_t**)&res, NULL);
                     /* wolfCrypt allows positive error codes on success in some
                      * scenarios */
                     if (ret >= 0) {
-                        const uint32_t hdr_sz =
-                            sizeof(whMessageCrypto_GenericResponseHeader) +
-                            sizeof(*res);
-                        /* Note whMessageCrypto_MlDsaVerifyResponse has no
-                         * size field */
-                        if (res_len < hdr_sz) {
-                            ret = WH_ERROR_ABORTED;
-                        }
-                        else {
-                            *out_res = res->res;
-                        }
+                        *out_res = res->res;
                     }
                 }
             }
@@ -10705,20 +10575,11 @@ static int _MlDsaMakeKeyDma(whClientContext* ctx, int level,
         if (ret == WH_ERROR_OK) {
             /* Get response structure pointer, validates generic header
              * rc */
-            ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_SIG_KEYGEN,
-                                     (uint8_t**)&res);
+            ret =
+                _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_SIG_KEYGEN, res_len,
+                                   sizeof(*res), (uint8_t**)&res, NULL);
             /* wolfCrypt allows positive error codes on success in some
              * scenarios */
-            if (ret >= 0) {
-                const uint32_t hdr_sz =
-                    sizeof(whMessageCrypto_GenericResponseHeader) +
-                    sizeof(*res);
-                /* Note whMessageCrypto_MlDsaKeyGenDmaResponse has no
-                 * trailing payload; keySize bounds the DMA buffer write */
-                if (res_len < hdr_sz) {
-                    ret = WH_ERROR_ABORTED;
-                }
-            }
             if (ret >= 0) {
                 /* Key is cached on server or is ephemeral */
                 key_id = (whKeyId)(res->keyId);
@@ -10941,17 +10802,12 @@ int wh_Client_MlDsaSignDma(whClientContext* ctx, const byte* in, word32 in_len,
                     /* Get response structure pointer, validates generic header
                      * rc */
                     ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_SIG_SIGN,
-                                             (uint8_t**)&res);
+                                             res_len, sizeof(*res),
+                                             (uint8_t**)&res, NULL);
                     /* wolfCrypt allows positive error codes on success in some
                      * scenarios */
                     if (ret >= 0) {
-                        const uint32_t hdr_sz =
-                            sizeof(whMessageCrypto_GenericResponseHeader) +
-                            sizeof(*res);
-                        if (res_len < hdr_sz) {
-                            ret = WH_ERROR_ABORTED;
-                        }
-                        else if (res->sigLen > sigCap) {
+                        if (res->sigLen > sigCap) {
                             ret = WH_ERROR_BADARGS;
                         }
                         else {
@@ -11096,22 +10952,13 @@ int wh_Client_MlDsaVerifyDma(whClientContext* ctx, const byte* sig,
                     /* Get response structure pointer, validates generic header
                      * rc */
                     ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_SIG_VERIFY,
-                                             (uint8_t**)&res);
+                                             res_len, sizeof(*res),
+                                             (uint8_t**)&res, NULL);
                     /* wolfCrypt allows positive error codes on success in some
                      * scenarios */
                     if (ret >= 0) {
-                        const uint32_t hdr_sz =
-                            sizeof(whMessageCrypto_GenericResponseHeader) +
-                            sizeof(*res);
-                        /* Note whMessageCrypto_MlDsaVerifyDmaResponse has no
-                         * size field */
-                        if (res_len < hdr_sz) {
-                            ret = WH_ERROR_ABORTED;
-                        }
-                        else {
-                            /* Set verification result */
-                            *out_res = res->verifyResult;
-                        }
+                        /* Set verification result */
+                        *out_res = res->verifyResult;
                     }
                 }
             }
@@ -11262,10 +11109,11 @@ static int _MlKemMakeKey(whClientContext* ctx, int level,
     uint8_t*                             dataPtr = NULL;
     whMessageCrypto_MlKemKeyGenRequest*  req     = NULL;
     whMessageCrypto_MlKemKeyGenResponse* res     = NULL;
-    uint16_t group  = WH_MESSAGE_GROUP_CRYPTO;
-    uint16_t action = WC_ALGO_TYPE_PK;
-    uint16_t req_len;
-    uint16_t res_len;
+    uint16_t                             group   = WH_MESSAGE_GROUP_CRYPTO;
+    uint16_t                             action  = WC_ALGO_TYPE_PK;
+    uint16_t                             req_len;
+    uint16_t                             res_len;
+    uint16_t                             trailSz = 0;
 
     if (ctx == NULL) {
         return WH_ERROR_BADARGS;
@@ -11320,8 +11168,8 @@ static int _MlKemMakeKey(whClientContext* ctx, int level,
         return ret;
     }
 
-    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_KEM_KEYGEN,
-                                (uint8_t**)&res);
+    ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_KEM_KEYGEN, res_len,
+                             sizeof(*res), (uint8_t**)&res, &trailSz);
     if (ret >= 0) {
         key_id = (whKeyId)res->keyId;
         WH_DEBUG_CLIENT_VERBOSE("MlKemMakeKey: Res recv:"
@@ -11338,10 +11186,7 @@ static int _MlKemMakeKey(whClientContext* ctx, int level,
              * material the server did not return. */
             if (res->len > 0) {
                 uint8_t*     key_raw = (uint8_t*)(res + 1);
-                const size_t hdr_sz  =
-                    sizeof(whMessageCrypto_GenericResponseHeader) +
-                    sizeof(*res);
-                if (res_len < hdr_sz || res->len > (res_len - hdr_sz)) {
+                if (res->len > trailSz) {
                     ret = WH_ERROR_ABORTED;
                 }
                 else {
@@ -11462,6 +11307,7 @@ int wh_Client_MlKemEncapsulate(whClientContext* ctx, MlKemKey* key,
         uint16_t req_len =
             sizeof(whMessageCrypto_GenericRequestHeader) + sizeof(*req);
         uint16_t res_len = 0;
+        uint16_t trailSz = 0;
         uint32_t options = 0;
 
         dataPtr = (uint8_t*)wh_CommClient_GetDataPtr(ctx->comm);
@@ -11504,21 +11350,18 @@ int wh_Client_MlKemEncapsulate(whClientContext* ctx, MlKemKey* key,
 
             if (ret == WH_ERROR_OK) {
                 ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_KEM_ENCAPS,
-                                         (uint8_t**)&res);
+                                         res_len, sizeof(*res), (uint8_t**)&res,
+                                         &trailSz);
                 if (ret >= 0) {
                     uint8_t*     resp_data  = (uint8_t*)(res + 1);
                     uint32_t     out_ct_len = res->ctSz;
                     uint32_t     out_ss_len = res->ssSz;
-                    const size_t hdr_sz =
-                        sizeof(whMessageCrypto_GenericResponseHeader) +
-                        sizeof(*res);
                     WH_DEBUG_CLIENT_VERBOSE("MlKemEncapsulate: Res recv:"
                                             "ctSz:%u, ssSz:%u, ret:%d\n",
                                             (unsigned int)out_ct_len,
                                             (unsigned int)out_ss_len, ret);
-                    if (res_len < hdr_sz ||
-                        out_ct_len > (res_len - hdr_sz) ||
-                        out_ss_len > (res_len - hdr_sz - out_ct_len)) {
+                    if (out_ct_len > trailSz ||
+                        out_ss_len > (trailSz - out_ct_len)) {
                         ret = WH_ERROR_ABORTED;
                     }
                     else if (*inout_ct_len < out_ct_len ||
@@ -11602,6 +11445,7 @@ int wh_Client_MlKemDecapsulate(whClientContext* ctx, MlKemKey* key,
             uint8_t* req_ct  = (uint8_t*)(req + 1);
             uint16_t req_len = (uint16_t)total_len;
             uint16_t res_len = 0;
+            uint16_t trailSz = 0;
 
             if (evict != 0) {
                 options |= WH_MESSAGE_CRYPTO_MLKEM_DECAPS_OPTIONS_EVICT;
@@ -11633,18 +11477,15 @@ int wh_Client_MlKemDecapsulate(whClientContext* ctx, MlKemKey* key,
 
             if (ret == WH_ERROR_OK) {
                 ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_KEM_DECAPS,
-                                         (uint8_t**)&res);
+                                         res_len, sizeof(*res), (uint8_t**)&res,
+                                         &trailSz);
                 if (ret >= 0) {
                     uint8_t*     resp_ss    = (uint8_t*)(res + 1);
                     uint32_t     out_ss_len = res->ssSz;
-                    const size_t hdr_sz =
-                        sizeof(whMessageCrypto_GenericResponseHeader) +
-                        sizeof(*res);
                     WH_DEBUG_CLIENT_VERBOSE("MlKemDecapsulate: Res recv:"
                                             "ssSz:%u, ret:%d\n",
                                             (unsigned int)out_ss_len, ret);
-                    if (res_len < hdr_sz ||
-                        out_ss_len > (res_len - hdr_sz)) {
+                    if (out_ss_len > trailSz) {
                         ret = WH_ERROR_ABORTED;
                     }
                     else if (*inout_ss_len < out_ss_len) {
@@ -11837,34 +11678,27 @@ static int _MlKemMakeKeyDma(whClientContext* ctx, int level,
         WH_DMA_OPER_CLIENT_WRITE_POST, (whDmaFlags){0});
 
     if (ret == WH_ERROR_OK) {
-        ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_KEM_KEYGEN,
-                                 (uint8_t**)&res);
+        ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_KEM_KEYGEN, res_len,
+                                 sizeof(*res), (uint8_t**)&res, NULL);
         if (ret >= 0) {
-            const uint32_t hdr_sz =
-                sizeof(whMessageCrypto_GenericResponseHeader) + sizeof(*res);
-            if (res_len < hdr_sz) {
-                ret = WH_ERROR_ABORTED;
+            key_id = (whKeyId)res->keyId;
+            if (inout_key_id != NULL) {
+                *inout_key_id = key_id;
             }
-            else {
-                key_id = (whKeyId)res->keyId;
-                if (inout_key_id != NULL) {
-                    *inout_key_id = key_id;
+            if (key != NULL) {
+                wh_Client_MlKemSetKeyId(key, key_id);
+                /* buffer holds the exported key (EPHEMERAL) or the public
+                 * key (cached keygen); keySize bounds the DMA write. An
+                 * empty result means the server returned no key material. */
+                if (res->keySize == 0) {
+                    ret = WH_ERROR_ABORTED;
                 }
-                if (key != NULL) {
-                    wh_Client_MlKemSetKeyId(key, key_id);
-                    /* buffer holds the exported key (EPHEMERAL) or the public
-                     * key (cached keygen); keySize bounds the DMA write. An
-                     * empty result means the server returned no key material. */
-                    if (res->keySize == 0) {
-                        ret = WH_ERROR_ABORTED;
-                    }
-                    else if (res->keySize > buffer_len) {
-                        ret = WH_ERROR_BADARGS;
-                    }
-                    else {
-                        ret = wh_Crypto_MlKemDeserializeKey(
-                            buffer, (uint16_t)res->keySize, key);
-                    }
+                else if (res->keySize > buffer_len) {
+                    ret = WH_ERROR_BADARGS;
+                }
+                else {
+                    ret = wh_Crypto_MlKemDeserializeKey(
+                        buffer, (uint16_t)res->keySize, key);
                 }
             }
         }
@@ -11968,6 +11802,7 @@ int wh_Client_MlKemEncapsulateDma(whClientContext* ctx, MlKemKey* key,
         uint16_t req_len =
             sizeof(whMessageCrypto_GenericRequestHeader) + sizeof(*req);
         uint16_t res_len = 0;
+        uint16_t trailSz = 0;
 
         dataPtr = (uint8_t*)wh_CommClient_GetDataPtr(ctx->comm);
         if (dataPtr == NULL) {
@@ -12015,15 +11850,12 @@ int wh_Client_MlKemEncapsulateDma(whClientContext* ctx, MlKemKey* key,
 
             if (ret == WH_ERROR_OK) {
                 ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_KEM_ENCAPS,
-                                         (uint8_t**)&res);
+                                         res_len, sizeof(*res), (uint8_t**)&res,
+                                         &trailSz);
                 if (ret >= 0) {
                     /* ct was transferred via DMA, ss is inline in response */
                     uint8_t*     resp_ss = (uint8_t*)(res + 1);
-                    const size_t hdr_sz =
-                        sizeof(whMessageCrypto_GenericResponseHeader) +
-                        sizeof(*res);
-                    if (res_len < hdr_sz ||
-                        res->ssLen > (res_len - hdr_sz)) {
+                    if (res->ssLen > trailSz) {
                         ret = WH_ERROR_ABORTED;
                     }
                     else if (res->ctLen > origCtSz ||
@@ -12093,6 +11925,7 @@ int wh_Client_MlKemDecapsulateDma(whClientContext* ctx, MlKemKey* key,
         uint16_t req_len =
             sizeof(whMessageCrypto_GenericRequestHeader) + sizeof(*req);
         uint16_t res_len = 0;
+        uint16_t trailSz = 0;
 
         dataPtr = (uint8_t*)wh_CommClient_GetDataPtr(ctx->comm);
         if (dataPtr == NULL) {
@@ -12140,15 +11973,12 @@ int wh_Client_MlKemDecapsulateDma(whClientContext* ctx, MlKemKey* key,
 
             if (ret == WH_ERROR_OK) {
                 ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_KEM_DECAPS,
-                                         (uint8_t**)&res);
+                                         res_len, sizeof(*res), (uint8_t**)&res,
+                                         &trailSz);
                 if (ret >= 0) {
                     /* ss is inline in response, not via DMA */
                     uint8_t*     resp_ss = (uint8_t*)(res + 1);
-                    const size_t hdr_sz =
-                        sizeof(whMessageCrypto_GenericResponseHeader) +
-                        sizeof(*res);
-                    if (res_len < hdr_sz ||
-                        res->ssLen > (res_len - hdr_sz)) {
+                    if (res->ssLen > trailSz) {
                         ret = WH_ERROR_ABORTED;
                     }
                     else if (res->ssLen > *inout_ss_len) {
@@ -12299,23 +12129,15 @@ int wh_Client_LmsMakeKeyDma(whClientContext* ctx, LmsKey* key,
             WH_DMA_OPER_CLIENT_WRITE_POST, (whDmaFlags){0});
 
         if (ret == WH_ERROR_OK) {
-            ret = _getCryptoResponse(dataPtr,
-                                     WC_PK_TYPE_PQC_STATEFUL_SIG_KEYGEN,
-                                     (uint8_t**)&res);
+            ret = _getCryptoResponse(
+                dataPtr, WC_PK_TYPE_PQC_STATEFUL_SIG_KEYGEN, res_len,
+                sizeof(*res), (uint8_t**)&res, NULL);
             if (ret >= 0) {
-                const uint32_t hdr_sz =
-                    sizeof(whMessageCrypto_GenericResponseHeader) +
-                    sizeof(*res);
-                if (res_len < hdr_sz) {
-                    ret = WH_ERROR_ABORTED;
+                key_id = (whKeyId)res->keyId;
+                if (inout_key_id != NULL) {
+                    *inout_key_id = key_id;
                 }
-                else {
-                    key_id = (whKeyId)res->keyId;
-                    if (inout_key_id != NULL) {
-                        *inout_key_id = key_id;
-                    }
-                    wh_Client_LmsSetKeyId(key, key_id);
-                }
+                wh_Client_LmsSetKeyId(key, key_id);
             }
         }
 
@@ -12415,15 +12237,10 @@ int wh_Client_LmsSignDma(whClientContext* ctx, const byte* msg, word32 msgSz,
 
         if (ret == WH_ERROR_OK) {
             ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_STATEFUL_SIG_SIGN,
-                                     (uint8_t**)&res);
+                                     res_len, sizeof(*res), (uint8_t**)&res,
+                                     NULL);
             if (ret >= 0) {
-                const uint32_t hdr_sz =
-                    sizeof(whMessageCrypto_GenericResponseHeader) +
-                    sizeof(*res);
-                if (res_len < hdr_sz) {
-                    ret = WH_ERROR_ABORTED;
-                }
-                else if (res->sigLen > sigCap) {
+                if (res->sigLen > sigCap) {
                     ret = WH_ERROR_BADARGS;
                 }
                 else {
@@ -12521,20 +12338,12 @@ int wh_Client_LmsVerifyDma(whClientContext* ctx, const byte* sig, word32 sigSz,
             WH_DMA_OPER_CLIENT_READ_POST, (whDmaFlags){0});
 
         if (ret == WH_ERROR_OK) {
-            ret = _getCryptoResponse(dataPtr,
-                                     WC_PK_TYPE_PQC_STATEFUL_SIG_VERIFY,
-                                     (uint8_t**)&resp);
+            ret = _getCryptoResponse(
+                dataPtr, WC_PK_TYPE_PQC_STATEFUL_SIG_VERIFY, res_len,
+                sizeof(*resp), (uint8_t**)&resp, NULL);
             if (ret >= 0) {
-                const uint32_t hdr_sz =
-                    sizeof(whMessageCrypto_GenericResponseHeader) +
-                    sizeof(*resp);
-                if (res_len < hdr_sz) {
-                    ret = WH_ERROR_ABORTED;
-                }
-                else {
-                    *res = (int)resp->res;
-                    ret  = WH_ERROR_OK;
-                }
+                *res = (int)resp->res;
+                ret  = WH_ERROR_OK;
             }
         }
     }
@@ -12593,21 +12402,13 @@ int wh_Client_LmsSigsLeftDma(whClientContext* ctx, LmsKey* key)
             } while (ret == WH_ERROR_NOTREADY);
         }
         if (ret == WH_ERROR_OK) {
-            ret = _getCryptoResponse(dataPtr,
-                                     WC_PK_TYPE_PQC_STATEFUL_SIG_SIGS_LEFT,
-                                     (uint8_t**)&res);
+            ret = _getCryptoResponse(
+                dataPtr, WC_PK_TYPE_PQC_STATEFUL_SIG_SIGS_LEFT, res_len,
+                sizeof(*res), (uint8_t**)&res, NULL);
             if (ret >= 0) {
-                const uint32_t hdr_sz =
-                    sizeof(whMessageCrypto_GenericResponseHeader) +
-                    sizeof(*res);
-                if (res_len < hdr_sz) {
-                    ret = WH_ERROR_ABORTED;
-                }
-                else {
-                    /* The server mirrors wc_LmsKey_SigsLeft(), which is a
-                     * boolean. Normalize so the only nonzero return is 1. */
-                    ret = (res->sigsLeft != 0) ? 1 : 0;
-                }
+                /* The server mirrors wc_LmsKey_SigsLeft(), which is a
+                 * boolean. Normalize so the only nonzero return is 1. */
+                ret = (res->sigsLeft != 0) ? 1 : 0;
             }
         }
     }
@@ -12780,23 +12581,15 @@ int wh_Client_XmssMakeKeyDma(whClientContext* ctx, XmssKey* key,
             WH_DMA_OPER_CLIENT_WRITE_POST, (whDmaFlags){0});
 
         if (ret == WH_ERROR_OK) {
-            ret = _getCryptoResponse(dataPtr,
-                                     WC_PK_TYPE_PQC_STATEFUL_SIG_KEYGEN,
-                                     (uint8_t**)&res);
+            ret = _getCryptoResponse(
+                dataPtr, WC_PK_TYPE_PQC_STATEFUL_SIG_KEYGEN, res_len,
+                sizeof(*res), (uint8_t**)&res, NULL);
             if (ret >= 0) {
-                const uint32_t hdr_sz =
-                    sizeof(whMessageCrypto_GenericResponseHeader) +
-                    sizeof(*res);
-                if (res_len < hdr_sz) {
-                    ret = WH_ERROR_ABORTED;
+                key_id = (whKeyId)res->keyId;
+                if (inout_key_id != NULL) {
+                    *inout_key_id = key_id;
                 }
-                else {
-                    key_id = (whKeyId)res->keyId;
-                    if (inout_key_id != NULL) {
-                        *inout_key_id = key_id;
-                    }
-                    wh_Client_XmssSetKeyId(key, key_id);
-                }
+                wh_Client_XmssSetKeyId(key, key_id);
             }
         }
 
@@ -12896,15 +12689,10 @@ int wh_Client_XmssSignDma(whClientContext* ctx, const byte* msg, word32 msgSz,
 
         if (ret == WH_ERROR_OK) {
             ret = _getCryptoResponse(dataPtr, WC_PK_TYPE_PQC_STATEFUL_SIG_SIGN,
-                                     (uint8_t**)&res);
+                                     res_len, sizeof(*res), (uint8_t**)&res,
+                                     NULL);
             if (ret >= 0) {
-                const uint32_t hdr_sz =
-                    sizeof(whMessageCrypto_GenericResponseHeader) +
-                    sizeof(*res);
-                if (res_len < hdr_sz) {
-                    ret = WH_ERROR_ABORTED;
-                }
-                else if (res->sigLen > sigCap) {
+                if (res->sigLen > sigCap) {
                     ret = WH_ERROR_BADARGS;
                 }
                 else {
@@ -13003,20 +12791,12 @@ int wh_Client_XmssVerifyDma(whClientContext* ctx, const byte* sig,
             WH_DMA_OPER_CLIENT_READ_POST, (whDmaFlags){0});
 
         if (ret == WH_ERROR_OK) {
-            ret = _getCryptoResponse(dataPtr,
-                                     WC_PK_TYPE_PQC_STATEFUL_SIG_VERIFY,
-                                     (uint8_t**)&resp);
+            ret = _getCryptoResponse(
+                dataPtr, WC_PK_TYPE_PQC_STATEFUL_SIG_VERIFY, res_len,
+                sizeof(*resp), (uint8_t**)&resp, NULL);
             if (ret >= 0) {
-                const uint32_t hdr_sz =
-                    sizeof(whMessageCrypto_GenericResponseHeader) +
-                    sizeof(*resp);
-                if (res_len < hdr_sz) {
-                    ret = WH_ERROR_ABORTED;
-                }
-                else {
-                    *res = (int)resp->res;
-                    ret  = WH_ERROR_OK;
-                }
+                *res = (int)resp->res;
+                ret  = WH_ERROR_OK;
             }
         }
     }
@@ -13075,21 +12855,13 @@ int wh_Client_XmssSigsLeftDma(whClientContext* ctx, XmssKey* key)
             } while (ret == WH_ERROR_NOTREADY);
         }
         if (ret == WH_ERROR_OK) {
-            ret = _getCryptoResponse(dataPtr,
-                                     WC_PK_TYPE_PQC_STATEFUL_SIG_SIGS_LEFT,
-                                     (uint8_t**)&res);
+            ret = _getCryptoResponse(
+                dataPtr, WC_PK_TYPE_PQC_STATEFUL_SIG_SIGS_LEFT, res_len,
+                sizeof(*res), (uint8_t**)&res, NULL);
             if (ret >= 0) {
-                const uint32_t hdr_sz =
-                    sizeof(whMessageCrypto_GenericResponseHeader) +
-                    sizeof(*res);
-                if (res_len < hdr_sz) {
-                    ret = WH_ERROR_ABORTED;
-                }
-                else {
-                    /* The server mirrors wc_XmssKey_SigsLeft(), which is a
-                     * boolean. Normalize so the only nonzero return is 1. */
-                    ret = (res->sigsLeft != 0) ? 1 : 0;
-                }
+                /* The server mirrors wc_XmssKey_SigsLeft(), which is a
+                 * boolean. Normalize so the only nonzero return is 1. */
+                ret = (res->sigsLeft != 0) ? 1 : 0;
             }
         }
     }


### PR DESCRIPTION
Moves a handful of repeated hand-rolled size checks into a common function for DRYness.