### PR TITLE
fenrir fixes

### DIFF
--- a/docs/src/5-Features.md
+++ b/docs/src/5-Features.md
@@ -668,7 +668,7 @@ The SHE extension is independent of the rest of the crypto API: a server can be 
 The SHE client API is declared in `wolfhsm/wh_client_she.h` and maps one-to-one onto the AUTOSAR SHE command set. Each spec command is exposed as a `wh_Client_She*` function, with the same `Request` / `Response` split-transaction variants that the rest of the wolfHSM client API uses (see [Blocking and Non-Blocking Interfaces](#blocking-and-non-blocking-interfaces)). The full set comprises:
 
 - **Secure boot**: `wh_Client_SheSecureBoot` (`CMD_SECURE_BOOT`) — drives the three-phase INIT/UPDATE/FINISH state machine and reports the boot result through the status register
-- **Key update**: `wh_Client_SheLoadKey` (`CMD_LOAD_KEY`) — performs the encrypted M1–M5 key update protocol against any slot other than `RAM_KEY`
+- **Key update**: `wh_Client_SheLoadKey` (`CMD_LOAD_KEY`) — performs the encrypted M1–M5 key update protocol; the allowed target/authorization slot pairings are listed under [Update Authorization Policy](#update-authorization-policy)
 - **Plain key update**: `wh_Client_SheLoadPlainKey` (`CMD_LOAD_PLAIN_KEY`) and `wh_Client_SheExportRamKey` (`CMD_EXPORT_RAM_KEY`) — load the volatile `RAM_KEY` directly, and export it as an M1–M5 blob bound to the master ECU key for transfer to a peer
 - **PRNG**: `wh_Client_SheInitRnd` (`CMD_INIT_RNG`), `wh_Client_SheRnd` (`CMD_RND`), and `wh_Client_SheExtendSeed` (`CMD_EXTEND_SEED`) — initialize, draw from, and reseed the spec's deterministic PRNG
 - **Bulk crypto**: `wh_Client_SheEncEcb` / `wh_Client_SheEncCbc` / `wh_Client_SheDecEcb` / `wh_Client_SheDecCbc` (`CMD_ENC_*` / `CMD_DEC_*`) — AES-ECB and AES-CBC encrypt and decrypt against a selected key slot
@@ -756,13 +756,18 @@ The server-side handler enforces all of the spec's update constraints in additio
 Beyond requiring the authorization key to exist, wolfHSM enforces the SHE **memory update policy** (AUTOSAR SHE Table 4.5), which restricts *which* slot may authorize an update to *which* target. The target (KID) and authorization (AID) slot IDs are checked against the policy before any key material is read, and a disallowed pairing is rejected with `WH_SHE_ERC_KEY_INVALID`. The rules are:
 
 - **`MASTER_ECU_KEY`** may authorize an update to any updatable slot since it is the ECU owner's re-keying authority.
-- **`KEY_4`…`KEY_13`** may each be updated by `MASTER_ECU_KEY` or by the same key (rotation), but never by a *different* user key.
+- **`KEY_4`…`KEY_13`** (the spec's `KEY_1`…`KEY_10`, named here by slot ID) may each be updated by `MASTER_ECU_KEY` or by the same key (rotation), but never by a *different* user key.
 - **`BOOT_MAC_KEY`** and **`BOOT_MAC`** may be updated by `MASTER_ECU_KEY` or `BOOT_MAC_KEY`.
-- **`RAM_KEY`** may be updated by any user key `KEY_4`…`KEY_13` (or loaded in plaintext via `CMD_LOAD_PLAIN_KEY`).
+- **`RAM_KEY`** may be updated by any user key `KEY_4`…`KEY_13`, by `SECRET_KEY` when reloading a blob produced by `CMD_EXPORT_RAM_KEY`, or loaded in plaintext via `CMD_LOAD_PLAIN_KEY`.
 - **`RAM_KEY` and `PRNG_SEED` may never serve as the authorization key.**
 - **`SECRET_KEY` and `PRNG_SEED` are not updatable** through `CMD_LOAD_KEY`, as they are provisioned by other means.
 
-wolfHSM makes one deliberate extension to this policy: **`SECRET_KEY` may authorize any load.** In a SHE module `SECRET_KEY` is a ROM key inserted at fabrication that never leaves the device and cannot be read or chosen by a client, so wolfHSM treats it as the root of trust used to provision the first `MASTER_ECU_KEY` (`SECRET_KEY` → `MASTER_ECU_KEY`), after which normal updates are authorized by `MASTER_ECU_KEY`. Because `SECRET_KEY` is unknowable to a client, permitting it as an authorization key does not create a forgery path the way `RAM_KEY` would. This is the only pairing where wolfHSM's policy is broader than the letter of Table 4.5; every other pairing follows the specification exactly.
+wolfHSM's policy is deliberately broader than the letter of Table 4.5 in two places:
+
+- **`SECRET_KEY` may authorize any load.** The table lists `SECRET_KEY` as an authorizer only for `RAM_KEY` (the `CMD_EXPORT_RAM_KEY` reload path); wolfHSM accepts it for every updatable slot and treats it as the root of trust that provisions the first `MASTER_ECU_KEY` (`SECRET_KEY` → `MASTER_ECU_KEY`), after which normal updates are authorized by `MASTER_ECU_KEY`. In a SHE module `SECRET_KEY` is a ROM key inserted at fabrication, so permitting it as an authorization key does not create a forgery path the way `RAM_KEY` would. Note that wolfHSM itself does not stop a client from writing SHE slot 0 through the NVM API (`wh_Client_ShePreProgramKey` exists precisely to provision it), so this reasoning — and the update policy as a whole — is a security boundary only when client NVM writes to the SHE key range are restricted at deployment.
+- **`MASTER_ECU_KEY` may update `RAM_KEY`.** The table's `RAM_KEY` row names only the user keys and `SECRET_KEY`, but the spec's §4.4.2.1 describes `MASTER_ECU_KEY` as able to change any of the other keys, and the pairing grants its holder nothing it does not already have.
+
+Every other pairing follows Table 4.5 exactly.
 
 ### Secure Boot
 

--- a/docs/src/5-Features.md
+++ b/docs/src/5-Features.md
@@ -751,6 +751,19 @@ The protocol uses a key derivation function based on the **Miyaguchi-Preneel** o
 
 The server-side handler enforces all of the spec's update constraints in addition to verifying M3 and decrypting M2: the new counter must be strictly greater than the previous counter for that slot (rollback protection), the existing `WRITE_PROTECT` flag must not be set, the UID in M1 must match the ECU's configured UID (unless the existing key has `WILDCARD` set and M1 carries the all-zero UID), and the authorization key referenced by the AID field in M1 must exist. Only after all of these pass is the new key written into NVM and the response constructed.
 
+#### Update Authorization Policy
+
+Beyond requiring the authorization key to exist, wolfHSM enforces the SHE **memory update policy** (AUTOSAR SHE Table 4.5), which restricts *which* slot may authorize an update to *which* target. The target (KID) and authorization (AID) slot IDs are checked against the policy before any key material is read, and a disallowed pairing is rejected with `WH_SHE_ERC_KEY_INVALID`. The rules are:
+
+- **`MASTER_ECU_KEY`** may authorize an update to any updatable slot since it is the ECU owner's re-keying authority.
+- **`KEY_4`…`KEY_13`** may each be updated by `MASTER_ECU_KEY` or by the same key (rotation), but never by a *different* user key.
+- **`BOOT_MAC_KEY`** and **`BOOT_MAC`** may be updated by `MASTER_ECU_KEY` or `BOOT_MAC_KEY`.
+- **`RAM_KEY`** may be updated by any user key `KEY_4`…`KEY_13` (or loaded in plaintext via `CMD_LOAD_PLAIN_KEY`).
+- **`RAM_KEY` and `PRNG_SEED` may never serve as the authorization key.**
+- **`SECRET_KEY` and `PRNG_SEED` are not updatable** through `CMD_LOAD_KEY`, as they are provisioned by other means.
+
+wolfHSM makes one deliberate extension to this policy: **`SECRET_KEY` may authorize any load.** In a SHE module `SECRET_KEY` is a ROM key inserted at fabrication that never leaves the device and cannot be read or chosen by a client, so wolfHSM treats it as the root of trust used to provision the first `MASTER_ECU_KEY` (`SECRET_KEY` → `MASTER_ECU_KEY`), after which normal updates are authorized by `MASTER_ECU_KEY`. Because `SECRET_KEY` is unknowable to a client, permitting it as an authorization key does not create a forgery path the way `RAM_KEY` would. This is the only pairing where wolfHSM's policy is broader than the letter of Table 4.5; every other pairing follows the specification exactly.
+
 ### Secure Boot
 
 SHE secure boot is implemented as a three-phase state machine that the client drives via `CMD_SECURE_BOOT`:

--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -10121,7 +10121,7 @@ int wh_Client_MlDsaExportPublicKey(whClientContext* ctx, whKeyId keyId,
                                    uint8_t* label)
 {
     int      ret;
-    byte     buffer[MLDSA_MAX_BOTH_KEY_DER_SIZE] = {0};
+    byte     buffer[MAX_PUBLIC_KEY_SZ] = {0};
     uint16_t buffer_len = sizeof(buffer);
 
     if ((ctx == NULL) || WH_KEYID_ISERASED(keyId) || (key == NULL)) {

--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -6844,7 +6844,19 @@ int wh_Client_Sha256FinalResponse(whClientContext* ctx, wc_Sha256* sha,
 int wh_Client_Sha256(whClientContext* ctx, wc_Sha256* sha256, const uint8_t* in,
                      uint32_t inLen, uint8_t* out)
 {
-    int ret = WH_ERROR_OK;
+    int       ret = WH_ERROR_OK;
+    wc_Sha256 saved;
+
+    if (sha256 == NULL) {
+        return WH_ERROR_BADARGS;
+    }
+    /* Snapshot the full hash state before offloading. A server without SHA-256
+     * answers NOT_COMPILED_IN, which wolfCrypt maps to CRYPTOCB_UNAVAILABLE and
+     * re-hashes the same input in software. The update helpers mutate the
+     * partial-block buffer before sending and only roll back on a send failure,
+     * so restore on any error to keep the software fallback from absorbing the
+     * buffered bytes a second time and corrupting the digest. */
+    saved = *sha256;
 
     /* Caller invoked SHA Update:
      * wc_CryptoCb_Sha256Hash(sha256, data, len, NULL) */
@@ -6882,6 +6894,10 @@ int wh_Client_Sha256(whClientContext* ctx, wc_Sha256* sha256, const uint8_t* in,
                 ret = wh_Client_Sha256FinalResponse(ctx, sha256, out);
             } while (ret == WH_ERROR_NOTREADY);
         }
+    }
+
+    if (ret != WH_ERROR_OK) {
+        *sha256 = saved;
     }
 
     return ret;
@@ -7171,7 +7187,16 @@ int wh_Client_Sha256DmaFinalResponse(whClientContext* ctx, wc_Sha256* sha,
 int wh_Client_Sha256Dma(whClientContext* ctx, wc_Sha256* sha, const uint8_t* in,
                         uint32_t inLen, uint8_t* out)
 {
-    int ret = WH_ERROR_OK;
+    int       ret = WH_ERROR_OK;
+    wc_Sha256 saved;
+
+    if (sha == NULL) {
+        return WH_ERROR_BADARGS;
+    }
+    /* Snapshot so a failed offload (e.g. server without SHA-256 answering
+     * NOT_COMPILED_IN, which wolfCrypt maps to CRYPTOCB_UNAVAILABLE) cannot
+     * leave buffered bytes for the software fallback to absorb twice. */
+    saved = *sha;
 
     if (in != NULL && inLen > 0) {
         bool sent = false;
@@ -7189,6 +7214,9 @@ int wh_Client_Sha256Dma(whClientContext* ctx, wc_Sha256* sha, const uint8_t* in,
                 ret = wh_Client_Sha256DmaFinalResponse(ctx, sha, out);
             } while (ret == WH_ERROR_NOTREADY);
         }
+    }
+    if (ret != WH_ERROR_OK) {
+        *sha = saved;
     }
     return ret;
 }
@@ -7447,7 +7475,16 @@ int wh_Client_Sha224FinalResponse(whClientContext* ctx, wc_Sha224* sha,
 int wh_Client_Sha224(whClientContext* ctx, wc_Sha224* sha224, const uint8_t* in,
                      uint32_t inLen, uint8_t* out)
 {
-    int ret = WH_ERROR_OK;
+    int       ret = WH_ERROR_OK;
+    wc_Sha224 saved;
+
+    if (sha224 == NULL) {
+        return WH_ERROR_BADARGS;
+    }
+    /* Snapshot so a failed offload (e.g. server without SHA-224 answering
+     * NOT_COMPILED_IN, which wolfCrypt maps to CRYPTOCB_UNAVAILABLE) cannot
+     * leave buffered bytes for the software fallback to absorb twice. */
+    saved = *sha224;
 
     /* Caller invoked SHA Update:
      * wc_CryptoCb_Sha224Hash(sha224, data, len, NULL) */
@@ -7485,6 +7522,10 @@ int wh_Client_Sha224(whClientContext* ctx, wc_Sha224* sha224, const uint8_t* in,
                 ret = wh_Client_Sha224FinalResponse(ctx, sha224, out);
             } while (ret == WH_ERROR_NOTREADY);
         }
+    }
+
+    if (ret != WH_ERROR_OK) {
+        *sha224 = saved;
     }
 
     return ret;
@@ -7756,7 +7797,16 @@ int wh_Client_Sha224DmaFinalResponse(whClientContext* ctx, wc_Sha224* sha,
 int wh_Client_Sha224Dma(whClientContext* ctx, wc_Sha224* sha, const uint8_t* in,
                         uint32_t inLen, uint8_t* out)
 {
-    int ret = WH_ERROR_OK;
+    int       ret = WH_ERROR_OK;
+    wc_Sha224 saved;
+
+    if (sha == NULL) {
+        return WH_ERROR_BADARGS;
+    }
+    /* Snapshot so a failed offload (e.g. server without SHA-224 answering
+     * NOT_COMPILED_IN, which wolfCrypt maps to CRYPTOCB_UNAVAILABLE) cannot
+     * leave buffered bytes for the software fallback to absorb twice. */
+    saved = *sha;
 
     if (in != NULL && inLen > 0) {
         bool sent = false;
@@ -7774,6 +7824,9 @@ int wh_Client_Sha224Dma(whClientContext* ctx, wc_Sha224* sha, const uint8_t* in,
                 ret = wh_Client_Sha224DmaFinalResponse(ctx, sha, out);
             } while (ret == WH_ERROR_NOTREADY);
         }
+    }
+    if (ret != WH_ERROR_OK) {
+        *sha = saved;
     }
     return ret;
 }
@@ -8034,7 +8087,16 @@ int wh_Client_Sha384FinalResponse(whClientContext* ctx, wc_Sha384* sha,
 int wh_Client_Sha384(whClientContext* ctx, wc_Sha384* sha384, const uint8_t* in,
                      uint32_t inLen, uint8_t* out)
 {
-    int ret = WH_ERROR_OK;
+    int       ret = WH_ERROR_OK;
+    wc_Sha384 saved;
+
+    if (sha384 == NULL) {
+        return WH_ERROR_BADARGS;
+    }
+    /* Snapshot so a failed offload (e.g. server without SHA-384 answering
+     * NOT_COMPILED_IN, which wolfCrypt maps to CRYPTOCB_UNAVAILABLE) cannot
+     * leave buffered bytes for the software fallback to absorb twice. */
+    saved = *sha384;
 
     /* Caller invoked SHA Update:
      * wc_CryptoCb_Sha384Hash(sha384, data, len, NULL) */
@@ -8072,6 +8134,10 @@ int wh_Client_Sha384(whClientContext* ctx, wc_Sha384* sha384, const uint8_t* in,
                 ret = wh_Client_Sha384FinalResponse(ctx, sha384, out);
             } while (ret == WH_ERROR_NOTREADY);
         }
+    }
+
+    if (ret != WH_ERROR_OK) {
+        *sha384 = saved;
     }
 
     return ret;
@@ -8345,7 +8411,16 @@ int wh_Client_Sha384DmaFinalResponse(whClientContext* ctx, wc_Sha384* sha,
 int wh_Client_Sha384Dma(whClientContext* ctx, wc_Sha384* sha, const uint8_t* in,
                         uint32_t inLen, uint8_t* out)
 {
-    int ret = WH_ERROR_OK;
+    int       ret = WH_ERROR_OK;
+    wc_Sha384 saved;
+
+    if (sha == NULL) {
+        return WH_ERROR_BADARGS;
+    }
+    /* Snapshot so a failed offload (e.g. server without SHA-384 answering
+     * NOT_COMPILED_IN, which wolfCrypt maps to CRYPTOCB_UNAVAILABLE) cannot
+     * leave buffered bytes for the software fallback to absorb twice. */
+    saved = *sha;
 
     if (in != NULL && inLen > 0) {
         bool sent = false;
@@ -8363,6 +8438,9 @@ int wh_Client_Sha384Dma(whClientContext* ctx, wc_Sha384* sha, const uint8_t* in,
                 ret = wh_Client_Sha384DmaFinalResponse(ctx, sha, out);
             } while (ret == WH_ERROR_NOTREADY);
         }
+    }
+    if (ret != WH_ERROR_OK) {
+        *sha = saved;
     }
     return ret;
 }
@@ -8652,7 +8730,16 @@ int wh_Client_Sha512FinalResponse(whClientContext* ctx, wc_Sha512* sha,
 int wh_Client_Sha512(whClientContext* ctx, wc_Sha512* sha512, const uint8_t* in,
                      uint32_t inLen, uint8_t* out)
 {
-    int ret = WH_ERROR_OK;
+    int       ret = WH_ERROR_OK;
+    wc_Sha512 saved;
+
+    if (sha512 == NULL) {
+        return WH_ERROR_BADARGS;
+    }
+    /* Snapshot so a failed offload (e.g. server without SHA-512 answering
+     * NOT_COMPILED_IN, which wolfCrypt maps to CRYPTOCB_UNAVAILABLE) cannot
+     * leave buffered bytes for the software fallback to absorb twice. */
+    saved = *sha512;
 
     /* Caller invoked SHA Update:
      * wc_CryptoCb_Sha512Hash(sha512, data, len, NULL) */
@@ -8690,6 +8777,10 @@ int wh_Client_Sha512(whClientContext* ctx, wc_Sha512* sha512, const uint8_t* in,
                 ret = wh_Client_Sha512FinalResponse(ctx, sha512, out);
             } while (ret == WH_ERROR_NOTREADY);
         }
+    }
+
+    if (ret != WH_ERROR_OK) {
+        *sha512 = saved;
     }
 
     return ret;
@@ -8996,7 +9087,16 @@ int wh_Client_Sha512DmaFinalResponse(whClientContext* ctx, wc_Sha512* sha,
 int wh_Client_Sha512Dma(whClientContext* ctx, wc_Sha512* sha, const uint8_t* in,
                         uint32_t inLen, uint8_t* out)
 {
-    int ret = WH_ERROR_OK;
+    int       ret = WH_ERROR_OK;
+    wc_Sha512 saved;
+
+    if (sha == NULL) {
+        return WH_ERROR_BADARGS;
+    }
+    /* Snapshot so a failed offload (e.g. server without SHA-512 answering
+     * NOT_COMPILED_IN, which wolfCrypt maps to CRYPTOCB_UNAVAILABLE) cannot
+     * leave buffered bytes for the software fallback to absorb twice. */
+    saved = *sha;
 
     if (in != NULL && inLen > 0) {
         bool sent = false;
@@ -9014,6 +9114,9 @@ int wh_Client_Sha512Dma(whClientContext* ctx, wc_Sha512* sha, const uint8_t* in,
                 ret = wh_Client_Sha512DmaFinalResponse(ctx, sha, out);
             } while (ret == WH_ERROR_NOTREADY);
         }
+    }
+    if (ret != WH_ERROR_OK) {
+        *sha = saved;
     }
     return ret;
 }

--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -10140,7 +10140,10 @@ int wh_Client_MlDsaExportPublicKey(whClientContext* ctx, whKeyId keyId,
                                    uint8_t* label)
 {
     int      ret;
-    byte     buffer[MAX_PUBLIC_KEY_SZ] = {0};
+    /* Size the staging buffer with the ML-DSA DER bound, matching the ML-DSA
+     * export and DMA counterparts. MAX_PUBLIC_KEY_SZ already covers this when
+     * ML-DSA is enabled, but the ML-DSA-specific bound is self-documenting. */
+    byte     buffer[MLDSA_MAX_BOTH_KEY_DER_SIZE] = {0};
     uint16_t buffer_len = sizeof(buffer);
 
     if ((ctx == NULL) || WH_KEYID_ISERASED(keyId) || (key == NULL)) {

--- a/src/wh_client_crypto.c
+++ b/src/wh_client_crypto.c
@@ -6850,12 +6850,7 @@ int wh_Client_Sha256(whClientContext* ctx, wc_Sha256* sha256, const uint8_t* in,
     if (sha256 == NULL) {
         return WH_ERROR_BADARGS;
     }
-    /* Snapshot the full hash state before offloading. A server without SHA-256
-     * answers NOT_COMPILED_IN, which wolfCrypt maps to CRYPTOCB_UNAVAILABLE and
-     * re-hashes the same input in software. The update helpers mutate the
-     * partial-block buffer before sending and only roll back on a send failure,
-     * so restore on any error to keep the software fallback from absorbing the
-     * buffered bytes a second time and corrupting the digest. */
+    /* Save state to restore on error for software fallback. */
     saved = *sha256;
 
     /* Caller invoked SHA Update:
@@ -7193,9 +7188,7 @@ int wh_Client_Sha256Dma(whClientContext* ctx, wc_Sha256* sha, const uint8_t* in,
     if (sha == NULL) {
         return WH_ERROR_BADARGS;
     }
-    /* Snapshot so a failed offload (e.g. server without SHA-256 answering
-     * NOT_COMPILED_IN, which wolfCrypt maps to CRYPTOCB_UNAVAILABLE) cannot
-     * leave buffered bytes for the software fallback to absorb twice. */
+    /* Save state to restore on error for software fallback. */
     saved = *sha;
 
     if (in != NULL && inLen > 0) {
@@ -7481,9 +7474,7 @@ int wh_Client_Sha224(whClientContext* ctx, wc_Sha224* sha224, const uint8_t* in,
     if (sha224 == NULL) {
         return WH_ERROR_BADARGS;
     }
-    /* Snapshot so a failed offload (e.g. server without SHA-224 answering
-     * NOT_COMPILED_IN, which wolfCrypt maps to CRYPTOCB_UNAVAILABLE) cannot
-     * leave buffered bytes for the software fallback to absorb twice. */
+    /* Save state to restore on error for software fallback. */
     saved = *sha224;
 
     /* Caller invoked SHA Update:
@@ -7803,9 +7794,7 @@ int wh_Client_Sha224Dma(whClientContext* ctx, wc_Sha224* sha, const uint8_t* in,
     if (sha == NULL) {
         return WH_ERROR_BADARGS;
     }
-    /* Snapshot so a failed offload (e.g. server without SHA-224 answering
-     * NOT_COMPILED_IN, which wolfCrypt maps to CRYPTOCB_UNAVAILABLE) cannot
-     * leave buffered bytes for the software fallback to absorb twice. */
+    /* Save state to restore on error for software fallback. */
     saved = *sha;
 
     if (in != NULL && inLen > 0) {
@@ -8093,9 +8082,7 @@ int wh_Client_Sha384(whClientContext* ctx, wc_Sha384* sha384, const uint8_t* in,
     if (sha384 == NULL) {
         return WH_ERROR_BADARGS;
     }
-    /* Snapshot so a failed offload (e.g. server without SHA-384 answering
-     * NOT_COMPILED_IN, which wolfCrypt maps to CRYPTOCB_UNAVAILABLE) cannot
-     * leave buffered bytes for the software fallback to absorb twice. */
+    /* Save state to restore on error for software fallback. */
     saved = *sha384;
 
     /* Caller invoked SHA Update:
@@ -8417,9 +8404,7 @@ int wh_Client_Sha384Dma(whClientContext* ctx, wc_Sha384* sha, const uint8_t* in,
     if (sha == NULL) {
         return WH_ERROR_BADARGS;
     }
-    /* Snapshot so a failed offload (e.g. server without SHA-384 answering
-     * NOT_COMPILED_IN, which wolfCrypt maps to CRYPTOCB_UNAVAILABLE) cannot
-     * leave buffered bytes for the software fallback to absorb twice. */
+    /* Save state to restore on error for software fallback. */
     saved = *sha;
 
     if (in != NULL && inLen > 0) {
@@ -8736,9 +8721,7 @@ int wh_Client_Sha512(whClientContext* ctx, wc_Sha512* sha512, const uint8_t* in,
     if (sha512 == NULL) {
         return WH_ERROR_BADARGS;
     }
-    /* Snapshot so a failed offload (e.g. server without SHA-512 answering
-     * NOT_COMPILED_IN, which wolfCrypt maps to CRYPTOCB_UNAVAILABLE) cannot
-     * leave buffered bytes for the software fallback to absorb twice. */
+    /* Save state to restore on error for software fallback. */
     saved = *sha512;
 
     /* Caller invoked SHA Update:
@@ -9093,9 +9076,7 @@ int wh_Client_Sha512Dma(whClientContext* ctx, wc_Sha512* sha, const uint8_t* in,
     if (sha == NULL) {
         return WH_ERROR_BADARGS;
     }
-    /* Snapshot so a failed offload (e.g. server without SHA-512 answering
-     * NOT_COMPILED_IN, which wolfCrypt maps to CRYPTOCB_UNAVAILABLE) cannot
-     * leave buffered bytes for the software fallback to absorb twice. */
+    /* Save state to restore on error for software fallback. */
     saved = *sha;
 
     if (in != NULL && inLen > 0) {
@@ -10140,9 +10121,6 @@ int wh_Client_MlDsaExportPublicKey(whClientContext* ctx, whKeyId keyId,
                                    uint8_t* label)
 {
     int      ret;
-    /* Size the staging buffer with the ML-DSA DER bound, matching the ML-DSA
-     * export and DMA counterparts. MAX_PUBLIC_KEY_SZ already covers this when
-     * ML-DSA is enabled, but the ML-DSA-specific bound is self-documenting. */
     byte     buffer[MLDSA_MAX_BOTH_KEY_DER_SIZE] = {0};
     uint16_t buffer_len = sizeof(buffer);
 

--- a/src/wh_server.c
+++ b/src/wh_server.c
@@ -156,6 +156,9 @@ int wh_Server_Init(whServerContext* server, whServerConfig* config)
     if (NULL != config->dmaConfig) {
         server->dma.dmaAddrAllowList = config->dmaConfig->dmaAddrAllowList;
         server->dma.cb               = config->dmaConfig->cb;
+#ifdef WOLFHSM_CFG_DMA_CUSTOM_CLIENT_COPY
+        server->dma.memCopyCb        = config->dmaConfig->memCopyCb;
+#endif /* WOLFHSM_CFG_DMA_CUSTOM_CLIENT_COPY */
     }
 #endif /* WOLFHSM_CFG_DMA */
 

--- a/src/wh_server_dma.c
+++ b/src/wh_server_dma.c
@@ -190,8 +190,9 @@ int whServerDma_CopyToClient(struct whServerContext_t* server,
     /* Perform the actual copy */
 #ifdef WOLFHSM_CFG_DMA_CUSTOM_CLIENT_COPY
     if (server->dma.memCopyCb != NULL) {
-        rc = server->dma.memCopyCb(server, clientAddr, (uintptr_t)serverPtr,
-                                   len, WH_DMA_COPY_OPER_CLIENT_WRITE, flags);
+        rc = server->dma.memCopyCb(server, (uintptr_t)transformedAddr,
+                                   (uintptr_t)serverPtr, len,
+                                   WH_DMA_COPY_OPER_CLIENT_WRITE, flags);
         if (rc != WH_ERROR_OK) {
             return rc;
         }

--- a/src/wh_server_keystore.c
+++ b/src/wh_server_keystore.c
@@ -1407,15 +1407,24 @@ int wh_Server_KeystoreRevokeKey(whServerContext* server, whNvmId keyId)
         return WH_ERROR_OK;
     }
 
-    /* Revoke the key by updating its metadata */
-    _revokeKey(cacheMeta);
-    /* commit the changes */
     if (isInNvm) {
-        ret = wh_Nvm_AddObjectWithReclaim(server->nvm, cacheMeta,
-                                          cacheMeta->len, cacheBuf);
+        /* Persist the revocation from a temporary copy so a failed NVM write
+         * leaves the cached metadata and committed state untouched. Mutating
+         * the cache first would leave it revoked and committed while NVM still
+         * holds a usable key, and a retry would early-return success above
+         * without ever re-persisting. */
+        whNvmMetadata revokedMeta = *cacheMeta;
+        _revokeKey(&revokedMeta);
+        ret = wh_Nvm_AddObjectWithReclaim(server->nvm, &revokedMeta,
+                                          revokedMeta.len, cacheBuf);
         if (ret == WH_ERROR_OK) {
+            _revokeKey(cacheMeta);
             _MarkKeyCommitted(_GetCacheContext(server, keyId), keyId, 1);
         }
+    }
+    else {
+        /* No NVM copy: the cache is the only store, so revoke it directly. */
+        _revokeKey(cacheMeta);
     }
 
     return ret;

--- a/src/wh_server_keystore.c
+++ b/src/wh_server_keystore.c
@@ -1408,7 +1408,8 @@ int wh_Server_KeystoreRevokeKey(whServerContext* server, whNvmId keyId)
     }
 
     if (isInNvm) {
-        /* Persist revocation before updating cache to keep state consistent on failure. */
+        /* Persist revocation before updating cache to keep state consistent
+         * on failure. */
         whNvmMetadata revokedMeta = *cacheMeta;
         _revokeKey(&revokedMeta);
         ret = wh_Nvm_AddObjectWithReclaim(server->nvm, &revokedMeta,

--- a/src/wh_server_keystore.c
+++ b/src/wh_server_keystore.c
@@ -1408,11 +1408,7 @@ int wh_Server_KeystoreRevokeKey(whServerContext* server, whNvmId keyId)
     }
 
     if (isInNvm) {
-        /* Persist the revocation from a temporary copy so a failed NVM write
-         * leaves the cached metadata and committed state untouched. Mutating
-         * the cache first would leave it revoked and committed while NVM still
-         * holds a usable key, and a retry would early-return success above
-         * without ever re-persisting. */
+        /* Persist revocation before updating cache to keep state consistent on failure. */
         whNvmMetadata revokedMeta = *cacheMeta;
         _revokeKey(&revokedMeta);
         ret = wh_Nvm_AddObjectWithReclaim(server->nvm, &revokedMeta,
@@ -1423,7 +1419,6 @@ int wh_Server_KeystoreRevokeKey(whServerContext* server, whNvmId keyId)
         }
     }
     else {
-        /* No NVM copy: the cache is the only store, so revoke it directly. */
         _revokeKey(cacheMeta);
     }
 

--- a/src/wh_server_she.c
+++ b/src/wh_server_she.c
@@ -74,7 +74,7 @@ static int      _AesMp16(whServerContext* server, uint8_t* in, word32 inSz,
 static uint16_t _PopAuthId(uint8_t* messageOne);
 static uint16_t _PopId(uint8_t* messageOne);
 static uint32_t _PopFlags(uint8_t* messageTwo);
-static int      _SheAuthRank(uint16_t sheSlot);
+static int      _SheIsAppKey(uint16_t sheSlot);
 static int      _CheckLoadKeyAuth(uint16_t targetId, uint16_t authId);
 static int _SetUid(whServerContext* server, uint16_t magic, uint16_t req_size,
                    const void* req_packet, uint16_t* out_resp_size,
@@ -258,34 +258,62 @@ static uint32_t _PopFlags(uint8_t* messageTwo)
     return (((messageTwo[3] & 0x0f) << 4) | ((messageTwo[4] & 0x80) >> 7));
 }
 
-/* Return SHE key authorization rank, where higher ranks can authorize lower ranks.
- * RAM_KEY and PRNG_SEED are rank 0 and cannot authorize updates. */
-static int _SheAuthRank(uint16_t sheSlot)
+/* True for the general-purpose application key slots KEY_1..KEY_N, which sit
+ * between the boot slots and the volatile RAM_KEY. */
+static int _SheIsAppKey(uint16_t sheSlot)
 {
-    switch (sheSlot) {
-        case WH_SHE_SECRET_KEY_ID:
-            return 3;
-        case WH_SHE_MASTER_ECU_KEY_ID:
-            return 2;
-        case WH_SHE_RAM_KEY_ID:
-        case WH_SHE_PRNG_SEED_ID:
-            return 0;
-        default:
-            /* BOOT_MAC_KEY, BOOT_MAC, and KEY_1..KEY_N */
-            return 1;
-    }
+    return (sheSlot > WH_SHE_BOOT_MAC) && (sheSlot < WH_SHE_RAM_KEY_ID);
 }
 
-/* Verify the authorizing slot outranks or matches the target slot.
- * Returns 0 on success, or WH_SHE_ERC_KEY_INVALID if unauthorized. */
+/* Check that the authorizing slot may update the target slot, before any key
+ * material is read. This enforces the SHE memory update policy (AUTOSAR SHE
+ * Table 4.5), with one documented wolfHSM extension: SECRET_KEY, the ROM root
+ * of trust, may authorize any load so it can provision MASTER_ECU_KEY.
+ * Returns 0 when allowed, WH_SHE_ERC_KEY_INVALID otherwise. */
 static int _CheckLoadKeyAuth(uint16_t targetId, uint16_t authId)
 {
-    int authRank = _SheAuthRank(authId);
+    /* SECRET_KEY and PRNG_SEED are not updatable through LOAD_KEY. */
+    if ((targetId == WH_SHE_SECRET_KEY_ID) ||
+        (targetId == WH_SHE_PRNG_SEED_ID)) {
+        return WH_SHE_ERC_KEY_INVALID;
+    }
 
-    if ((authRank > 0) &&
-        ((authRank > _SheAuthRank(targetId)) || (authId == targetId))) {
+    /* SECRET_KEY never leaves the device and a client cannot set it to a known
+     * value, so it may authorize any load. wolfHSM uses it to provision the
+     * master key. This is the one extension to the published SHE spec */
+    if (authId == WH_SHE_SECRET_KEY_ID) {
         return 0;
     }
+
+    /* MASTER_ECU_KEY may update any other slot (SHE 4.4.2.1). */
+    if (authId == WH_SHE_MASTER_ECU_KEY_ID) {
+        return 0;
+    }
+
+    /* Remaining per-target authorizers from Table 4.5 (MASTER and SECRET are
+     * already handled above). */
+    switch (targetId) {
+        case WH_SHE_BOOT_MAC_KEY_ID:
+        case WH_SHE_BOOT_MAC:
+            /* Updatable by BOOT_MAC_KEY. */
+            if (authId == WH_SHE_BOOT_MAC_KEY_ID) {
+                return 0;
+            }
+            break;
+        case WH_SHE_RAM_KEY_ID:
+            /* Updatable by any application key (or in plaintext elsewhere). */
+            if (_SheIsAppKey(authId)) {
+                return 0;
+            }
+            break;
+        default:
+            /* An application key may be rotated with the same key. */
+            if (_SheIsAppKey(targetId) && (authId == targetId)) {
+                return 0;
+            }
+            break;
+    }
+
     return WH_SHE_ERC_KEY_INVALID;
 }
 

--- a/src/wh_server_she.c
+++ b/src/wh_server_she.c
@@ -1166,6 +1166,14 @@ static int _InitRnd(whServerContext* server, uint16_t magic, uint16_t req_size,
         }
         else {
             ret = wh_Nvm_AddObject(server->nvm, meta, meta->len, cmacOutput);
+            /* Evict any auto-cached copy so a later read of PRNG_SEED returns
+             * the seed just persisted, not a stale cache entry. */
+            if (ret == 0) {
+                ret = wh_Server_KeystoreEvictKey(server, meta->id);
+                if (ret == WH_ERROR_NOTFOUND) {
+                    ret = 0;
+                }
+            }
         }
         if (ret != 0) {
             ret = WH_SHE_ERC_KEY_UPDATE_ERROR;
@@ -1309,6 +1317,14 @@ static int _ExtendSeed(whServerContext* server, uint16_t magic,
         }
         else {
             ret = wh_Nvm_AddObject(server->nvm, meta, meta->len, kdfInput);
+            /* Evict any auto-cached copy so a later read of PRNG_SEED returns
+             * the seed just persisted, not a stale cache entry. */
+            if (ret == 0) {
+                ret = wh_Server_KeystoreEvictKey(server, meta->id);
+                if (ret == WH_ERROR_NOTFOUND) {
+                    ret = 0;
+                }
+            }
         }
         if (ret != 0) {
             ret = WH_SHE_ERC_KEY_UPDATE_ERROR;

--- a/src/wh_server_she.c
+++ b/src/wh_server_she.c
@@ -278,9 +278,9 @@ static int _CheckLoadKeyAuth(uint16_t targetId, uint16_t authId)
         return WH_SHE_ERC_KEY_INVALID;
     }
 
-    /* SECRET_KEY never leaves the device and a client cannot set it to a known
-     * value, so it may authorize any load. wolfHSM uses it to provision the
-     * master key. This is the one extension to the published SHE spec */
+    /* SECRET_KEY may authorize any load. The SHE spec lists it only for RAM_KEY
+     * (reloading an exported RAM key), but wolfHSM extends it to every slot so
+     * it can provision the first MASTER_ECU_KEY */
     if (authId == WH_SHE_SECRET_KEY_ID) {
         return 0;
     }

--- a/src/wh_server_she.c
+++ b/src/wh_server_she.c
@@ -74,6 +74,8 @@ static int      _AesMp16(whServerContext* server, uint8_t* in, word32 inSz,
 static uint16_t _PopAuthId(uint8_t* messageOne);
 static uint16_t _PopId(uint8_t* messageOne);
 static uint32_t _PopFlags(uint8_t* messageTwo);
+static int      _SheAuthRank(uint16_t sheSlot);
+static int      _CheckLoadKeyAuth(uint16_t targetId, uint16_t authId);
 static int _SetUid(whServerContext* server, uint16_t magic, uint16_t req_size,
                    const void* req_packet, uint16_t* out_resp_size,
                    void* resp_packet);
@@ -254,6 +256,42 @@ static uint16_t _PopId(uint8_t* messageOne)
 static uint32_t _PopFlags(uint8_t* messageTwo)
 {
     return (((messageTwo[3] & 0x0f) << 4) | ((messageTwo[4] & 0x80) >> 7));
+}
+
+/* Privilege rank of a SHE slot for the memory-update authorization scheme.
+ * A higher rank may authorize updates to a lower rank. RAM_KEY and PRNG_SEED
+ * are rank 0 and may never authorize an update: RAM_KEY is loadable in
+ * plaintext, so treating it as an authorizer would let a client forge a valid
+ * update for any protected slot, and PRNG_SEED is not a key. */
+static int _SheAuthRank(uint16_t sheSlot)
+{
+    switch (sheSlot) {
+        case WH_SHE_SECRET_KEY_ID:
+            return 3;
+        case WH_SHE_MASTER_ECU_KEY_ID:
+            return 2;
+        case WH_SHE_RAM_KEY_ID:
+        case WH_SHE_PRNG_SEED_ID:
+            return 0;
+        default:
+            /* BOOT_MAC_KEY, BOOT_MAC, and KEY_1..KEY_N */
+            return 1;
+    }
+}
+
+/* Check that the authorizing slot may update the target slot before any key
+ * material is read. The authorizer must outrank the target or be the target
+ * itself (key rotation). Returns 0 when allowed, WH_SHE_ERC_KEY_INVALID
+ * otherwise. */
+static int _CheckLoadKeyAuth(uint16_t targetId, uint16_t authId)
+{
+    int authRank = _SheAuthRank(authId);
+
+    if ((authRank > 0) &&
+        ((authRank > _SheAuthRank(targetId)) || (authId == targetId))) {
+        return 0;
+    }
+    return WH_SHE_ERC_KEY_INVALID;
 }
 
 static int _SetUid(whServerContext* server, uint16_t magic, uint16_t req_size,
@@ -586,6 +624,14 @@ static int _LoadKey(whServerContext* server, uint16_t magic, uint16_t req_size,
     }
     if (ret == 0) {
         ret = wh_MessageShe_TranslateLoadKeyRequest(magic, req_packet, &req);
+    }
+
+    /* enforce the SHE authorization matrix before reading any key material, so
+     * a low-privilege slot (e.g. a plaintext RAM key) cannot authorize an
+     * update to a protected slot */
+    if (ret == 0) {
+        ret = _CheckLoadKeyAuth(_PopId(req.messageOne),
+                                _PopAuthId(req.messageOne));
     }
 
     /* read the auth key by AuthID */

--- a/src/wh_server_she.c
+++ b/src/wh_server_she.c
@@ -258,11 +258,8 @@ static uint32_t _PopFlags(uint8_t* messageTwo)
     return (((messageTwo[3] & 0x0f) << 4) | ((messageTwo[4] & 0x80) >> 7));
 }
 
-/* Privilege rank of a SHE slot for the memory-update authorization scheme.
- * A higher rank may authorize updates to a lower rank. RAM_KEY and PRNG_SEED
- * are rank 0 and may never authorize an update: RAM_KEY is loadable in
- * plaintext, so treating it as an authorizer would let a client forge a valid
- * update for any protected slot, and PRNG_SEED is not a key. */
+/* Return SHE key authorization rank, where higher ranks can authorize lower ranks.
+ * RAM_KEY and PRNG_SEED are rank 0 and cannot authorize updates. */
 static int _SheAuthRank(uint16_t sheSlot)
 {
     switch (sheSlot) {
@@ -279,10 +276,8 @@ static int _SheAuthRank(uint16_t sheSlot)
     }
 }
 
-/* Check that the authorizing slot may update the target slot before any key
- * material is read. The authorizer must outrank the target or be the target
- * itself (key rotation). Returns 0 when allowed, WH_SHE_ERC_KEY_INVALID
- * otherwise. */
+/* Verify the authorizing slot outranks or matches the target slot.
+ * Returns 0 on success, or WH_SHE_ERC_KEY_INVALID if unauthorized. */
 static int _CheckLoadKeyAuth(uint16_t targetId, uint16_t authId)
 {
     int authRank = _SheAuthRank(authId);
@@ -626,9 +621,7 @@ static int _LoadKey(whServerContext* server, uint16_t magic, uint16_t req_size,
         ret = wh_MessageShe_TranslateLoadKeyRequest(magic, req_packet, &req);
     }
 
-    /* enforce the SHE authorization matrix before reading any key material, so
-     * a low-privilege slot (e.g. a plaintext RAM key) cannot authorize an
-     * update to a protected slot */
+    /* Verify key update authorization. */
     if (ret == 0) {
         ret = _CheckLoadKeyAuth(_PopId(req.messageOne),
                                 _PopAuthId(req.messageOne));
@@ -1166,8 +1159,7 @@ static int _InitRnd(whServerContext* server, uint16_t magic, uint16_t req_size,
         }
         else {
             ret = wh_Nvm_AddObject(server->nvm, meta, meta->len, cmacOutput);
-            /* Evict any auto-cached copy so a later read of PRNG_SEED returns
-             * the seed just persisted, not a stale cache entry. */
+            /* Evict stale cached seed after persisting new value. */
             if (ret == 0) {
                 ret = wh_Server_KeystoreEvictKey(server, meta->id);
                 if (ret == WH_ERROR_NOTFOUND) {
@@ -1317,8 +1309,7 @@ static int _ExtendSeed(whServerContext* server, uint16_t magic,
         }
         else {
             ret = wh_Nvm_AddObject(server->nvm, meta, meta->len, kdfInput);
-            /* Evict any auto-cached copy so a later read of PRNG_SEED returns
-             * the seed just persisted, not a stale cache entry. */
+            /* Evict stale cached seed after persisting new value. */
             if (ret == 0) {
                 ret = wh_Server_KeystoreEvictKey(server, meta->id);
                 if (ret == WH_ERROR_NOTFOUND) {

--- a/test-refactor/client-server/wh_test_she.c
+++ b/test-refactor/client-server/wh_test_she.c
@@ -476,6 +476,48 @@ int whTest_She(whClientContext* client)
             ret = WH_ERROR_ABORTED;
             goto exit;
         }
+
+        /* One application key may not authorize an update to a different
+         * application key (Table 4.5: KEY_<n> only by MASTER or itself). The
+         * authorization check runs before any key material is read, so the
+         * slots need not be populated. */
+        if ((ret = wh_She_GenerateLoadableKey(
+                 10, 11, 1, 0, sheUid, vectorRawKey, vectorRawKey, messageOne,
+                 messageTwo, messageThree, messageFour, messageFive)) != 0) {
+            WH_ERROR_PRINT("Failed to generate peer-authorized M1/M2/M3 %d\n",
+                           ret);
+            goto exit;
+        }
+        ret = wh_Client_SheLoadKey(client, messageOne, messageTwo, messageThree,
+                                   outMessageFour, outMessageFive);
+        if (ret != WH_SHE_ERC_KEY_INVALID) {
+            WH_ERROR_PRINT("SHE LOAD KEY peer-authorized update: "
+                           "expected KEY_INVALID, got %d\n",
+                           ret);
+            ret = WH_ERROR_ABORTED;
+            goto exit;
+        }
+
+        /* BOOT_MAC_KEY may authorize an update to BOOT_MAC (Table 4.5): a
+         * same-privilege cross-slot update the spec allows. Rewrite the same
+         * digest so secure-boot state is unchanged. */
+        if ((ret = wh_She_GenerateLoadableKey(
+                 WH_SHE_BOOT_MAC, WH_SHE_BOOT_MAC_KEY_ID, 1, 0, sheUid,
+                 bootMacDigest, key, messageOne, messageTwo, messageThree,
+                 messageFour, messageFive)) != 0) {
+            WH_ERROR_PRINT("Failed to generate BOOT_MAC_KEY-authorized "
+                           "M1/M2/M3 %d\n",
+                           ret);
+            goto exit;
+        }
+        if ((ret = wh_Client_SheLoadKey(client, messageOne, messageTwo,
+                                        messageThree, outMessageFour,
+                                        outMessageFive)) != 0) {
+            WH_ERROR_PRINT("SHE LOAD KEY BOOT_MAC_KEY-authorized BOOT_MAC "
+                           "update: expected success, got %d\n",
+                           ret);
+            goto exit;
+        }
         WH_TEST_PRINT("SHE LOAD KEY authorization matrix SUCCESS\n");
     }
 
@@ -647,7 +689,7 @@ int whTest_She(whClientContext* client)
         goto exit;
     }
     if ((ret = wh_She_GenerateLoadableKey(
-             SHE_SIZE_CHECK_KEY_ID, SHE_OVERSIZE_AUTH_ID, 1, 0, sheUid,
+             SHE_OVERSIZE_AUTH_ID, SHE_OVERSIZE_AUTH_ID, 1, 0, sheUid,
              vectorRawKey, vectorRawKey, messageOne, messageTwo, messageThree,
              messageFour, messageFive)) != 0) {
         WH_ERROR_PRINT("Failed to generate loadable key %d\n", ret);

--- a/test-refactor/client-server/wh_test_she.c
+++ b/test-refactor/client-server/wh_test_she.c
@@ -450,10 +450,7 @@ int whTest_She(whClientContext* client)
 
     /* === Authorization matrix === */
 
-    /* A plaintext-loadable RAM key must never authorize an update to a
-     * protected slot. Load a known RAM key, then try to update MASTER_ECU_KEY
-     * authorized by it. Even though M3 is valid (the RAM key value is known
-     * here), the server must reject the unauthorized authorizer before M3. */
+    /* Verify that updating a protected slot authorized by RAM_KEY is rejected. */
     {
         uint8_t ramKey[WH_SHE_KEY_SZ];
         memset(ramKey, 0x5A, sizeof(ramKey));

--- a/test-refactor/client-server/wh_test_she.c
+++ b/test-refactor/client-server/wh_test_she.c
@@ -575,6 +575,82 @@ int whTest_She(whClientContext* client)
                            ret);
             goto exit;
         }
+        /* Application keys other than BOOT_MAC_KEY may not update the boot
+         * slots. */
+        if ((ret = wh_She_GenerateLoadableKey(
+                 WH_SHE_BOOT_MAC, SHE_TEST_VECTOR_KEY_ID, 2, 0, sheUid,
+                 bootMacDigest, vectorRawKey, messageOne, messageTwo,
+                 messageThree, messageFour, messageFive)) != 0) {
+            WH_ERROR_PRINT("Failed to generate app-key-authorized BOOT_MAC "
+                           "M1/M2/M3 %d\n",
+                           ret);
+            goto exit;
+        }
+        ret = wh_Client_SheLoadKey(client, messageOne, messageTwo, messageThree,
+                                   outMessageFour, outMessageFive);
+        if (ret != WH_SHE_ERC_KEY_INVALID) {
+            WH_ERROR_PRINT("SHE LOAD KEY app-key-authorized BOOT_MAC update: "
+                           "expected KEY_INVALID, got %d\n",
+                           ret);
+            ret = WH_ERROR_ABORTED;
+            goto exit;
+        }
+
+        /* An application key may load RAM_KEY (Table 4.5). M4/M5 come back
+         * derived from the new key, which proves the load landed. The RAM key
+         * is reloaded in plaintext before it is used again below. */
+        memset(ramKey, 0xA5, sizeof(ramKey));
+        if ((ret = wh_She_GenerateLoadableKey(
+                 WH_SHE_RAM_KEY_ID, SHE_TEST_VECTOR_KEY_ID, 1, 0, sheUid,
+                 ramKey, vectorRawKey, messageOne, messageTwo, messageThree,
+                 messageFour, messageFive)) != 0) {
+            WH_ERROR_PRINT("Failed to generate app-key-authorized RAM_KEY "
+                           "M1/M2/M3 %d\n",
+                           ret);
+            goto exit;
+        }
+        if ((ret = wh_Client_SheLoadKey(client, messageOne, messageTwo,
+                                        messageThree, outMessageFour,
+                                        outMessageFive)) != 0) {
+            WH_ERROR_PRINT("SHE LOAD KEY app-key-authorized RAM_KEY update: "
+                           "expected success, got %d\n",
+                           ret);
+            goto exit;
+        }
+        if (memcmp(outMessageFour, messageFour, sizeof(messageFour)) != 0 ||
+            memcmp(outMessageFive, messageFive, sizeof(messageFive)) != 0) {
+            WH_ERROR_PRINT("SHE LOAD KEY app-key-authorized RAM_KEY update: "
+                           "M4/M5 mismatch\n");
+            ret = WH_ERROR_ABORTED;
+            goto exit;
+        }
+
+        /* An application key may be rotated with itself as the authorizing
+         * key (Table 4.5). Reload the same material with a higher counter so
+         * only the slot's counter changes. */
+        if ((ret = wh_She_GenerateLoadableKey(
+                 SHE_TEST_VECTOR_KEY_ID, SHE_TEST_VECTOR_KEY_ID, 2, 0, sheUid,
+                 vectorRawKey, vectorRawKey, messageOne, messageTwo,
+                 messageThree, messageFour, messageFive)) != 0) {
+            WH_ERROR_PRINT("Failed to generate self-authorized M1/M2/M3 %d\n",
+                           ret);
+            goto exit;
+        }
+        if ((ret = wh_Client_SheLoadKey(client, messageOne, messageTwo,
+                                        messageThree, outMessageFour,
+                                        outMessageFive)) != 0) {
+            WH_ERROR_PRINT("SHE LOAD KEY self-authorized rotation: "
+                           "expected success, got %d\n",
+                           ret);
+            goto exit;
+        }
+        if (memcmp(outMessageFour, messageFour, sizeof(messageFour)) != 0 ||
+            memcmp(outMessageFive, messageFive, sizeof(messageFive)) != 0) {
+            WH_ERROR_PRINT("SHE LOAD KEY self-authorized rotation: "
+                           "M4/M5 mismatch\n");
+            ret = WH_ERROR_ABORTED;
+            goto exit;
+        }
         WH_TEST_PRINT("SHE LOAD KEY authorization matrix SUCCESS\n");
     }
 

--- a/test-refactor/client-server/wh_test_she.c
+++ b/test-refactor/client-server/wh_test_she.c
@@ -450,7 +450,9 @@ int whTest_She(whClientContext* client)
 
     /* === Authorization matrix === */
 
-    /* Verify that updating a protected slot authorized by RAM_KEY is rejected. */
+    /* Authorization matrix: RAM_KEY and peer application keys may not
+     * authorize updates, SECRET_KEY and PRNG_SEED may not be targets, and
+     * BOOT_MAC_KEY may update BOOT_MAC. */
     {
         uint8_t ramKey[WH_SHE_KEY_SZ];
         memset(ramKey, 0x5A, sizeof(ramKey));
@@ -492,6 +494,61 @@ int whTest_She(whClientContext* client)
                                    outMessageFour, outMessageFive);
         if (ret != WH_SHE_ERC_KEY_INVALID) {
             WH_ERROR_PRINT("SHE LOAD KEY peer-authorized update: "
+                           "expected KEY_INVALID, got %d\n",
+                           ret);
+            ret = WH_ERROR_ABORTED;
+            goto exit;
+        }
+
+        /* SECRET_KEY and PRNG_SEED are not updatable LOAD_KEY targets. */
+        if ((ret = wh_She_GenerateLoadableKey(
+                 WH_SHE_SECRET_KEY_ID, WH_SHE_MASTER_ECU_KEY_ID, 1, 0, sheUid,
+                 vectorRawKey, vectorMasterEcuKey, messageOne, messageTwo,
+                 messageThree, messageFour, messageFive)) != 0) {
+            WH_ERROR_PRINT("Failed to generate SECRET-target M1/M2/M3 %d\n",
+                           ret);
+            goto exit;
+        }
+        ret = wh_Client_SheLoadKey(client, messageOne, messageTwo, messageThree,
+                                   outMessageFour, outMessageFive);
+        if (ret != WH_SHE_ERC_KEY_INVALID) {
+            WH_ERROR_PRINT("SHE LOAD KEY SECRET_KEY target: "
+                           "expected KEY_INVALID, got %d\n",
+                           ret);
+            ret = WH_ERROR_ABORTED;
+            goto exit;
+        }
+
+        if ((ret = wh_She_GenerateLoadableKey(
+                 WH_SHE_PRNG_SEED_ID, WH_SHE_MASTER_ECU_KEY_ID, 1, 0, sheUid,
+                 vectorRawKey, vectorMasterEcuKey, messageOne, messageTwo,
+                 messageThree, messageFour, messageFive)) != 0) {
+            WH_ERROR_PRINT("Failed to generate PRNG-target M1/M2/M3 %d\n", ret);
+            goto exit;
+        }
+        ret = wh_Client_SheLoadKey(client, messageOne, messageTwo, messageThree,
+                                   outMessageFour, outMessageFive);
+        if (ret != WH_SHE_ERC_KEY_INVALID) {
+            WH_ERROR_PRINT("SHE LOAD KEY PRNG_SEED target: "
+                           "expected KEY_INVALID, got %d\n",
+                           ret);
+            ret = WH_ERROR_ABORTED;
+            goto exit;
+        }
+
+        /* RAM_KEY accepts updates from application keys only, so it may not
+         * authorize itself. */
+        if ((ret = wh_She_GenerateLoadableKey(
+                 WH_SHE_RAM_KEY_ID, WH_SHE_RAM_KEY_ID, 1, 0, sheUid,
+                 vectorRawKey, ramKey, messageOne, messageTwo, messageThree,
+                 messageFour, messageFive)) != 0) {
+            WH_ERROR_PRINT("Failed to generate RAM-target M1/M2/M3 %d\n", ret);
+            goto exit;
+        }
+        ret = wh_Client_SheLoadKey(client, messageOne, messageTwo, messageThree,
+                                   outMessageFour, outMessageFive);
+        if (ret != WH_SHE_ERC_KEY_INVALID) {
+            WH_ERROR_PRINT("SHE LOAD KEY RAM-authorized RAM_KEY update: "
                            "expected KEY_INVALID, got %d\n",
                            ret);
             ret = WH_ERROR_ABORTED;

--- a/test-refactor/client-server/wh_test_she.c
+++ b/test-refactor/client-server/wh_test_she.c
@@ -448,6 +448,40 @@ int whTest_She(whClientContext* client)
         WH_TEST_PRINT("SHE LOAD KEY UID checks SUCCESS\n");
     }
 
+    /* === Authorization matrix === */
+
+    /* A plaintext-loadable RAM key must never authorize an update to a
+     * protected slot. Load a known RAM key, then try to update MASTER_ECU_KEY
+     * authorized by it. Even though M3 is valid (the RAM key value is known
+     * here), the server must reject the unauthorized authorizer before M3. */
+    {
+        uint8_t ramKey[WH_SHE_KEY_SZ];
+        memset(ramKey, 0x5A, sizeof(ramKey));
+
+        if ((ret = wh_Client_SheLoadPlainKey(client, ramKey,
+                sizeof(ramKey))) != 0) {
+            WH_ERROR_PRINT("Failed to load plain RAM key %d\n", ret);
+            goto exit;
+        }
+        if ((ret = wh_She_GenerateLoadableKey(WH_SHE_MASTER_ECU_KEY_ID,
+                WH_SHE_RAM_KEY_ID, 2, 0, sheUid, vectorRawKey, ramKey,
+                messageOne, messageTwo, messageThree, messageFour,
+                messageFive)) != 0) {
+            WH_ERROR_PRINT("Failed to generate RAM-authorized M1/M2/M3 %d\n",
+                           ret);
+            goto exit;
+        }
+        ret = wh_Client_SheLoadKey(client, messageOne, messageTwo, messageThree,
+                outMessageFour, outMessageFive);
+        if (ret != WH_SHE_ERC_KEY_INVALID) {
+            WH_ERROR_PRINT("SHE LOAD KEY RAM-authorized MASTER_ECU update: "
+                           "expected KEY_INVALID, got %d\n", ret);
+            ret = WH_ERROR_ABORTED;
+            goto exit;
+        }
+        WH_TEST_PRINT("SHE LOAD KEY authorization matrix SUCCESS\n");
+    }
+
     /* === RND === */
 
     if ((ret = wh_Client_SheInitRnd(client)) != 0) {

--- a/test-refactor/server/wh_test_she_server.c
+++ b/test-refactor/server/wh_test_she_server.c
@@ -623,4 +623,124 @@ int whTest_SheStateGate(whServerContext* server)
     return 0;
 }
 
+/* Read the persisted PRNG_SEED, check it moved on from prevSeed, then check
+ * the keystore hands back that same value rather than a stale cached copy.
+ * Leaves the persisted seed in prevSeed for the next step. */
+static int _SheCheckSeedAdvanced(whServerContext* server, whKeyId seedId,
+                                 uint8_t* prevSeed)
+{
+    whNvmMetadata meta[1] = {{0}};
+    uint8_t       nvmSeed[WH_SHE_KEY_SZ];
+    uint8_t       readSeed[WH_SHE_KEY_SZ];
+    uint32_t      readSz = sizeof(readSeed);
+
+    WH_TEST_RETURN_ON_FAIL(
+        wh_Nvm_Read(server->nvm, seedId, 0, WH_SHE_KEY_SZ, nvmSeed));
+    WH_TEST_ASSERT_RETURN(memcmp(nvmSeed, prevSeed, WH_SHE_KEY_SZ) != 0);
+
+    WH_TEST_RETURN_ON_FAIL(
+        wh_Server_KeystoreReadKey(server, seedId, meta, readSeed, &readSz));
+    WH_TEST_ASSERT_RETURN(readSz == WH_SHE_KEY_SZ);
+    WH_TEST_ASSERT_RETURN(memcmp(readSeed, nvmSeed, WH_SHE_KEY_SZ) == 0);
+
+    memcpy(prevSeed, nvmSeed, WH_SHE_KEY_SZ);
+    return 0;
+}
+
+/* Drive INIT_RND and two EXTEND_SEEDs on a server whose NVM holds SECRET_KEY
+ * and PRNG_SEED for seedId. Each command persists a new seed, and each must
+ * drop the cached copy of the old one: otherwise EXTEND_SEED keeps deriving
+ * from the pre-INIT seed and two extends with the same entropy persist the
+ * same value. Leaves the server with rndInited set. */
+static int _ShePrngSeedFlow(whServerContext* server, whKeyId seedId,
+                            const uint8_t* initialSeed)
+{
+    int32_t       rc;
+    uint32_t      i;
+    uint8_t       prevSeed[WH_SHE_KEY_SZ];
+    uint8_t       req_packet[WOLFHSM_CFG_COMM_DATA_LEN];
+    uint8_t       resp_packet[WOLFHSM_CFG_COMM_DATA_LEN];
+    const uint8_t entropy[WH_SHE_KEY_SZ] = {0xae, 0x2d, 0x8a, 0x57, 0x1e, 0x03,
+                                            0xac, 0x9c, 0x9e, 0xb7, 0x6f, 0xac,
+                                            0x45, 0xaf, 0x8e, 0x51};
+    whMessageShe_ExtendSeedRequest* extendReq =
+        (whMessageShe_ExtendSeedRequest*)req_packet;
+
+    /* Pass the state gate without a full secure boot. */
+    server->she->uidSet  = 1;
+    server->she->sbState = TEST_SHE_SB_STATE_SUCCESS;
+
+    /* INIT_RND replaces the provisioned seed. */
+    memcpy(prevSeed, initialSeed, WH_SHE_KEY_SZ);
+    memset(req_packet, 0, sizeof(req_packet));
+    rc =
+        wh_She_SheActionRc(server, WH_SHE_INIT_RND, req_packet, 0, resp_packet);
+    WH_TEST_ASSERT_RETURN(rc == WH_SHE_ERC_NO_ERROR);
+    WH_TEST_RETURN_ON_FAIL(_SheCheckSeedAdvanced(server, seedId, prevSeed));
+
+    /* EXTEND_SEED must build on the seed INIT_RND just persisted, and the
+     * second one on the first. */
+    for (i = 0; i < 2; i++) {
+        memcpy(extendReq->entropy, entropy, sizeof(entropy));
+        rc = wh_She_SheActionRc(server, WH_SHE_EXTEND_SEED, req_packet,
+                                sizeof(*extendReq), resp_packet);
+        WH_TEST_ASSERT_RETURN(rc == WH_SHE_ERC_NO_ERROR);
+        WH_TEST_RETURN_ON_FAIL(_SheCheckSeedAdvanced(server, seedId, prevSeed));
+    }
+
+    return 0;
+}
+
+/* Server-direct check that INIT_RND and EXTEND_SEED persist the PRNG seed
+ * coherently with the key cache. See _ShePrngSeedFlow. Provisions and then
+ * removes SECRET_KEY and PRNG_SEED so nothing leaks into later groups. */
+int whTest_ShePrngSeedPersistence(whServerContext* server)
+{
+    int           ret;
+    whNvmMetadata meta[1] = {{0}};
+    whKeyId       ids[2];
+
+    /* SECRET_KEY and PRNG_SEED from the SHE test vectors */
+    uint8_t secretKey[WH_SHE_KEY_SZ] = {0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae,
+                                        0xd2, 0xa6, 0xab, 0xf7, 0x15, 0x88,
+                                        0x09, 0xcf, 0x4f, 0x3c};
+    uint8_t prngSeed[WH_SHE_KEY_SZ]  = {0x6b, 0xc1, 0xbe, 0xe2, 0x2e, 0x40,
+                                        0x9f, 0x96, 0xe9, 0x3d, 0x7e, 0x11,
+                                        0x73, 0x93, 0x17, 0x2a};
+
+    if (server == NULL) {
+        return WH_ERROR_BADARGS;
+    }
+    if (server->nvm == NULL) {
+        return WH_TEST_SKIPPED;
+    }
+
+    ids[0] = WH_SHE_MAKE_KEYID(server->comm->client_id, WH_SHE_SECRET_KEY_ID);
+    ids[1] = WH_SHE_MAKE_KEYID(server->comm->client_id, WH_SHE_PRNG_SEED_ID);
+
+    /* Provision the two keys INIT_RND reads straight into NVM. */
+    meta->len    = WH_SHE_KEY_SZ;
+    meta->access = WH_NVM_ACCESS_ANY;
+    meta->id     = ids[0];
+    WH_TEST_RETURN_ON_FAIL(
+        wh_Nvm_AddObject(server->nvm, meta, WH_SHE_KEY_SZ, secretKey));
+    meta->id = ids[1];
+    WH_TEST_RETURN_ON_FAIL(
+        wh_Nvm_AddObject(server->nvm, meta, WH_SHE_KEY_SZ, prngSeed));
+
+    ret = _ShePrngSeedFlow(server, ids[1], prngSeed);
+
+    /* Remove the provisioned keys from cache and NVM, and restore a clean SHE
+     * context so the poked state doesn't leak into the live request loop. */
+    (void)wh_Server_KeystoreEvictKey(server, ids[0]);
+    (void)wh_Server_KeystoreEvictKey(server, ids[1]);
+    WH_TEST_RETURN_ON_FAIL(wh_Nvm_DestroyObjects(server->nvm, 2, ids));
+    memset(server->she, 0, sizeof(*server->she));
+
+    if (ret == 0) {
+        WH_TEST_PRINT("SHE PRNG seed persistence test SUCCESS\n");
+    }
+    return ret;
+}
+
 #endif /* WOLFHSM_CFG_SHE_EXTENSION && !WOLFHSM_CFG_NO_CRYPTO */

--- a/test-refactor/wh_test_list.c
+++ b/test-refactor/wh_test_list.c
@@ -89,6 +89,7 @@ WH_TEST_DECL(whTest_SheMasterEcuKeyFallback);
 WH_TEST_DECL(whTest_SheNoNvm);
 WH_TEST_DECL(whTest_SheReqSizeChecking);
 WH_TEST_DECL(whTest_SheStateGate);
+WH_TEST_DECL(whTest_ShePrngSeedPersistence);
 WH_TEST_DECL(whTest_SheUidClient);
 WH_TEST_DECL(whTest_SheUidCb);
 WH_TEST_DECL(whTest_Echo);
@@ -124,17 +125,18 @@ const whTestCase whTestsMisc[] = {
 const size_t whTestsMiscCount = ARRAY_SIZE(whTestsMisc);
 
 const whTestCase whTestsServer[] = {
-    { "whTest_CertVerify", whTest_CertVerify },
-    { "whTest_CertNvmPolicy", whTest_CertNvmPolicy },
-    { "whTest_CertReadRejectsServerOnly", whTest_CertReadRejectsServerOnly },
-    { "whTest_ServerImgMgr", whTest_ServerImgMgr },
-    { "whTest_CertReadTrusted", whTest_CertReadTrusted },
-    { "whTest_NvmOptional", whTest_NvmOptional },
-    { "whTest_NvmPolicyChecked", whTest_NvmPolicyChecked },
-    { "whTest_SheMasterEcuKeyFallback", whTest_SheMasterEcuKeyFallback },
-    { "whTest_SheReqSizeChecking", whTest_SheReqSizeChecking },
-    { "whTest_HwKeystoreServer", whTest_HwKeystoreServer },
-    { "whTest_SheStateGate", whTest_SheStateGate },
+    {"whTest_CertVerify", whTest_CertVerify},
+    {"whTest_CertNvmPolicy", whTest_CertNvmPolicy},
+    {"whTest_CertReadRejectsServerOnly", whTest_CertReadRejectsServerOnly},
+    {"whTest_ServerImgMgr", whTest_ServerImgMgr},
+    {"whTest_CertReadTrusted", whTest_CertReadTrusted},
+    {"whTest_NvmOptional", whTest_NvmOptional},
+    {"whTest_NvmPolicyChecked", whTest_NvmPolicyChecked},
+    {"whTest_SheMasterEcuKeyFallback", whTest_SheMasterEcuKeyFallback},
+    {"whTest_SheReqSizeChecking", whTest_SheReqSizeChecking},
+    {"whTest_HwKeystoreServer", whTest_HwKeystoreServer},
+    {"whTest_SheStateGate", whTest_SheStateGate},
+    {"whTest_ShePrngSeedPersistence", whTest_ShePrngSeedPersistence},
 };
 const size_t whTestsServerCount = ARRAY_SIZE(whTestsServer);
 

--- a/test/wh_test_she.c
+++ b/test/wh_test_she.c
@@ -452,6 +452,39 @@ int whTest_SheClientConfig(whClientConfig* config)
         WH_TEST_PRINT("SHE LOAD KEY UID checks SUCCESS\n");
     }
 
+    /* _LoadKey authorization matrix: a plaintext-loadable RAM key must never
+     * authorize an update to a protected slot. Load a known RAM key, then try
+     * to update MASTER_ECU_KEY authorized by it. Even though M3 is valid (the
+     * RAM key value is known here), the server must reject the unauthorized
+     * authorizer before checking M3. */
+    {
+        uint8_t ramKey[WH_SHE_KEY_SZ];
+        memset(ramKey, 0x5A, sizeof(ramKey));
+
+        if ((ret = wh_Client_SheLoadPlainKey(client, ramKey,
+                sizeof(ramKey))) != 0) {
+            WH_ERROR_PRINT("Failed to load plain RAM key %d\n", ret);
+            goto exit;
+        }
+        if ((ret = wh_She_GenerateLoadableKey(WH_SHE_MASTER_ECU_KEY_ID,
+                WH_SHE_RAM_KEY_ID, 2, 0, sheUid, vectorRawKey, ramKey,
+                messageOne, messageTwo, messageThree, messageFour,
+                messageFive)) != 0) {
+            WH_ERROR_PRINT("Failed to generate RAM-authorized M1/M2/M3 %d\n",
+                           ret);
+            goto exit;
+        }
+        ret = wh_Client_SheLoadKey(client, messageOne, messageTwo,
+                messageThree, outMessageFour, outMessageFive);
+        if (ret != WH_SHE_ERC_KEY_INVALID) {
+            WH_ERROR_PRINT("SHE LOAD KEY RAM-authorized MASTER_ECU update: "
+                           "expected KEY_INVALID, got %d\n", ret);
+            ret = WH_ERROR_ABORTED;
+            goto exit;
+        }
+        WH_TEST_PRINT("SHE LOAD KEY authorization matrix SUCCESS\n");
+    }
+
     if ((ret = wh_Client_SheInitRnd(client)) != 0) {
         WH_ERROR_PRINT("Failed to wh_Client_SheInitRnd %d\n", ret);
         goto exit;

--- a/test/wh_test_she.c
+++ b/test/wh_test_she.c
@@ -478,6 +478,48 @@ int whTest_SheClientConfig(whClientConfig* config)
             ret = WH_ERROR_ABORTED;
             goto exit;
         }
+
+        /* One application key may not authorize an update to a different
+         * application key (Table 4.5: KEY_<n> only by MASTER or itself). The
+         * authorization check runs before any key material is read, so the
+         * slots need not be populated. */
+        if ((ret = wh_She_GenerateLoadableKey(
+                 10, 11, 1, 0, sheUid, vectorRawKey, vectorRawKey, messageOne,
+                 messageTwo, messageThree, messageFour, messageFive)) != 0) {
+            WH_ERROR_PRINT("Failed to generate peer-authorized M1/M2/M3 %d\n",
+                           ret);
+            goto exit;
+        }
+        ret = wh_Client_SheLoadKey(client, messageOne, messageTwo, messageThree,
+                                   outMessageFour, outMessageFive);
+        if (ret != WH_SHE_ERC_KEY_INVALID) {
+            WH_ERROR_PRINT("SHE LOAD KEY peer-authorized update: "
+                           "expected KEY_INVALID, got %d\n",
+                           ret);
+            ret = WH_ERROR_ABORTED;
+            goto exit;
+        }
+
+        /* BOOT_MAC_KEY may authorize an update to BOOT_MAC (Table 4.5): a
+         * same-privilege cross-slot update the spec allows. Rewrite the same
+         * digest so secure-boot state is unchanged. */
+        if ((ret = wh_She_GenerateLoadableKey(
+                 WH_SHE_BOOT_MAC, WH_SHE_BOOT_MAC_KEY_ID, 1, 0, sheUid,
+                 bootMacDigest, key, messageOne, messageTwo, messageThree,
+                 messageFour, messageFive)) != 0) {
+            WH_ERROR_PRINT("Failed to generate BOOT_MAC_KEY-authorized "
+                           "M1/M2/M3 %d\n",
+                           ret);
+            goto exit;
+        }
+        if ((ret = wh_Client_SheLoadKey(client, messageOne, messageTwo,
+                                        messageThree, outMessageFour,
+                                        outMessageFive)) != 0) {
+            WH_ERROR_PRINT("SHE LOAD KEY BOOT_MAC_KEY-authorized BOOT_MAC "
+                           "update: expected success, got %d\n",
+                           ret);
+            goto exit;
+        }
         WH_TEST_PRINT("SHE LOAD KEY authorization matrix SUCCESS\n");
     }
 

--- a/test/wh_test_she.c
+++ b/test/wh_test_she.c
@@ -452,7 +452,9 @@ int whTest_SheClientConfig(whClientConfig* config)
         WH_TEST_PRINT("SHE LOAD KEY UID checks SUCCESS\n");
     }
 
-    /* Verify that updating a protected slot authorized by RAM_KEY is rejected. */
+    /* Authorization matrix: RAM_KEY and peer application keys may not
+     * authorize updates, SECRET_KEY and PRNG_SEED may not be targets, and
+     * BOOT_MAC_KEY may update BOOT_MAC. */
     {
         uint8_t ramKey[WH_SHE_KEY_SZ];
         memset(ramKey, 0x5A, sizeof(ramKey));
@@ -494,6 +496,61 @@ int whTest_SheClientConfig(whClientConfig* config)
                                    outMessageFour, outMessageFive);
         if (ret != WH_SHE_ERC_KEY_INVALID) {
             WH_ERROR_PRINT("SHE LOAD KEY peer-authorized update: "
+                           "expected KEY_INVALID, got %d\n",
+                           ret);
+            ret = WH_ERROR_ABORTED;
+            goto exit;
+        }
+
+        /* SECRET_KEY and PRNG_SEED are not updatable LOAD_KEY targets. */
+        if ((ret = wh_She_GenerateLoadableKey(
+                 WH_SHE_SECRET_KEY_ID, WH_SHE_MASTER_ECU_KEY_ID, 1, 0, sheUid,
+                 vectorRawKey, vectorMasterEcuKey, messageOne, messageTwo,
+                 messageThree, messageFour, messageFive)) != 0) {
+            WH_ERROR_PRINT("Failed to generate SECRET-target M1/M2/M3 %d\n",
+                           ret);
+            goto exit;
+        }
+        ret = wh_Client_SheLoadKey(client, messageOne, messageTwo, messageThree,
+                                   outMessageFour, outMessageFive);
+        if (ret != WH_SHE_ERC_KEY_INVALID) {
+            WH_ERROR_PRINT("SHE LOAD KEY SECRET_KEY target: "
+                           "expected KEY_INVALID, got %d\n",
+                           ret);
+            ret = WH_ERROR_ABORTED;
+            goto exit;
+        }
+
+        if ((ret = wh_She_GenerateLoadableKey(
+                 WH_SHE_PRNG_SEED_ID, WH_SHE_MASTER_ECU_KEY_ID, 1, 0, sheUid,
+                 vectorRawKey, vectorMasterEcuKey, messageOne, messageTwo,
+                 messageThree, messageFour, messageFive)) != 0) {
+            WH_ERROR_PRINT("Failed to generate PRNG-target M1/M2/M3 %d\n", ret);
+            goto exit;
+        }
+        ret = wh_Client_SheLoadKey(client, messageOne, messageTwo, messageThree,
+                                   outMessageFour, outMessageFive);
+        if (ret != WH_SHE_ERC_KEY_INVALID) {
+            WH_ERROR_PRINT("SHE LOAD KEY PRNG_SEED target: "
+                           "expected KEY_INVALID, got %d\n",
+                           ret);
+            ret = WH_ERROR_ABORTED;
+            goto exit;
+        }
+
+        /* RAM_KEY accepts updates from application keys only, so it may not
+         * authorize itself. */
+        if ((ret = wh_She_GenerateLoadableKey(
+                 WH_SHE_RAM_KEY_ID, WH_SHE_RAM_KEY_ID, 1, 0, sheUid,
+                 vectorRawKey, ramKey, messageOne, messageTwo, messageThree,
+                 messageFour, messageFive)) != 0) {
+            WH_ERROR_PRINT("Failed to generate RAM-target M1/M2/M3 %d\n", ret);
+            goto exit;
+        }
+        ret = wh_Client_SheLoadKey(client, messageOne, messageTwo, messageThree,
+                                   outMessageFour, outMessageFive);
+        if (ret != WH_SHE_ERC_KEY_INVALID) {
+            WH_ERROR_PRINT("SHE LOAD KEY RAM-authorized RAM_KEY update: "
                            "expected KEY_INVALID, got %d\n",
                            ret);
             ret = WH_ERROR_ABORTED;

--- a/test/wh_test_she.c
+++ b/test/wh_test_she.c
@@ -452,11 +452,7 @@ int whTest_SheClientConfig(whClientConfig* config)
         WH_TEST_PRINT("SHE LOAD KEY UID checks SUCCESS\n");
     }
 
-    /* _LoadKey authorization matrix: a plaintext-loadable RAM key must never
-     * authorize an update to a protected slot. Load a known RAM key, then try
-     * to update MASTER_ECU_KEY authorized by it. Even though M3 is valid (the
-     * RAM key value is known here), the server must reject the unauthorized
-     * authorizer before checking M3. */
+    /* Verify that updating a protected slot authorized by RAM_KEY is rejected. */
     {
         uint8_t ramKey[WH_SHE_KEY_SZ];
         memset(ramKey, 0x5A, sizeof(ramKey));

--- a/test/wh_test_she.c
+++ b/test/wh_test_she.c
@@ -577,6 +577,82 @@ int whTest_SheClientConfig(whClientConfig* config)
                            ret);
             goto exit;
         }
+        /* Application keys other than BOOT_MAC_KEY may not update the boot
+         * slots. */
+        if ((ret = wh_She_GenerateLoadableKey(
+                 WH_SHE_BOOT_MAC, SHE_TEST_VECTOR_KEY_ID, 2, 0, sheUid,
+                 bootMacDigest, vectorRawKey, messageOne, messageTwo,
+                 messageThree, messageFour, messageFive)) != 0) {
+            WH_ERROR_PRINT("Failed to generate app-key-authorized BOOT_MAC "
+                           "M1/M2/M3 %d\n",
+                           ret);
+            goto exit;
+        }
+        ret = wh_Client_SheLoadKey(client, messageOne, messageTwo, messageThree,
+                                   outMessageFour, outMessageFive);
+        if (ret != WH_SHE_ERC_KEY_INVALID) {
+            WH_ERROR_PRINT("SHE LOAD KEY app-key-authorized BOOT_MAC update: "
+                           "expected KEY_INVALID, got %d\n",
+                           ret);
+            ret = WH_ERROR_ABORTED;
+            goto exit;
+        }
+
+        /* An application key may load RAM_KEY (Table 4.5). M4/M5 come back
+         * derived from the new key, which proves the load landed. The RAM key
+         * is reloaded in plaintext before it is used again below. */
+        memset(ramKey, 0xA5, sizeof(ramKey));
+        if ((ret = wh_She_GenerateLoadableKey(
+                 WH_SHE_RAM_KEY_ID, SHE_TEST_VECTOR_KEY_ID, 1, 0, sheUid,
+                 ramKey, vectorRawKey, messageOne, messageTwo, messageThree,
+                 messageFour, messageFive)) != 0) {
+            WH_ERROR_PRINT("Failed to generate app-key-authorized RAM_KEY "
+                           "M1/M2/M3 %d\n",
+                           ret);
+            goto exit;
+        }
+        if ((ret = wh_Client_SheLoadKey(client, messageOne, messageTwo,
+                                        messageThree, outMessageFour,
+                                        outMessageFive)) != 0) {
+            WH_ERROR_PRINT("SHE LOAD KEY app-key-authorized RAM_KEY update: "
+                           "expected success, got %d\n",
+                           ret);
+            goto exit;
+        }
+        if (memcmp(outMessageFour, messageFour, sizeof(messageFour)) != 0 ||
+            memcmp(outMessageFive, messageFive, sizeof(messageFive)) != 0) {
+            WH_ERROR_PRINT("SHE LOAD KEY app-key-authorized RAM_KEY update: "
+                           "M4/M5 mismatch\n");
+            ret = WH_ERROR_ABORTED;
+            goto exit;
+        }
+
+        /* An application key may be rotated with itself as the authorizing
+         * key (Table 4.5). Reload the same material with a higher counter so
+         * only the slot's counter changes. */
+        if ((ret = wh_She_GenerateLoadableKey(
+                 SHE_TEST_VECTOR_KEY_ID, SHE_TEST_VECTOR_KEY_ID, 2, 0, sheUid,
+                 vectorRawKey, vectorRawKey, messageOne, messageTwo,
+                 messageThree, messageFour, messageFive)) != 0) {
+            WH_ERROR_PRINT("Failed to generate self-authorized M1/M2/M3 %d\n",
+                           ret);
+            goto exit;
+        }
+        if ((ret = wh_Client_SheLoadKey(client, messageOne, messageTwo,
+                                        messageThree, outMessageFour,
+                                        outMessageFive)) != 0) {
+            WH_ERROR_PRINT("SHE LOAD KEY self-authorized rotation: "
+                           "expected success, got %d\n",
+                           ret);
+            goto exit;
+        }
+        if (memcmp(outMessageFour, messageFour, sizeof(messageFour)) != 0 ||
+            memcmp(outMessageFive, messageFive, sizeof(messageFive)) != 0) {
+            WH_ERROR_PRINT("SHE LOAD KEY self-authorized rotation: "
+                           "M4/M5 mismatch\n");
+            ret = WH_ERROR_ABORTED;
+            goto exit;
+        }
         WH_TEST_PRINT("SHE LOAD KEY authorization matrix SUCCESS\n");
     }
 
@@ -2582,6 +2658,184 @@ static int wh_She_TestGetId(void)
 
     return 0;
 }
+
+/* Read the persisted PRNG_SEED, check it moved on from prevSeed, then check
+ * the keystore hands back that same value rather than a stale cached copy.
+ * Leaves the persisted seed in prevSeed for the next step. */
+static int _SheCheckSeedAdvanced(whServerContext* server, whKeyId seedId,
+                                 uint8_t* prevSeed)
+{
+    whNvmMetadata meta[1] = {{0}};
+    uint8_t       nvmSeed[WH_SHE_KEY_SZ];
+    uint8_t       readSeed[WH_SHE_KEY_SZ];
+    uint32_t      readSz = sizeof(readSeed);
+
+    WH_TEST_RETURN_ON_FAIL(
+        wh_Nvm_Read(server->nvm, seedId, 0, WH_SHE_KEY_SZ, nvmSeed));
+    WH_TEST_ASSERT_RETURN(memcmp(nvmSeed, prevSeed, WH_SHE_KEY_SZ) != 0);
+
+    WH_TEST_RETURN_ON_FAIL(
+        wh_Server_KeystoreReadKey(server, seedId, meta, readSeed, &readSz));
+    WH_TEST_ASSERT_RETURN(readSz == WH_SHE_KEY_SZ);
+    WH_TEST_ASSERT_RETURN(memcmp(readSeed, nvmSeed, WH_SHE_KEY_SZ) == 0);
+
+    memcpy(prevSeed, nvmSeed, WH_SHE_KEY_SZ);
+    return 0;
+}
+
+/* Drive INIT_RND and two EXTEND_SEEDs on a server whose NVM holds SECRET_KEY
+ * and PRNG_SEED for seedId. Each command persists a new seed, and each must
+ * drop the cached copy of the old one: otherwise EXTEND_SEED keeps deriving
+ * from the pre-INIT seed and two extends with the same entropy persist the
+ * same value. Leaves the server with rndInited set. */
+static int _ShePrngSeedFlow(whServerContext* server, whKeyId seedId,
+                            const uint8_t* initialSeed)
+{
+    int32_t       rc;
+    uint32_t      i;
+    uint8_t       prevSeed[WH_SHE_KEY_SZ];
+    uint8_t       req_packet[WOLFHSM_CFG_COMM_DATA_LEN];
+    uint8_t       resp_packet[WOLFHSM_CFG_COMM_DATA_LEN];
+    const uint8_t entropy[WH_SHE_KEY_SZ] = {0xae, 0x2d, 0x8a, 0x57, 0x1e, 0x03,
+                                            0xac, 0x9c, 0x9e, 0xb7, 0x6f, 0xac,
+                                            0x45, 0xaf, 0x8e, 0x51};
+    whMessageShe_ExtendSeedRequest* extendReq =
+        (whMessageShe_ExtendSeedRequest*)req_packet;
+
+    /* Pass the state gate without a full secure boot. */
+    server->she->uidSet  = 1;
+    server->she->sbState = TEST_SHE_SB_STATE_SUCCESS;
+
+    /* INIT_RND replaces the provisioned seed. */
+    memcpy(prevSeed, initialSeed, WH_SHE_KEY_SZ);
+    memset(req_packet, 0, sizeof(req_packet));
+    rc =
+        wh_She_SheActionRc(server, WH_SHE_INIT_RND, req_packet, 0, resp_packet);
+    WH_TEST_ASSERT_RETURN(rc == WH_SHE_ERC_NO_ERROR);
+    WH_TEST_RETURN_ON_FAIL(_SheCheckSeedAdvanced(server, seedId, prevSeed));
+
+    /* EXTEND_SEED must build on the seed INIT_RND just persisted, and the
+     * second one on the first. */
+    for (i = 0; i < 2; i++) {
+        memcpy(extendReq->entropy, entropy, sizeof(entropy));
+        rc = wh_She_SheActionRc(server, WH_SHE_EXTEND_SEED, req_packet,
+                                sizeof(*extendReq), resp_packet);
+        WH_TEST_ASSERT_RETURN(rc == WH_SHE_ERC_NO_ERROR);
+        WH_TEST_RETURN_ON_FAIL(_SheCheckSeedAdvanced(server, seedId, prevSeed));
+    }
+
+    return 0;
+}
+
+/* Server-direct check that INIT_RND and EXTEND_SEED persist the PRNG seed
+ * coherently with the key cache. See _ShePrngSeedFlow. */
+static int wh_She_TestPrngSeedPersistence(void)
+{
+    int             ret       = 0;
+    whServerContext server[1] = {0};
+    whNvmMetadata   meta[1]   = {{0}};
+    whKeyId         seedId;
+
+    /* SECRET_KEY and PRNG_SEED from the SHE test vectors */
+    uint8_t secretKey[WH_SHE_KEY_SZ] = {0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae,
+                                        0xd2, 0xa6, 0xab, 0xf7, 0x15, 0x88,
+                                        0x09, 0xcf, 0x4f, 0x3c};
+    uint8_t prngSeed[WH_SHE_KEY_SZ]  = {0x6b, 0xc1, 0xbe, 0xe2, 0x2e, 0x40,
+                                        0x9f, 0x96, 0xe9, 0x3d, 0x7e, 0x11,
+                                        0x73, 0x93, 0x17, 0x2a};
+
+    /* Transport (not used, but required for server init) */
+    uint8_t                     reqBuf[BUFFER_SIZE]  = {0};
+    uint8_t                     respBuf[BUFFER_SIZE] = {0};
+    whTransportMemConfig        tmcf[1]              = {{
+                            .req       = (whTransportMemCsr*)reqBuf,
+                            .req_size  = sizeof(reqBuf),
+                            .resp      = (whTransportMemCsr*)respBuf,
+                            .resp_size = sizeof(respBuf),
+    }};
+    whTransportServerCb         tscb[1]    = {WH_TRANSPORT_MEM_SERVER_CB};
+    whTransportMemServerContext tmsc[1]    = {0};
+    whCommServerConfig          cs_conf[1] = {{
+                 .transport_cb      = tscb,
+                 .transport_context = (void*)tmsc,
+                 .transport_config  = (void*)tmcf,
+                 .server_id         = 125,
+    }};
+
+    /* RamSim Flash state and configuration.
+     * memory[] is static to avoid 1MB stack allocation. */
+    static uint8_t   memory[FLASH_RAM_SIZE];
+    whFlashRamsimCtx fc[1]      = {0};
+    whFlashRamsimCfg fc_conf[1] = {{0}};
+    const whFlashCb  fcb[1]     = {WH_FLASH_RAMSIM_CB};
+
+    /* NVM */
+    whNvmFlashConfig  nf_conf[1] = {{
+         .cb      = fcb,
+         .context = fc,
+         .config  = fc_conf,
+    }};
+    whNvmFlashContext nfc[1]     = {0};
+    whNvmCb           nfcb[1]    = {WH_NVM_FLASH_CB};
+    whNvmConfig       n_conf[1]  = {{
+               .cb      = nfcb,
+               .context = nfc,
+               .config  = nf_conf,
+    }};
+    whNvmContext      nvm[1]     = {{0}};
+
+    /* Crypto context */
+    whServerCryptoContext crypto[1] = {0};
+
+    whServerSheContext she[1];
+
+    whServerConfig s_conf[1] = {{
+        .comm_config = cs_conf,
+        .nvm         = nvm,
+        .crypto      = crypto,
+        .she         = she,
+        .devId       = INVALID_DEVID,
+    }};
+
+    memset(she, 0, sizeof(she));
+    memset(memory, 0, sizeof(memory));
+
+    fc_conf->size       = FLASH_RAM_SIZE;
+    fc_conf->sectorSize = FLASH_SECTOR_SIZE;
+    fc_conf->pageSize   = FLASH_PAGE_SIZE;
+    fc_conf->erasedByte = ~(uint8_t)0;
+    fc_conf->memory     = memory;
+
+    WH_TEST_RETURN_ON_FAIL(wh_Nvm_Init(nvm, n_conf));
+    WH_TEST_RETURN_ON_FAIL(wolfCrypt_Init());
+    WH_TEST_RETURN_ON_FAIL(wc_InitRng_ex(crypto->rng, NULL, s_conf->devId));
+    WH_TEST_RETURN_ON_FAIL(wh_Server_Init(server, s_conf));
+    WH_TEST_RETURN_ON_FAIL(wh_Server_SetConnected(server, WH_COMM_CONNECTED));
+
+    /* Provision the two keys INIT_RND reads straight into NVM. */
+    meta->len    = WH_SHE_KEY_SZ;
+    meta->access = WH_NVM_ACCESS_ANY;
+    meta->id = WH_SHE_MAKE_KEYID(server->comm->client_id, WH_SHE_SECRET_KEY_ID);
+    WH_TEST_RETURN_ON_FAIL(
+        wh_Nvm_AddObject(nvm, meta, WH_SHE_KEY_SZ, secretKey));
+    seedId   = WH_SHE_MAKE_KEYID(server->comm->client_id, WH_SHE_PRNG_SEED_ID);
+    meta->id = seedId;
+    WH_TEST_RETURN_ON_FAIL(
+        wh_Nvm_AddObject(nvm, meta, WH_SHE_KEY_SZ, prngSeed));
+
+    ret = _ShePrngSeedFlow(server, seedId, prngSeed);
+
+    wh_Server_Cleanup(server);
+    wh_Nvm_Cleanup(nvm);
+    wc_FreeRng(crypto->rng);
+    wolfCrypt_Cleanup();
+
+    if (ret == 0) {
+        WH_TEST_PRINT("SHE PRNG seed persistence test SUCCESS\n");
+    }
+    return ret;
+}
+
 #endif /* WOLFHSM_CFG_ENABLE_SERVER */
 
 #if defined(WOLFHSM_CFG_TEST_POSIX) && defined(WOLFHSM_CFG_ENABLE_CLIENT) && \
@@ -2861,6 +3115,8 @@ int whTest_She(void)
     WH_TEST_RETURN_ON_FAIL(wh_She_TestStateGate());
     WH_TEST_PRINT("Testing SHE: GET_ID empty-key / pre-secure-boot...\n");
     WH_TEST_RETURN_ON_FAIL(wh_She_TestGetId());
+    WH_TEST_PRINT("Testing SHE: PRNG seed persistence...\n");
+    WH_TEST_RETURN_ON_FAIL(wh_She_TestPrngSeedPersistence());
     WH_TEST_PRINT("Testing SHE: (pthread) mem core flow...\n");
     WH_TEST_RETURN_ON_FAIL(
         wh_ClientServer_MemThreadTest(whTest_SheClientConfig));


### PR DESCRIPTION
- **F-11419**: SHE `LOAD_KEY` accepted any slot as the authorizing key (e.g. a client-loaded RAM key could overwrite `MASTER_ECU_KEY`). Changed to now enforce the AUTOSAR SHE update-authorization matrix (Table 4.5), documented in `docs/src/5-Features.md`.
- **F-10226**: SHA-2 client wrappers left hash state mutated when the server returned an error, so wolfCrypt's software fallback silently produced a wrong digest. State is now snapshotted on entry and restored on any failure (mirrors the existing SHA-3 handling). Note that this behavior is dumb HOWEVER is required for correctness as long as silent software fallback exists.
- **F-11394**: a failed NVM write during key revocation left the cache marked revoked+committed, so a retry returned success while the NVM record stayed unrevoked. Revocation is now persisted from a temp copy and the cache mutated only on NVM success.
- **F-11393**: `wh_Server_Init` dropped the DMA `memCopyCb` supplied through `whServerConfig`. Fixed, it is now installed (under `WOLFHSM_CFG_DMA_CUSTOM_CLIENT_COPY`).
- **F-10219**: the SHE PRNG seed's auto-cached copy was not evicted after persisting a new seed, so `_ExtendSeed` re-read a stale seed. Fixed so the cache entry is now evicted after the NVM write.
