### PR TITLE
Fix bug in data unwrap. Remove unnecessary stack buffers in key wrap code

### DIFF
--- a/src/wh_client_keywrap.c
+++ b/src/wh_client_keywrap.c
@@ -599,9 +599,10 @@ int wh_Client_DataUnwrapRequest(whClientContext*   ctx,
         return WH_ERROR_BADARGS;
     }
 
-    /* Bound the whole wire length before copying into the comm data buffer */
+    /* Bound the wire length; the blob adds the wrap header to the plaintext */
     if (wrappedDataInSz == 0 ||
-        wrappedDataInSz > WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE ||
+        wrappedDataInSz > (uint32_t)WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE +
+                              WH_KEYWRAP_AES_GCM_HEADER_SIZE ||
         (size_t)sizeof(*req) + wrappedDataInSz > WOLFHSM_CFG_COMM_DATA_LEN) {
         return WH_ERROR_BADARGS;
     }

--- a/src/wh_client_keywrap.c
+++ b/src/wh_client_keywrap.c
@@ -253,7 +253,8 @@ int wh_Client_KeyUnwrapAndExportRequest(whClientContext*   ctx,
     }
 
     /* Bound the whole wire length before copying into the comm data buffer */
-    if (wrappedKeySz == 0 || wrappedKeySz > WOLFHSM_CFG_KEYWRAP_MAX_KEY_SIZE ||
+    if (wrappedKeySz == 0 ||
+        wrappedKeySz > WH_KEYWRAP_AES_GCM_MAX_WRAPPED_KEY_SIZE ||
         (size_t)sizeof(*req) + wrappedKeySz > WOLFHSM_CFG_COMM_DATA_LEN) {
         return WH_ERROR_BADARGS;
     }
@@ -377,7 +378,8 @@ int wh_Client_KeyUnwrapAndCacheRequest(whClientContext*   ctx,
         return WH_ERROR_BADARGS;
 
     /* Bound the whole wire length before copying into the comm data buffer */
-    if (wrappedKeySz == 0 || wrappedKeySz > WOLFHSM_CFG_KEYWRAP_MAX_KEY_SIZE ||
+    if (wrappedKeySz == 0 ||
+        wrappedKeySz > WH_KEYWRAP_AES_GCM_MAX_WRAPPED_KEY_SIZE ||
         (size_t)sizeof(*req) + wrappedKeySz > WOLFHSM_CFG_COMM_DATA_LEN) {
         return WH_ERROR_BADARGS;
     }

--- a/src/wh_server_keystore.c
+++ b/src/wh_server_keystore.c
@@ -1701,8 +1701,10 @@ static int _AesGcmDataWrapWithKek(whServerContext* server,
     uint8_t  authTag[WH_KEYWRAP_AES_GCM_TAG_SIZE];
     uint8_t  iv[WH_KEYWRAP_AES_GCM_IV_SIZE];
     uint8_t* encBlob;
+    uint8_t  plainData[WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE];
 
-    if (server == NULL || dataIn == NULL || wrappedDataOut == NULL) {
+    if (server == NULL || dataIn == NULL || wrappedDataOut == NULL ||
+        dataSz > WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE) {
         return WH_ERROR_BADARGS;
     }
 
@@ -1733,22 +1735,23 @@ static int _AesGcmDataWrapWithKek(whServerContext* server,
     /* Place the encrypted blob after the IV and Auth Tag */
     encBlob = (uint8_t*)wrappedDataOut + sizeof(iv) + sizeof(authTag);
 
+    memcpy(plainData, dataIn, dataSz);
+
     /* Encrypt the blob under the data-wrap domain */
-    ret = wc_AesGcmEncrypt(aes, encBlob, dataIn, dataSz, iv, sizeof(iv),
+    ret = wc_AesGcmEncrypt(aes, encBlob, plainData, dataSz, iv, sizeof(iv),
                            authTag, sizeof(authTag), WH_KEYWRAP_AAD_DATA,
                            WH_KEYWRAP_AAD_DATA_LEN);
-    if (ret != 0) {
-        wc_AesFree(aes);
-        return ret;
+    if (ret == 0) {
+        /* Prepend IV + authTag to encrypted blob */
+        memcpy(wrappedDataOut, iv, sizeof(iv));
+        memcpy(wrappedDataOut + sizeof(iv), authTag, sizeof(authTag));
     }
-
-    /* Prepend IV + authTag to encrypted blob */
-    memcpy(wrappedDataOut, iv, sizeof(iv));
-    memcpy(wrappedDataOut + sizeof(iv), authTag, sizeof(authTag));
 
     wc_AesFree(aes);
 
-    return WH_ERROR_OK;
+    wh_Utils_ForceZero(plainData, dataSz);
+
+    return (ret == 0) ? WH_ERROR_OK : ret;
 }
 
 static int _AesGcmDataWrap(whServerContext* server, whKeyId serverKeyId,
@@ -1792,6 +1795,7 @@ static int _AesGcmDataUnwrapWithKek(whServerContext* server,
     uint8_t  iv[WH_KEYWRAP_AES_GCM_IV_SIZE];
     uint8_t* encBlob;
     uint16_t encBlobSz;
+    uint8_t  plainData[WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE];
 
     if (server == NULL || wrappedDataIn == NULL || dataOut == NULL ||
         dataSz > WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE) {
@@ -1804,6 +1808,10 @@ static int _AesGcmDataUnwrapWithKek(whServerContext* server,
 
     encBlob   = (uint8_t*)wrappedDataIn + sizeof(iv) + sizeof(authTag);
     encBlobSz = wrappedDataSz - sizeof(iv) - sizeof(authTag);
+
+    if (encBlobSz > dataSz) {
+        return WH_ERROR_BUFFER_SIZE;
+    }
 
     /* Initialize AES context and set it to use the server side key */
     ret = wc_AesInit(aes, NULL, server->devId);
@@ -1822,16 +1830,18 @@ static int _AesGcmDataUnwrapWithKek(whServerContext* server,
     memcpy(authTag, (const uint8_t*)wrappedDataIn + sizeof(iv), sizeof(authTag));
 
     /* Decrypt under the data-wrap domain; a key blob won't authenticate here */
-    ret = wc_AesGcmDecrypt(aes, dataOut, encBlob, encBlobSz, iv, sizeof(iv),
+    ret = wc_AesGcmDecrypt(aes, plainData, encBlob, encBlobSz, iv, sizeof(iv),
                            authTag, sizeof(authTag), WH_KEYWRAP_AAD_DATA,
                            WH_KEYWRAP_AAD_DATA_LEN);
-    if (ret != 0) {
-        wc_AesFree(aes);
-        return ret;
+    if (ret == 0) {
+        memcpy(dataOut, plainData, encBlobSz);
     }
 
     wc_AesFree(aes);
-    return WH_ERROR_OK;
+
+    wh_Utils_ForceZero(plainData, encBlobSz);
+
+    return (ret == 0) ? WH_ERROR_OK : ret;
 }
 
 static int _AesGcmDataUnwrap(whServerContext* server, uint16_t serverKeyId,
@@ -1878,7 +1888,7 @@ static int _HandleKeyWrapRequest(whServerContext*                  server,
     int           ret;
     uint8_t*      wrappedKey;
     whNvmMetadata metadata;
-    uint8_t       key[WOLFHSM_CFG_KEYWRAP_MAX_KEY_SIZE];
+    uint8_t*      key;
     whKeyId       serverKeyId;
 
     if (server == NULL || req == NULL || reqData == NULL ||
@@ -1904,7 +1914,7 @@ static int _HandleKeyWrapRequest(whServerContext*                  server,
     if (ret != WH_ERROR_OK) {
         return ret;
     }
-    memcpy(key, reqData + sizeof(metadata), req->keySz);
+    key = reqData + sizeof(metadata);
 
     /* Ensure the keyId in the wrapped metadata has the wrapped flag set */
     if (!WH_KEYID_ISWRAPPED(metadata.id)) {
@@ -1970,8 +1980,8 @@ _HandleKeyWrapExportRequest(whServerContext*                        server,
     int           ret;
     uint8_t*      wrappedKey;
     whNvmMetadata metadata = {0};
-    uint8_t       key[WOLFHSM_CFG_KEYWRAP_MAX_KEY_SIZE];
-    uint32_t      keySz = sizeof(key);
+    uint8_t*      key;
+    uint32_t      keySz;
     whKeyId       targetKeyId;
     whKeyId       serverKeyId;
     uint16_t      targetKeyType;
@@ -1984,6 +1994,13 @@ _HandleKeyWrapExportRequest(whServerContext*                        server,
     if (server == NULL || req == NULL || resp == NULL || respData == NULL) {
         return WH_ERROR_BADARGS;
     }
+
+    /* Read the key into the response buffer. The wrap helper stages the whole
+     * plaintext blob before writing, so the ciphertext may land back over it */
+    key   = respData;
+    keySz = (respDataSz < WOLFHSM_CFG_KEYWRAP_MAX_KEY_SIZE)
+                ? respDataSz
+                : WOLFHSM_CFG_KEYWRAP_MAX_KEY_SIZE;
 
     /* Ensure the cipher type in the response matches the request */
     resp->cipherType = req->cipherType;
@@ -2081,9 +2098,11 @@ _HandleKeyWrapExportRequest(whServerContext*                        server,
     ret = WH_ERROR_OK;
 
 out:
-    /* key[] held a cleartext server secret; wipe the stack copy on every exit
-     */
-    wh_Utils_ForceZero(key, sizeof(key));
+    /* key held a cleartext server secret. On success the wrapped blob is longer
+     * than the key and has already covered it, so only failures need a wipe */
+    if (ret != WH_ERROR_OK) {
+        wh_Utils_ForceZero(key, keySz);
+    }
     return ret;
 }
 
@@ -2252,7 +2271,7 @@ static int _HandleKeyUnwrapAndCacheRequest(
     uint8_t*      wrappedKey;
     whNvmMetadata metadata = {0};
     uint16_t      keySz = 0;
-    uint8_t       key[WOLFHSM_CFG_KEYWRAP_MAX_KEY_SIZE];
+    uint8_t*      key;
     whKeyId       serverKeyId;
     uint16_t      wrappedKeyUser;
     uint16_t      wrappedKeyType;
@@ -2262,8 +2281,10 @@ static int _HandleKeyUnwrapAndCacheRequest(
         return WH_ERROR_BUFFER_SIZE;
     }
 
-    /* Set the wrapped key to the request data */
+    /* Set the wrapped key to the request data. The unwrap helper reads the
+     * whole blob before writing, so the plaintext can go back over it */
     wrappedKey = reqData;
+    key        = reqData;
 
     /* Translate the server key id passed in from the client */
     serverKeyId = wh_KeyId_TranslateFromClient(WH_KEYTYPE_CRYPTO,
@@ -2430,8 +2451,8 @@ static int _HandleKeyUnwrapAndCacheRequest(
     ret = wh_Server_KeystoreCacheKey(server, &metadata, key);
 
 out:
-    /* key[] held decrypted key material; wipe the stack copy on every exit */
-    wh_Utils_ForceZero(key, sizeof(key));
+    /* key held decrypted key material; wipe it on every exit */
+    wh_Utils_ForceZero(key, keySz);
     return ret;
 }
 
@@ -2444,7 +2465,7 @@ static int _HandleDataWrapRequest(whServerContext*                   server,
 
     int      ret;
     uint8_t* wrappedData;
-    uint8_t  data[WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE];
+    uint8_t* data;
     whKeyId  serverKeyId;
 
     if (server == NULL || req == NULL || reqData == NULL || resp == NULL ||
@@ -2457,8 +2478,7 @@ static int _HandleDataWrapRequest(whServerContext*                   server,
         return WH_ERROR_BUFFER_SIZE;
     }
 
-    /* Extract the metadata and data from reqData */
-    memcpy(data, reqData, req->dataSz);
+    data = reqData;
 
     /* Translate the server key id passed in from the client */
     serverKeyId = wh_KeyId_TranslateFromClient(WH_KEYTYPE_CRYPTO,

--- a/src/wh_server_keystore.c
+++ b/src/wh_server_keystore.c
@@ -1701,7 +1701,6 @@ static int _AesGcmDataWrapWithKek(whServerContext* server,
     uint8_t  authTag[WH_KEYWRAP_AES_GCM_TAG_SIZE];
     uint8_t  iv[WH_KEYWRAP_AES_GCM_IV_SIZE];
     uint8_t* encBlob;
-    uint8_t  plainData[WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE];
 
     if (server == NULL || dataIn == NULL || wrappedDataOut == NULL ||
         dataSz > WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE) {
@@ -1735,10 +1734,8 @@ static int _AesGcmDataWrapWithKek(whServerContext* server,
     /* Place the encrypted blob after the IV and Auth Tag */
     encBlob = (uint8_t*)wrappedDataOut + sizeof(iv) + sizeof(authTag);
 
-    memcpy(plainData, dataIn, dataSz);
-
     /* Encrypt the blob under the data-wrap domain */
-    ret = wc_AesGcmEncrypt(aes, encBlob, plainData, dataSz, iv, sizeof(iv),
+    ret = wc_AesGcmEncrypt(aes, encBlob, dataIn, dataSz, iv, sizeof(iv),
                            authTag, sizeof(authTag), WH_KEYWRAP_AAD_DATA,
                            WH_KEYWRAP_AAD_DATA_LEN);
     if (ret == 0) {
@@ -1748,8 +1745,6 @@ static int _AesGcmDataWrapWithKek(whServerContext* server,
     }
 
     wc_AesFree(aes);
-
-    wh_Utils_ForceZero(plainData, dataSz);
 
     return (ret == 0) ? WH_ERROR_OK : ret;
 }
@@ -1795,7 +1790,6 @@ static int _AesGcmDataUnwrapWithKek(whServerContext* server,
     uint8_t  iv[WH_KEYWRAP_AES_GCM_IV_SIZE];
     uint8_t* encBlob;
     uint16_t encBlobSz;
-    uint8_t  plainData[WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE];
 
     if (server == NULL || wrappedDataIn == NULL || dataOut == NULL ||
         dataSz > WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE) {
@@ -1830,16 +1824,10 @@ static int _AesGcmDataUnwrapWithKek(whServerContext* server,
     memcpy(authTag, (const uint8_t*)wrappedDataIn + sizeof(iv), sizeof(authTag));
 
     /* Decrypt under the data-wrap domain; a key blob won't authenticate here */
-    ret = wc_AesGcmDecrypt(aes, plainData, encBlob, encBlobSz, iv, sizeof(iv),
+    ret = wc_AesGcmDecrypt(aes, dataOut, encBlob, encBlobSz, iv, sizeof(iv),
                            authTag, sizeof(authTag), WH_KEYWRAP_AAD_DATA,
                            WH_KEYWRAP_AAD_DATA_LEN);
-    if (ret == 0) {
-        memcpy(dataOut, plainData, encBlobSz);
-    }
-
     wc_AesFree(aes);
-
-    wh_Utils_ForceZero(plainData, encBlobSz);
 
     return (ret == 0) ? WH_ERROR_OK : ret;
 }
@@ -1886,7 +1874,6 @@ static int _HandleKeyWrapRequest(whServerContext*                  server,
 {
 
     int           ret;
-    uint8_t*      wrappedKey;
     whNvmMetadata metadata;
     uint8_t*      key;
     whKeyId       serverKeyId;
@@ -1928,14 +1915,12 @@ static int _HandleKeyWrapRequest(whServerContext*                  server,
                                                server->comm->client_id,
                                                req->serverKeyId);
 
-    /* Store the wrapped key in the response data */
-    wrappedKey = respData;
-
     switch (req->cipherType) {
 
 #ifndef NO_AES
 #ifdef HAVE_AESGCM
         case WC_CIPHER_AES_GCM: {
+            uint8_t  wrappedKeyStage[WH_KEYWRAP_AES_GCM_MAX_WRAPPED_KEY_SIZE];
             uint16_t wrappedKeySz =
                 WH_KEYWRAP_AES_GCM_HEADER_SIZE + sizeof(metadata) + req->keySz;
 
@@ -1947,11 +1932,16 @@ static int _HandleKeyWrapRequest(whServerContext*                  server,
             /* Wrap the key. The client supplies the plaintext, so no server
              * secret crosses the boundary; the KEK may be any client key. */
             ret = _AesGcmKeyWrap(server, serverKeyId, /*requireTrustedKek=*/0,
-                                 key, req->keySz, &metadata, wrappedKey,
+                                 key, req->keySz, &metadata, wrappedKeyStage,
                                  wrappedKeySz);
             if (ret != WH_ERROR_OK) {
+                wh_Utils_ForceZero(wrappedKeyStage, sizeof(wrappedKeyStage));
                 return ret;
             }
+
+            /* Copy the wrapped key on to the response data buffer */
+            memcpy(respData, wrappedKeyStage, wrappedKeySz);
+            wh_Utils_ForceZero(wrappedKeyStage, sizeof(wrappedKeyStage));
 
             /* Tell the client how big the wrapped key is */
             resp->wrappedKeySz = wrappedKeySz;
@@ -1978,7 +1968,6 @@ _HandleKeyWrapExportRequest(whServerContext*                        server,
                             uint8_t* respData, uint32_t respDataSz)
 {
     int           ret;
-    uint8_t*      wrappedKey;
     whNvmMetadata metadata = {0};
     uint8_t*      key;
     uint32_t      keySz;
@@ -2056,14 +2045,12 @@ _HandleKeyWrapExportRequest(whServerContext*                        server,
                           WH_KEYID_ID(metadata.id));
     }
 
-    /* Store the wrapped key in the response data */
-    wrappedKey = respData;
-
     switch (req->cipherType) {
 
 #ifndef NO_AES
 #ifdef HAVE_AESGCM
         case WC_CIPHER_AES_GCM: {
+            uint8_t  wrappedKeyStage[WH_KEYWRAP_AES_GCM_MAX_WRAPPED_KEY_SIZE];
             uint16_t wrappedKeySz = WH_KEYWRAP_AES_GCM_HEADER_SIZE +
                                     sizeof(metadata) + (uint16_t)keySz;
 
@@ -2077,11 +2064,16 @@ _HandleKeyWrapExportRequest(whServerContext*                        server,
              * secret to the client, so the KEK must be a trusted (HW or
              * WH_NVM_FLAGS_TRUSTED) key the client cannot know. */
             ret = _AesGcmKeyWrap(server, serverKeyId, /*requireTrustedKek=*/1,
-                                 key, (uint16_t)keySz, &metadata, wrappedKey,
-                                 wrappedKeySz);
+                                 key, (uint16_t)keySz, &metadata,
+                                 wrappedKeyStage, wrappedKeySz);
             if (ret != WH_ERROR_OK) {
+                wh_Utils_ForceZero(wrappedKeyStage, sizeof(wrappedKeyStage));
                 goto out;
             }
+
+            /* Copy the wrapped key on to the response data buffer */
+            memcpy(respData, wrappedKeyStage, wrappedKeySz);
+            wh_Utils_ForceZero(wrappedKeyStage, sizeof(wrappedKeyStage));
 
             /* Tell the client how big the wrapped key is */
             resp->wrappedKeySz = wrappedKeySz;
@@ -2113,12 +2105,12 @@ static int _HandleKeyUnwrapAndExportRequest(
     uint8_t* respData, uint32_t respDataSz)
 {
     /* Defensive: a case that never assigns ret cannot report success */
-    int            ret = WH_ERROR_BADARGS;
-    uint8_t*       wrappedKey;
-    whNvmMetadata* metadata;
-    uint8_t*       key;
-    whKeyId        serverKeyId;
-    uint16_t       keySz = 0;
+    int           ret = WH_ERROR_BADARGS;
+    uint8_t*      wrappedKey;
+    whNvmMetadata metadata = {0};
+    uint8_t       keyStage[WOLFHSM_CFG_KEYWRAP_MAX_KEY_SIZE];
+    whKeyId       serverKeyId;
+    uint16_t      keySz = 0;
 
     if (server == NULL || req == NULL || reqData == NULL || resp == NULL ||
         respData == NULL) {
@@ -2143,10 +2135,6 @@ static int _HandleKeyUnwrapAndExportRequest(
     /* Key size is only passed back to the client on success */
     resp->keySz = 0;
 
-    /* Store the metadata and key in the respData */
-    metadata = (whNvmMetadata*)respData;
-    key      = respData + sizeof(*metadata);
-
     switch (req->cipherType) {
 
 #ifndef NO_AES
@@ -2156,16 +2144,22 @@ static int _HandleKeyUnwrapAndExportRequest(
             uint16_t wrappedKeyType = 0;
 
             if (req->wrappedKeySz < WH_KEYWRAP_AES_GCM_HEADER_SIZE +
-                                    sizeof(*metadata)) {
+                                    sizeof(metadata)) {
                 ret = WH_ERROR_BADARGS;
                 break;
             }
 
             keySz = req->wrappedKeySz -
-                    WH_KEYWRAP_AES_GCM_HEADER_SIZE - sizeof(*metadata);
+                    WH_KEYWRAP_AES_GCM_HEADER_SIZE - sizeof(metadata);
+
+            /* Check if the staging buffer can fit the key */
+            if (keySz > sizeof(keyStage)) {
+                ret = WH_ERROR_BADARGS;
+                break;
+            }
 
             /* Check if the response data can fit the metadata + key  */
-            if (respDataSz < sizeof(*metadata) + keySz) {
+            if (respDataSz < sizeof(metadata) + keySz) {
                 ret = WH_ERROR_BUFFER_SIZE;
                 break;
             }
@@ -2174,13 +2168,14 @@ static int _HandleKeyUnwrapAndExportRequest(
              * injected into the server, so the KEK may be any client key. */
             ret = _AesGcmKeyUnwrap(server, serverKeyId,
                                    /*requireTrustedKek=*/0, wrappedKey,
-                                   req->wrappedKeySz, metadata, key, keySz);
+                                   req->wrappedKeySz, &metadata, keyStage,
+                                   keySz);
             if (ret != WH_ERROR_OK) {
                 break;
             }
 
             /* Dynamic keyId generation for wrapped keys is not allowed */
-            if (WH_KEYID_IS_UNASSIGNED(metadata->id)) {
+            if (WH_KEYID_IS_UNASSIGNED(metadata.id)) {
                 /* Wrapped keys must use explicit identifiers */
                 ret = WH_ERROR_BADARGS;
                 break;
@@ -2188,8 +2183,8 @@ static int _HandleKeyUnwrapAndExportRequest(
 
             /* Extract ownership from unwrapped metadata (preserves original
              * owner) */
-            wrappedKeyUser = WH_KEYID_USER(metadata->id);
-            wrappedKeyType = WH_KEYID_TYPE(metadata->id);
+            wrappedKeyUser = WH_KEYID_USER(metadata.id);
+            wrappedKeyType = WH_KEYID_TYPE(metadata.id);
 
             /* Require explicit wrapped-key encoding */
             if (wrappedKeyType != WH_KEYTYPE_WRAPPED) {
@@ -2198,7 +2193,7 @@ static int _HandleKeyUnwrapAndExportRequest(
             }
 
             /* Check if the key is exportable */
-            if (metadata->flags & WH_NVM_FLAGS_NONEXPORTABLE) {
+            if (metadata.flags & WH_NVM_FLAGS_NONEXPORTABLE) {
                 ret = WH_ERROR_ACCESS;
                 break;
             }
@@ -2220,8 +2215,6 @@ static int _HandleKeyUnwrapAndExportRequest(
             }
 #endif /* WOLFHSM_CFG_GLOBAL_KEYS */
 
-            /* Tell the client how big the key is on success */
-            resp->keySz = keySz;
         } break;
 #endif /* HAVE_AESGCM */
 #endif /* !NO_AES */
@@ -2234,20 +2227,20 @@ static int _HandleKeyUnwrapAndExportRequest(
     if (ret == WH_ERROR_OK) {
         /* The blob stores metadata in server order, so every check above ran
          * on native values. Convert to client order only on the way out */
-        ret = wh_MessageNvm_TranslateMetadata(magic, metadata, metadata);
+        ret = wh_MessageNvm_TranslateMetadata(magic, &metadata, &metadata);
     }
 
-    /* Keyed off the final ret so a failed translation scrubs too. respData is
-     * the long-lived comm buffer, so wipe the trailer and any decrypted key */
-    if (ret != WH_ERROR_OK && respDataSz >= sizeof(*metadata)) {
-        uint32_t scrubSz = sizeof(*metadata) + keySz;
+    if (ret == WH_ERROR_OK) {
+        /* Copy the metadata and key on to the response data buffer */
+        memcpy(respData, &metadata, sizeof(metadata));
+        memcpy(respData + sizeof(metadata), keyStage, keySz);
 
-        if (scrubSz > respDataSz) {
-            scrubSz = respDataSz;
-        }
-        resp->keySz = 0;
-        wh_Utils_ForceZero(metadata, scrubSz);
+        /* Tell the client how big the key is */
+        resp->keySz = keySz;
     }
+
+    /* keyStage held the decrypted key; wipe the stack copy */
+    wh_Utils_ForceZero(keyStage, sizeof(keyStage));
 
     return ret;
 }
@@ -2271,7 +2264,7 @@ static int _HandleKeyUnwrapAndCacheRequest(
     uint8_t*      wrappedKey;
     whNvmMetadata metadata = {0};
     uint16_t      keySz = 0;
-    uint8_t*      key;
+    uint8_t       keyStage[WOLFHSM_CFG_KEYWRAP_MAX_KEY_SIZE];
     whKeyId       serverKeyId;
     uint16_t      wrappedKeyUser;
     uint16_t      wrappedKeyType;
@@ -2281,10 +2274,8 @@ static int _HandleKeyUnwrapAndCacheRequest(
         return WH_ERROR_BUFFER_SIZE;
     }
 
-    /* Set the wrapped key to the request data. The unwrap helper reads the
-     * whole blob before writing, so the plaintext can go back over it */
+    /* Set the wrapped key to the request data */
     wrappedKey = reqData;
-    key        = reqData;
 
     /* Translate the server key id passed in from the client */
     serverKeyId = wh_KeyId_TranslateFromClient(WH_KEYTYPE_CRYPTO,
@@ -2310,12 +2301,18 @@ static int _HandleKeyUnwrapAndCacheRequest(
                     sizeof(metadata);
             resp->cipherType = WC_CIPHER_AES_GCM;
 
+            /* Check if the staging buffer can fit the key */
+            if (keySz > sizeof(keyStage)) {
+                return WH_ERROR_BADARGS;
+            }
+
             /* Unwrap-and-cache injects a key into the server keystore, so the
              * KEK must be a trusted (HW or WH_NVM_FLAGS_TRUSTED) key, else a
              * client could forge a blob under a KEK it knows. */
             ret = _AesGcmKeyUnwrap(server, serverKeyId,
                                    /*requireTrustedKek=*/1, wrappedKey,
-                                   req->wrappedKeySz, &metadata, key, keySz);
+                                   req->wrappedKeySz, &metadata, keyStage,
+                                   keySz);
             if (ret != WH_ERROR_OK) {
                 goto out;
             }
@@ -2441,18 +2438,18 @@ static int _HandleKeyUnwrapAndCacheRequest(
 #if defined(WOLFSSL_HAVE_LMS) || defined(WOLFSSL_HAVE_XMSS)
     /* Stateful (LMS/XMSS) private key state must never enter the keystore via
      * unwrap; that would permit a signature-index roll-back. */
-    if (wh_Crypto_IsStatefulSigPrivBlob(key, (uint16_t)metadata.len)) {
+    if (wh_Crypto_IsStatefulSigPrivBlob(keyStage, (uint16_t)metadata.len)) {
         ret = WH_ERROR_ACCESS;
         goto out;
     }
 #endif
 
     /* Cache the key */
-    ret = wh_Server_KeystoreCacheKey(server, &metadata, key);
+    ret = wh_Server_KeystoreCacheKey(server, &metadata, keyStage);
 
 out:
-    /* key held decrypted key material; wipe it on every exit */
-    wh_Utils_ForceZero(key, keySz);
+    /* keyStage held decrypted key material; wipe it on every exit */
+    wh_Utils_ForceZero(keyStage, sizeof(keyStage));
     return ret;
 }
 
@@ -2463,8 +2460,7 @@ static int _HandleDataWrapRequest(whServerContext*                   server,
                                   uint8_t* respData, uint32_t respDataSz)
 {
 
-    int      ret;
-    uint8_t* wrappedData;
+    int      ret = WH_ERROR_BADARGS;
     uint8_t* data;
     whKeyId  serverKeyId;
 
@@ -2490,14 +2486,12 @@ static int _HandleDataWrapRequest(whServerContext*                   server,
     /* Wrapped data size is only passed back to the client on success */
     resp->wrappedDataSz = 0;
 
-    /* Store the wrapped data in the response data */
-    wrappedData = respData;
-
     switch (req->cipherType) {
 
 #ifndef NO_AES
 #ifdef HAVE_AESGCM
         case WC_CIPHER_AES_GCM: {
+            uint8_t  wrappedDataStage[WH_KEYWRAP_AES_GCM_MAX_WRAPPED_DATA_SIZE];
             uint16_t wrappedDataSz =
                 WH_KEYWRAP_AES_GCM_HEADER_SIZE + req->dataSz;
 
@@ -2508,14 +2502,18 @@ static int _HandleDataWrapRequest(whServerContext*                   server,
 
             /* Wrap the data */
             ret = _AesGcmDataWrap(server, serverKeyId, data, req->dataSz,
-                                  wrappedData, wrappedDataSz);
-            if (ret != WH_ERROR_OK) {
-                return ret;
+                                  wrappedDataStage, wrappedDataSz);
+            if (ret == WH_ERROR_OK) {
+                /* Copy the wrapped data on to the response data buffer */
+                memcpy(respData, wrappedDataStage, wrappedDataSz);
+
+                /* Tell the client how big the wrapped data is */
+                resp->wrappedDataSz = wrappedDataSz;
+                resp->cipherType    = WC_CIPHER_AES_GCM;
             }
 
-            /* Tell the client how big the wrapped data is */
-            resp->wrappedDataSz = wrappedDataSz;
-            resp->cipherType    = WC_CIPHER_AES_GCM;
+            /* wrappedDataStage held the wrapped data; wipe the stack copy */
+            wh_Utils_ForceZero(wrappedDataStage, sizeof(wrappedDataStage));
 
         } break;
 #endif /* HAVE_AESGCM */
@@ -2525,7 +2523,7 @@ static int _HandleDataWrapRequest(whServerContext*                   server,
             return WH_ERROR_BADARGS;
     }
 
-    return WH_ERROR_OK;
+    return ret;
 }
 
 static int _HandleDataUnwrapRequest(whServerContext*                     server,
@@ -2534,9 +2532,8 @@ static int _HandleDataUnwrapRequest(whServerContext*                     server,
                                     whMessageKeystore_DataUnwrapResponse* resp,
                                     uint8_t* respData, uint32_t respDataSz)
 {
-    int      ret;
+    int      ret = WH_ERROR_BADARGS;
     uint8_t* wrappedData;
-    uint8_t* data;
     whKeyId  serverKeyId;
 
     if (server == NULL || req == NULL || reqData == NULL || resp == NULL ||
@@ -2561,21 +2558,24 @@ static int _HandleDataUnwrapRequest(whServerContext*                     server,
     /* Data size is only passed back to the client on success */
     resp->dataSz = 0;
 
-    /* Store the unwrapped data in the respData */
-    data = respData;
-
     switch (req->cipherType) {
 
 #ifndef NO_AES
 #ifdef HAVE_AESGCM
         case WC_CIPHER_AES_GCM: {
             uint16_t dataSz;
+            uint8_t  dataStage[WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE];
 
             if (req->wrappedDataSz < WH_KEYWRAP_AES_GCM_HEADER_SIZE) {
                 return WH_ERROR_BADARGS;
             }
 
             dataSz = req->wrappedDataSz - WH_KEYWRAP_AES_GCM_HEADER_SIZE;
+
+            /* Check if the staging buffer can fit the unwrapped data */
+            if (dataSz > sizeof(dataStage)) {
+                return WH_ERROR_BADARGS;
+            }
 
             /* Check if the response data can fit the unwrapped data */
             if (respDataSz < dataSz) {
@@ -2584,14 +2584,18 @@ static int _HandleDataUnwrapRequest(whServerContext*                     server,
 
             /* Unwrap the data */
             ret = _AesGcmDataUnwrap(server, serverKeyId, wrappedData,
-                                    req->wrappedDataSz, data, dataSz);
-            if (ret != WH_ERROR_OK) {
-                return ret;
+                                    req->wrappedDataSz, dataStage, dataSz);
+            if (ret == WH_ERROR_OK) {
+                /* Copy the unwrapped data to the response data buffer */
+                memcpy(respData, dataStage, dataSz);
+
+                /* Tell the client how big the unwrapped data is */
+                resp->dataSz     = dataSz;
+                resp->cipherType = WC_CIPHER_AES_GCM;
             }
 
-            /* Tell the client how big the unwrapped data is */
-            resp->dataSz     = dataSz;
-            resp->cipherType = WC_CIPHER_AES_GCM;
+            /* dataStage held the decrypted data; wipe the stack copy */
+            wh_Utils_ForceZero(dataStage, sizeof(dataStage));
 
         } break;
 #endif /* HAVE_AESGCM */
@@ -2601,7 +2605,7 @@ static int _HandleDataUnwrapRequest(whServerContext*                     server,
             return WH_ERROR_BADARGS;
     }
 
-    return WH_ERROR_OK;
+    return ret;
 }
 #endif /* WOLFHSM_CFG_KEYWRAP */
 

--- a/test-refactor/client-server/wh_test_keywrap.c
+++ b/test-refactor/client-server/wh_test_keywrap.c
@@ -73,6 +73,9 @@
  * for the maximum plus its header, so this is the binding limit */
 #define WH_TEST_KW_OVER_KEY (WOLFHSM_CFG_KEYWRAP_MAX_KEY_SIZE + 1)
 #define WH_TEST_KW_OVER_DATA (WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE + 1)
+/* Unwrap takes a blob, so its limit adds the wrap header */
+#define WH_TEST_KW_OVER_WRAPPED_DATA \
+    (WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE + WH_KEYWRAP_AES_GCM_HEADER_SIZE + 1)
 
 /* Distinct id range so nothing collides with other client-group suites; every
  * subtest cleans up its own keys */
@@ -330,6 +333,53 @@ static int _whTest_KeywrapDataWrapUsage(whClientContext* client)
 
     WH_TEST_RETURN_ON_FAIL(_CacheSwKek(client, &kekId));
 
+    /* Round-trip sizes spanning the AES block boundary and the configured max */
+    {
+        static const uint32_t sizes[] = {
+            1,  15, 16,  17,  31, 32,
+            33, 64, 127, 128,
+            WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE - 1,
+            WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE};
+        uint8_t  big[WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE];
+        uint8_t  rt[WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE];
+        uint8_t  wr[WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE +
+                   WH_KEYWRAP_AES_GCM_HEADER_SIZE];
+        uint32_t i;
+        uint32_t n;
+        uint32_t wrSz;
+        uint32_t rtSz;
+
+        for (i = 0; i < sizeof(big); i++) {
+            big[i] = (uint8_t)(i & 0xFF);
+        }
+
+        for (i = 0; i < (sizeof(sizes) / sizeof(sizes[0])); i++) {
+            n    = sizes[i];
+            wrSz = sizeof(wr);
+            rtSz = sizeof(rt);
+
+            ret = wh_Client_DataWrap(client, WC_CIPHER_AES_GCM, kekId, big, n,
+                                     wr, &wrSz);
+            if (ret == WH_ERROR_OK) {
+                ret = wh_Client_DataUnwrap(client, WC_CIPHER_AES_GCM, kekId, wr,
+                                           wrSz, rt, &rtSz);
+            }
+            if (ret != WH_ERROR_OK) {
+                WH_ERROR_PRINT("Data wrap round-trip size %u failed %d\n",
+                               (unsigned int)n, ret);
+                (void)wh_Client_KeyEvict(client, kekId);
+                return ret;
+            }
+
+            if (rtSz != n || memcmp(big, rt, n) != 0) {
+                WH_ERROR_PRINT("Data wrap round-trip corrupt at size %u\n",
+                               (unsigned int)n);
+                (void)wh_Client_KeyEvict(client, kekId);
+                return WH_ERROR_ABORTED;
+            }
+        }
+    }
+
     ret = wh_Client_DataWrap(client, WC_CIPHER_AES_GCM, kekId, data,
                              sizeof(data), wrappedData, &wrappedDataSz);
     if (ret != WH_ERROR_OK) {
@@ -513,7 +563,8 @@ static int _whTest_KeywrapOversizeRequest(whClientContext* client)
         ret = _CheckOversizeRejected(
             "DataUnwrap",
             wh_Client_DataUnwrap(client, WC_CIPHER_AES_GCM, kekId, in,
-                                 WH_TEST_KW_OVER_DATA, out, &dataOutSz));
+                                 WH_TEST_KW_OVER_WRAPPED_DATA, out,
+                                 &dataOutSz));
     }
 
     (void)wh_Client_KeyEvict(client, kekId);

--- a/test-refactor/client-server/wh_test_keywrap.c
+++ b/test-refactor/client-server/wh_test_keywrap.c
@@ -74,6 +74,8 @@
 #define WH_TEST_KW_OVER_KEY (WOLFHSM_CFG_KEYWRAP_MAX_KEY_SIZE + 1)
 #define WH_TEST_KW_OVER_DATA (WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE + 1)
 /* Unwrap takes a blob, so its limit adds the wrap header */
+#define WH_TEST_KW_OVER_WRAPPED_KEY \
+    (WH_KEYWRAP_AES_GCM_MAX_WRAPPED_KEY_SIZE + 1)
 #define WH_TEST_KW_OVER_WRAPPED_DATA \
     (WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE + WH_KEYWRAP_AES_GCM_HEADER_SIZE + 1)
 
@@ -541,15 +543,16 @@ static int _whTest_KeywrapOversizeRequest(whClientContext* client)
         ret = _CheckOversizeRejected(
             "KeyUnwrapAndExport",
             wh_Client_KeyUnwrapAndExport(client, WC_CIPHER_AES_GCM, kekId, in,
-                                         (uint16_t)WH_TEST_KW_OVER_KEY, &meta,
-                                         out, &keyOutSz));
+                                         (uint16_t)WH_TEST_KW_OVER_WRAPPED_KEY,
+                                         &meta, out, &keyOutSz));
     }
 
     if (ret == WH_ERROR_OK) {
         ret = _CheckOversizeRejected(
-            "KeyUnwrapAndCache", wh_Client_KeyUnwrapAndCache(
-                                     client, WC_CIPHER_AES_GCM, kekId, in,
-                                     (uint16_t)WH_TEST_KW_OVER_KEY, &cachedId));
+            "KeyUnwrapAndCache",
+            wh_Client_KeyUnwrapAndCache(client, WC_CIPHER_AES_GCM, kekId, in,
+                                        (uint16_t)WH_TEST_KW_OVER_WRAPPED_KEY,
+                                        &cachedId));
     }
 
     if (ret == WH_ERROR_OK) {
@@ -571,6 +574,62 @@ static int _whTest_KeywrapOversizeRequest(whClientContext* client)
     return ret;
 }
 
+/* A blob is the key plus the wrap header and metadata, so a maximum-size key
+ * wraps to more than WOLFHSM_CFG_KEYWRAP_MAX_KEY_SIZE bytes. Round trip the
+ * largest permitted key: bounding the blob by the key limit left every key
+ * over MAX_KEY_SIZE minus the blob overhead wrappable but never unwrappable */
+static int _whTest_KeywrapMaxKeyRoundTrip(whClientContext* client)
+{
+    int           ret;
+    whKeyId       kekId = WH_KEYID_ERASED;
+    uint8_t       srcKey[WOLFHSM_CFG_KEYWRAP_MAX_KEY_SIZE];
+    uint8_t       outKey[WOLFHSM_CFG_KEYWRAP_MAX_KEY_SIZE];
+    uint8_t       wrappedKey[WH_KEYWRAP_AES_GCM_MAX_WRAPPED_KEY_SIZE];
+    uint16_t      wrappedKeySz = (uint16_t)sizeof(wrappedKey);
+    uint16_t      outKeySz     = (uint16_t)sizeof(outKey);
+    whNvmMetadata wrapMeta     = {0};
+    whNvmMetadata outMeta      = {0};
+    size_t        i;
+
+    wrapMeta.id    = WH_CLIENT_KEYID_MAKE_WRAPPED_META(client->comm->client_id,
+                                                       WH_TEST_KW_META_ID);
+    wrapMeta.len   = (whNvmSize)sizeof(srcKey);
+    wrapMeta.flags = WH_NVM_FLAGS_USAGE_ANY;
+    memcpy(wrapMeta.label, "KW max key", sizeof("KW max key"));
+
+    for (i = 0; i < sizeof(srcKey); i++) {
+        srcKey[i] = (uint8_t)(0x5A ^ i);
+    }
+
+    WH_TEST_RETURN_ON_FAIL(_CacheSwKek(client, &kekId));
+
+    ret = wh_Client_KeyWrap(client, WC_CIPHER_AES_GCM, kekId, srcKey,
+                            (uint16_t)sizeof(srcKey), &wrapMeta, wrappedKey,
+                            &wrappedKeySz);
+    if (ret != WH_ERROR_OK) {
+        WH_ERROR_PRINT("max-key: KeyWrap failed %d\n", ret);
+        goto cleanup;
+    }
+
+    ret = wh_Client_KeyUnwrapAndExport(client, WC_CIPHER_AES_GCM, kekId,
+                                       wrappedKey, wrappedKeySz, &outMeta,
+                                       outKey, &outKeySz);
+    if (ret != WH_ERROR_OK) {
+        WH_ERROR_PRINT("max-key: KeyUnwrapAndExport failed %d\n", ret);
+        goto cleanup;
+    }
+
+    if (outKeySz != (uint16_t)sizeof(srcKey) ||
+        memcmp(srcKey, outKey, sizeof(srcKey)) != 0) {
+        WH_ERROR_PRINT("max-key: round trip mismatch\n");
+        ret = WH_ERROR_ABORTED;
+    }
+
+cleanup:
+    (void)wh_Client_KeyEvict(client, kekId);
+    return ret;
+}
+
 int whTest_KeyWrap(whClientContext* ctx)
 {
     WH_TEST_RETURN_ON_FAIL(_whTest_KeywrapTrustedKekPolicy(ctx));
@@ -578,6 +637,7 @@ int whTest_KeyWrap(whClientContext* ctx)
     WH_TEST_RETURN_ON_FAIL(_whTest_KeywrapKeyUnwrapUnderflow(ctx));
     WH_TEST_RETURN_ON_FAIL(_whTest_KeywrapDataUnwrapUnderflow(ctx));
     WH_TEST_RETURN_ON_FAIL(_whTest_KeywrapOversizeRequest(ctx));
+    WH_TEST_RETURN_ON_FAIL(_whTest_KeywrapMaxKeyRoundTrip(ctx));
 
     WH_TEST_PRINT("KEYWRAP POLICY SUCCESS\n");
     return 0;

--- a/test/wh_test_keywrap.c
+++ b/test/wh_test_keywrap.c
@@ -724,7 +724,7 @@ static int _AesGcm_TestTrustedKekPolicy(whClientContext* client, WC_RNG* rng)
 static int _AesGcm_TestDataWrap(whClientContext* client)
 {
     int     ret                                           = 0;
-    uint8_t data[]                                        = "Example data!";
+    uint8_t data[]                                        = "Example data spanning several AES blocks to catch overlap bugs!";
     uint8_t unwrappedData[sizeof(data)]                   = {0};
     uint32_t unwrappedDataSz = sizeof(unwrappedData);
     uint8_t  wrappedData[sizeof(data) + WH_KEYWRAP_AES_GCM_HEADER_SIZE] = {0};
@@ -971,7 +971,7 @@ static int _AesGcm_TestHwKeystoreDataWrap(whClientContext* client)
 {
     int      ret;
     whKeyId  hwKekId = WH_CLIENT_KEYID_MAKE_HW(WH_TEST_HWKEK_ID);
-    uint8_t  data[]  = "Example data!";
+    uint8_t  data[]  = "Example data spanning several AES blocks to catch overlap bugs!";
     uint8_t  unwrappedData[sizeof(data)] = {0};
     uint32_t unwrappedDataSz             = sizeof(unwrappedData);
     uint8_t  wrappedData[sizeof(data) + WH_KEYWRAP_AES_GCM_HEADER_SIZE] = {0};

--- a/wolfhsm/wh_common.h
+++ b/wolfhsm/wh_common.h
@@ -147,6 +147,13 @@ typedef uint16_t whCertFlags;
 #define WH_KEYWRAP_AES_GCM_HEADER_SIZE \
     (WH_KEYWRAP_AES_GCM_IV_SIZE + WH_KEYWRAP_AES_GCM_TAG_SIZE)
 
+#define WH_KEYWRAP_AES_GCM_MAX_WRAPPED_KEY_SIZE \
+    (WH_KEYWRAP_AES_GCM_HEADER_SIZE +           \
+     sizeof(whNvmMetadata) + WOLFHSM_CFG_KEYWRAP_MAX_KEY_SIZE)
+
+#define WH_KEYWRAP_AES_GCM_MAX_WRAPPED_DATA_SIZE \
+    (WH_KEYWRAP_AES_GCM_HEADER_SIZE + WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE)
+
 /* AES-GCM AAD domain separation for wrapped blobs.
  *
  * WARNING: Changing these strings will invalidate actively stored wrapped

--- a/wolfhsm/wh_message_keystore.h
+++ b/wolfhsm/wh_message_keystore.h
@@ -541,8 +541,10 @@ WH_UTILS_STATIC_ASSERT((uint32_t)sizeof(whMessageKeystore_DataWrapRequest) +
                        "WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE too large for "
                        "WOLFHSM_CFG_COMM_DATA_LEN");
 
+/* The unwrap request carries the wrap header on top of the maximum plaintext */
 WH_UTILS_STATIC_ASSERT((uint32_t)sizeof(whMessageKeystore_DataUnwrapRequest) +
-                               (uint32_t)WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE <=
+                               (uint32_t)WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE +
+                               (uint32_t)WH_KEYWRAP_AES_GCM_HEADER_SIZE <=
                            (uint32_t)WOLFHSM_CFG_COMM_DATA_LEN,
                        "WOLFHSM_CFG_KEYWRAP_MAX_DATA_SIZE too large for "
                        "WOLFHSM_CFG_COMM_DATA_LEN");


### PR DESCRIPTION
  Bug fix
  - _AesGcmDataUnwrapWithKek decrypts into a staging plainData[] instead of dataOut, which overlapped the ciphertext in the shared comm buffer. Fixes silent corruption of any wh_Client_DataUnwrap payload >= 32 bytes.
  - Added encBlobSz > dataSz bound check.

  Data wrap restructure
  - _AesGcmDataWrapWithKek now stages into plainData[] and rejects dataSz > MAX_DATA_SIZE, so the helper owns the no-alias requirement rather than trusting callers.
  - _HandleDataWrapRequest drops its 2 KB data[] and uses reqData directly.
  - Both data helpers ForceZero the staging buffer and return the wolfSSL error instead of discarding it.

  Stack buffers removed (~6 KB)
  - _HandleKeyWrapRequest: key[] becomes a pointer into reqData.
  - _HandleKeyUnwrapAndCacheRequest: key[] becomes a pointer into reqData. Scrub now uses keySz, since sizeof on a pointer would have wiped only 8 bytes.
  - _HandleKeyWrapExportRequest: key[] reads into respData. keySz bounded by min(respDataSz, MAX_KEY_SIZE), and the scrub is failure-only so it cannot clobber the wrapped output.

  Tests
  - Added a data wrap/unwrap round-trip sweep over sizes 1 to 128, spanning the AES block boundary.
  - Enlarged the two legacy data-wrap payloads from 14 to 63 bytes. The old sub-block payload is why the corruption went unnoticed.