### PR TITLE
benchmark string fix to save RAM

### DIFF
--- a/benchmark/wh_bench_ops.c
+++ b/benchmark/wh_bench_ops.c
@@ -94,8 +94,7 @@ int wh_Bench_RegisterOp(whBenchOpContext* ctx, const char* name,
 
     /* Check if operation with this name already exists */
     for (i = 0; i < ctx->opCount; i++) {
-        if (ctx->ops[i].valid &&
-            strncmp(ctx->ops[i].name, name, sizeof((ctx->ops[i].name))) == 0) {
+        if (ctx->ops[i].valid && strcmp(ctx->ops[i].name, name) == 0) {
             *id = i;
             return WH_ERROR_OK; /* Operation already registered */
         }
@@ -108,8 +107,7 @@ int wh_Bench_RegisterOp(whBenchOpContext* ctx, const char* name,
 
     /* Register the new operation */
     *id = ctx->opCount;
-    strncpy(ctx->ops[*id].name, name, MAX_OP_NAME - 1);
-    ctx->ops[*id].name[MAX_OP_NAME - 1] = '\0'; /* Ensure null termination */
+    ctx->ops[*id].name                  = name;
     ctx->ops[*id].valid                 = 1;
     ctx->ops[*id].inProgress            = 0;
     ctx->ops[*id].totalTimeUs           = 0;

--- a/benchmark/wh_bench_ops.c
+++ b/benchmark/wh_bench_ops.c
@@ -413,6 +413,11 @@ int wh_Bench_Cleanup(whBenchOpContext* ctx)
         return WH_ERROR_BADARGS;
     }
 
+    /* Clear the caller's ops array so no name pointers outlive cleanup */
+    if ((ctx->ops != NULL) && (ctx->maxOps > 0)) {
+        memset(ctx->ops, 0, (size_t)ctx->maxOps * sizeof(*ctx->ops));
+    }
+
     /* Clear benchmark context */
     memset(ctx, 0, sizeof(whBenchOpContext));
 

--- a/benchmark/wh_bench_ops.h
+++ b/benchmark/wh_bench_ops.h
@@ -25,9 +25,6 @@
 
 #include <stdint.h>
 
-/* Maximum length of operation name */
-#define MAX_OP_NAME 64
-
 /* Throughput metric types */
 typedef enum {
     BENCH_THROUGHPUT_NONE, /* No throughput calculation */
@@ -47,8 +44,9 @@ typedef enum {
 } whBenchTransportType;
 
 typedef struct whBenchOp {
-    /* Name of the operation being timed */
-    char name[MAX_OP_NAME];
+    /* Name of the operation being timed. Stored by reference: the string
+     * must stay valid until wh_Bench_Cleanup */
+    const char* name;
     /* Is this a valid benchmark entry */
     int valid;
     /* Is this operation currently in progress? */
@@ -86,7 +84,9 @@ typedef struct whBenchOpContext {
  * registered operations, which must stay valid until wh_Bench_Cleanup. */
 int wh_Bench_Init(whBenchOpContext* ctx, whBenchOp* ops, int maxOps);
 
-/* Register a new benchmark operation with a name, returns ID via pointer */
+/* Register a new benchmark operation with a name, returns ID via pointer.
+ * The name is stored by reference and must stay valid until
+ * wh_Bench_Cleanup */
 int wh_Bench_RegisterOp(whBenchOpContext* ctx, const char* name,
                         whBenchOpThroughputType tpType, int* id);
 


### PR DESCRIPTION


This PR reduces RAM usage in the benchmark timing subsystem by changing benchmark operation names from an inline fixed-size buffer to a referenced string pointer.

Changes:

    Replace whBenchOp.name fixed-size char[] storage with a const char* stored by reference.
    Update wh_Bench_RegisterOp to compare names with strcmp and store the pointer directly.
    Update header comments to document the new name lifetime requirement.
