### PR TITLE
Fix broken CI on main

### DIFF
--- a/.github/actions/checkout-wolfssl/action.yml
+++ b/.github/actions/checkout-wolfssl/action.yml
@@ -1,0 +1,25 @@
+name: 'Checkout wolfSSL'
+description: >
+  Check out wolfssl/wolfssl into ./wolfssl at the pinned ref below. This is
+  the one place the CI wolfSSL version lives: change the default of `ref`
+  here to move every workflow at once, or pass `ref` from a workflow to
+  override it for that job only.
+
+inputs:
+  ref:
+    description: >
+      wolfSSL git ref to check out: a tag, a branch, or a full 40-character
+      commit SHA (actions/checkout does not resolve abbreviated SHAs).
+    required: false
+    # wolfSSL tag or commit SHA to checkout:
+    default: '339aa5779f7f5fc3a94109558161926dd2eb4748'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout wolfssl at ${{ inputs.ref }}
+      uses: actions/checkout@v4
+      with:
+        repository: wolfssl/wolfssl
+        ref: ${{ inputs.ref }}
+        path: wolfssl

--- a/.github/workflows/build-and-bench.yml
+++ b/.github/workflows/build-and-bench.yml
@@ -37,10 +37,7 @@ jobs:
 
     # pull and build wolfssl
     - name: Checkout wolfssl
-      uses: actions/checkout@v4
-      with:
-        repository: wolfssl/wolfssl
-        path: wolfssl
+      uses: ./.github/actions/checkout-wolfssl
 
     # Compiler cache; PR runs restore without saving
     - name: Set up ccache

--- a/.github/workflows/build-and-run-examples.yml
+++ b/.github/workflows/build-and-run-examples.yml
@@ -28,10 +28,7 @@ jobs:
 
     # pull and build wolfssl
     - name: Checkout wolfssl
-      uses: actions/checkout@v4
-      with:
-        repository: wolfssl/wolfssl
-        path: wolfssl
+      uses: ./.github/actions/checkout-wolfssl
 
     # One job per transport; the flag combos run as a loop because a
     # matrix job per combo spends about half its time on runner setup.

--- a/.github/workflows/build-and-test-clientonly.yml
+++ b/.github/workflows/build-and-test-clientonly.yml
@@ -39,10 +39,7 @@ jobs:
 
     # pull and build wolfssl
     - name: Checkout wolfssl
-      uses: actions/checkout@v4
-      with:
-        repository: wolfssl/wolfssl
-        path: wolfssl
+      uses: ./.github/actions/checkout-wolfssl
 
     # Compiler cache; PR runs restore without saving
     - name: Set up ccache

--- a/.github/workflows/build-and-test-refactor.yml
+++ b/.github/workflows/build-and-test-refactor.yml
@@ -58,10 +58,7 @@ jobs:
 
     # pull and build wolfssl
     - name: Checkout wolfssl
-      uses: actions/checkout@v4
-      with:
-        repository: wolfssl/wolfssl
-        path: wolfssl
+      uses: ./.github/actions/checkout-wolfssl
 
     # Compiler cache; PR runs restore without saving
     - name: Set up ccache
@@ -223,10 +220,7 @@ jobs:
 
     # pull and build wolfssl
     - name: Checkout wolfssl
-      uses: actions/checkout@v4
-      with:
-        repository: wolfssl/wolfssl
-        path: wolfssl
+      uses: ./.github/actions/checkout-wolfssl
 
     # Compiler cache; PR runs restore without saving. Own config-hash so the
     # -m32 objects get a separate cache namespace from the 64-bit build job

--- a/.github/workflows/build-and-test-stress.yml
+++ b/.github/workflows/build-and-test-stress.yml
@@ -37,10 +37,7 @@ jobs:
 
     # pull and build wolfssl
     - name: Checkout wolfssl
-      uses: actions/checkout@v4
-      with:
-        repository: wolfssl/wolfssl
-        path: wolfssl
+      uses: ./.github/actions/checkout-wolfssl
 
     # Compiler cache; PR runs restore without saving
     - name: Set up ccache

--- a/.github/workflows/build-and-test-whnvmtool.yml
+++ b/.github/workflows/build-and-test-whnvmtool.yml
@@ -37,10 +37,7 @@ jobs:
 
     # pull and build wolfssl
     - name: Checkout wolfssl
-      uses: actions/checkout@v4
-      with:
-        repository: wolfssl/wolfssl
-        path: wolfssl
+      uses: ./.github/actions/checkout-wolfssl
 
     # Compiler cache; PR runs restore without saving
     - name: Set up ccache

--- a/.github/workflows/build-and-test-wolfssl-lib.yml
+++ b/.github/workflows/build-and-test-wolfssl-lib.yml
@@ -30,10 +30,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Checkout wolfssl
-      uses: actions/checkout@v4
-      with:
-        repository: wolfssl/wolfssl
-        path: wolfssl
+      uses: ./.github/actions/checkout-wolfssl
 
     # Compiler cache; PR runs restore without saving
     - name: Set up ccache

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,10 +58,7 @@ jobs:
 
     # pull and build wolfssl
     - name: Checkout wolfssl
-      uses: actions/checkout@v4
-      with:
-        repository: wolfssl/wolfssl
-        path: wolfssl
+      uses: ./.github/actions/checkout-wolfssl
 
     # Compiler cache; PR runs restore without saving
     - name: Set up ccache

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -46,10 +46,7 @@ jobs:
         run: pipx install 'gcovr==8.6'
 
       - name: Checkout wolfssl
-        uses: actions/checkout@v4
-        with:
-          repository: wolfssl/wolfssl
-          path: wolfssl
+        uses: ./.github/actions/checkout-wolfssl
 
       - name: Build, run, and emit tracefile (${{ matrix.tree }} ${{ matrix.config.name }})
         # legacy and refactor trees differ only in the test dir and the

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -23,11 +23,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Checkout wolfssl
-      uses: actions/checkout@v4
-      with:
-        repository: wolfssl/wolfssl
-        ref: v5.6.4-stable
-        path: wolfssl
+      uses: ./.github/actions/checkout-wolfssl
 
     - name: Install cppcheck
       run: |
@@ -82,10 +78,7 @@ jobs:
         path: wolfHSM
 
     - name: Checkout wolfssl
-      uses: actions/checkout@v4
-      with:
-        repository: wolfssl/wolfssl
-        path: wolfssl
+      uses: ./wolfHSM/.github/actions/checkout-wolfssl
 
     - name: Install dependencies
       run: |
@@ -112,10 +105,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Checkout wolfssl
-      uses: actions/checkout@v4
-      with:
-        repository: wolfssl/wolfssl
-        path: wolfssl
+      uses: ./.github/actions/checkout-wolfssl
 
     - name: Install dependencies
       run: |

--- a/examples/posix/wh_posix_client/Makefile
+++ b/examples/posix/wh_posix_client/Makefile
@@ -121,9 +121,10 @@ SRC_C += $(wildcard $(WOLFSSL_DIR)/wolfcrypt/src/*.c)
 SRC_C += $(wildcard $(WOLFSSL_DIR)/src/*.c)
 endif
 
-# wolfCrypt test/benchmark source files
-SRC_C += $(WOLFSSL_DIR)/wolfcrypt/test/test.c
-SRC_C += $(WOLFSSL_DIR)/wolfcrypt/benchmark/benchmark.c
+# wolfCrypt test/benchmark source files (skipped via wildcard when WOLFSSL_DIR
+# is undefined (e.g. WOLFSSL_LIB=1 pointing at installed headers)
+SRC_C += $(wildcard $(WOLFSSL_DIR)/wolfcrypt/test/test.c)
+SRC_C += $(wildcard $(WOLFSSL_DIR)/wolfcrypt/benchmark/benchmark.c)
 
 # Set the default device ID for wolfCrypt tests
 ifeq ($(DMA),1)

--- a/examples/posix/wh_posix_client/Makefile
+++ b/examples/posix/wh_posix_client/Makefile
@@ -121,10 +121,9 @@ SRC_C += $(wildcard $(WOLFSSL_DIR)/wolfcrypt/src/*.c)
 SRC_C += $(wildcard $(WOLFSSL_DIR)/src/*.c)
 endif
 
-# wolfCrypt test/benchmark source files (compiled even with WOLFSSL_LIB=1
-# since these are not part of libwolfssl)
-SRC_C += $(wildcard $(WOLFSSL_DIR)/wolfcrypt/test/*.c)
-SRC_C += $(wildcard $(WOLFSSL_DIR)/wolfcrypt/benchmark/*.c)
+# wolfCrypt test/benchmark source files
+SRC_C += $(WOLFSSL_DIR)/wolfcrypt/test/test.c
+SRC_C += $(WOLFSSL_DIR)/wolfcrypt/benchmark/benchmark.c
 
 # Set the default device ID for wolfCrypt tests
 ifeq ($(DMA),1)

--- a/test-refactor/posix/Makefile
+++ b/test-refactor/posix/Makefile
@@ -204,8 +204,8 @@ ifeq ($(TESTWOLFCRYPT),1)
     # TESTWOLFCRYPT_DMA uses WH_DEV_ID_DMA).
     DEF += -DWC_USE_DEVID=$(TESTWOLFCRYPT_DEVID)
 
-    # wolfCrypt test source files
-    SRC_C += $(wildcard $(WOLFSSL_DIR)/wolfcrypt/test/*.c)
+    # wolfCrypt test source file
+    SRC_C += $(WOLFSSL_DIR)/wolfcrypt/test/test.c
 endif
 endif
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -299,6 +299,11 @@ SRC_C +=  $(wildcard $(WOLFHSM_PORT_DIR)/*.c)
 SRC_C +=  $(wildcard $(PROJECT_DIR)/*.c)
 
 
+# Only analyze wolfHSM sources
+ifeq ($(SCAN),1)
+SRC_C := $(filter-out $(WOLFSSL_DIR)/%,$(SRC_C))
+endif
+
 ## Automated processing below
 
 FILENAMES_C = $(notdir $(SRC_C))
@@ -329,9 +334,7 @@ analyze:$(OBJS_ASM) $(OBJS_C)
 scan:$(BUILD_DIR)
 	@echo "Running scan-build static analysis"
 	@mkdir -p $(WOLFHSM_DIR)/scan_out/
-	@scan-build --exclude $(WOLFSSL_DIR)/wolfcrypt \
-	            --exclude $(WOLFSSL_DIR)/src \
-	            --status-bugs $(MAKE) analyze 2> $(WOLFHSM_DIR)/scan_out/$(SCAN_LOG)
+	@scan-build --status-bugs $(MAKE) analyze 2> $(WOLFHSM_DIR)/scan_out/$(SCAN_LOG)
 
 $(BUILD_DIR):
 	$(CMD_ECHO) mkdir -p $(BUILD_DIR)

--- a/test/Makefile
+++ b/test/Makefile
@@ -281,8 +281,8 @@ ifeq ($(TESTWOLFCRYPT),1)
     # defaults to WH_DEV_ID; TESTWOLFCRYPT_DMA uses WH_DEV_ID_DMA).
     DEF += -DWC_USE_DEVID=$(TESTWOLFCRYPT_DEVID)
 
-	# wolfCrypt test source files
-    SRC_C += $(wildcard $(WOLFSSL_DIR)/wolfcrypt/test/*.c)
+    # wolfCrypt test source file
+    SRC_C += $(WOLFSSL_DIR)/wolfcrypt/test/test.c
 endif
 
 # End of NOCRYPTO


### PR DESCRIPTION
fixes broken CI due to a few upstream wolfSSL breakages:

- scan-build was improperly excluding wolfCrypt/wolfSSL using the `--exclude-flag` but turns out that this only excludes it from the HTML report, so wolfCrypt was still getting scanned. Silly things like dead stores were causing it to fail
- excludes unnecessary FIPS files from test/bench, causing failure due to redefinition of `main()`
- changes CI to checkout pinned version of wolfSSL going forward