### PR TITLE
Fenrir fixes

### DIFF
--- a/docs/src/5-Features.md
+++ b/docs/src/5-Features.md
@@ -890,7 +890,7 @@ A verify method returns `WH_ERROR_OK` on a successful verification, `WH_ERROR_NO
 - `wh_Server_ImgMgrVerifyMethodWolfBootRsa4096WithSha256`: RSA-4096 verification of a wolfBoot-formatted image (see [wolfBoot Image Support](#wolfboot-image-support))
 - `wh_Server_ImgMgrVerifyMethodWolfBootCertChainRsa4096WithSha256`: cert-chain-based RSA-4096 verification of a wolfBoot image
 
-Applications can supply their own verify method to support algorithms not represented in the built-in set, or to layer additional checks on top of an existing one — for example, validating a monotonic counter against a [non-volatile counter](#non-volatile-monotonic-counters) inside a wrapper verify method to add anti-rollback protection. The maximum signature size handled by the framework is `WOLFHSM_CFG_SERVER_IMG_MGR_MAX_SIG_SIZE`, whose default accommodates RSA-4096.
+Applications can supply their own verify method to support algorithms not represented in the built-in set, or to layer additional checks on top of an existing one — for example, validating a monotonic counter against a [non-volatile counter](#non-volatile-monotonic-counters) inside a wrapper verify method to add anti-rollback protection. The maximum signature size handled by the framework is `WOLFHSM_CFG_SERVER_IMG_MGR_MAX_SIG_SIZE`, whose default accommodates RSA-4096. Verification keys are copied out of the keystore into a private buffer before the verify method runs, bounded by `WOLFHSM_CFG_SERVER_IMG_MGR_MAX_KEY_SIZE` (default 1200 bytes, enough for an ASN.1 RSA-4096 public key).
 
 ### Verify Actions
 

--- a/docs/src/9-Configuration.md
+++ b/docs/src/9-Configuration.md
@@ -117,6 +117,7 @@ These macros size the server-side key cache. The cache is split into "regular" s
 | `WOLFHSM_CFG_SERVER_IMG_MGR` | Undefined | If defined, compile the server-side image manager (manifest-driven boot/runtime image verification). |
 | `WOLFHSM_CFG_SERVER_IMG_MGR_MAX_IMG_COUNT` | `4` | Maximum number of images that a single image-manager configuration can track at one time. |
 | `WOLFHSM_CFG_SERVER_IMG_MGR_MAX_SIG_SIZE` | `512` | Maximum signature size, in bytes, that the image manager will allocate buffer space for. The default accommodates RSA-4096; raise it when using signature schemes with larger signatures. |
+| `WOLFHSM_CFG_SERVER_IMG_MGR_MAX_KEY_SIZE` | `1200` | Maximum verification key size, in bytes, that the image manager copies out of the keystore before invoking a verify method. The default accommodates an ASN.1 RSA-4096 public key; raise it for larger keys such as ML-DSA. |
 
 ## Custom Server Callbacks
 

--- a/port/posix/posix_transport_shm.c
+++ b/port/posix/posix_transport_shm.c
@@ -661,6 +661,9 @@ int posixTransportShm_ClientStaticMemDmaCallback(
     else if (oper == WH_DMA_OPER_CLIENT_READ_POST) {
         if (isInDma == 0) {
             uint8_t* ptr = (uint8_t*)dmaPtr + (uintptr_t)*xformedCliAddr;
+            /* Scrub key material before freeing. len is bounded by the temp
+             * buffer's XMALLOC, well within uint32_t for this transport. */
+            wh_Utils_ForceZero(ptr, (uint32_t)len);
             XFREE(ptr, heap, DYNAMIC_TYPE_TMP_BUFFER);
         }
     }
@@ -669,6 +672,9 @@ int posixTransportShm_ClientStaticMemDmaCallback(
             uint8_t* ptr = (uint8_t*)dmaPtr + (uintptr_t)*xformedCliAddr;
             memcpy((void*)clientAddr, ptr,
                    len); /* copy results of what server wrote */
+            /* Scrub key material before freeing. len is bounded by the temp
+             * buffer's XMALLOC, well within uint32_t for this transport. */
+            wh_Utils_ForceZero(ptr, (uint32_t)len);
             XFREE(ptr, heap, DYNAMIC_TYPE_TMP_BUFFER);
         }
     }

--- a/src/wh_server_counter.c
+++ b/src/wh_server_counter.c
@@ -225,7 +225,8 @@ int wh_Server_HandleCounter(whServerContext* server, uint16_t magic,
         } break;
 
         default:
-            ret = WH_ERROR_BADARGS;
+            *out_resp_size = 0;
+            ret            = WH_ERROR_BADARGS;
             break;
     }
 

--- a/src/wh_server_crypto.c
+++ b/src/wh_server_crypto.c
@@ -4613,7 +4613,10 @@ static int _HandleCmac(whServerContext* ctx, uint16_t magic, int devId,
             *outSize = sizeof(res) + res.outSz;
         }
     }
+    /* Scrub the key and the Cmac context (AES schedule, k1/k2). Zeroing the
+     * struct instead of wc_CmacFree avoids a double free after wc_CmacFinal */
     wc_ForceZero(tmpKey, sizeof(tmpKey));
+    wc_ForceZero(cmac, sizeof(cmac));
     WH_DEBUG_SERVER_VERBOSE("cmac end ret:%d\n", ret);
     return ret;
 }
@@ -9127,7 +9130,10 @@ static int _HandleCmacDma(whServerContext* ctx, uint16_t magic, int devId,
         }
     }
 
+    /* Scrub the key and the Cmac context (AES schedule, k1/k2). Zeroing the
+     * struct instead of wc_CmacFree avoids a double free after wc_CmacFinal */
     wc_ForceZero(tmpKey, sizeof(tmpKey));
+    wc_ForceZero(cmac, sizeof(cmac));
     WH_DEBUG_SERVER_VERBOSE("dma cmac end ret:%d\n", ret);
     return ret;
 }

--- a/src/wh_server_img_mgr.c
+++ b/src/wh_server_img_mgr.c
@@ -33,6 +33,7 @@
 #include <string.h>
 
 #include "wolfhsm/wh_error.h"
+#include "wolfhsm/wh_utils.h"
 #include "wolfhsm/wh_server.h"
 #include "wolfhsm/wh_server_img_mgr.h"
 #include "wolfhsm/wh_server_keystore.h"
@@ -95,15 +96,38 @@ int wh_Server_ImgMgrInit(whServerImgMgrContext*      context,
     return ret;
 }
 
+/* Copy the key out of the keystore under the NVM lock so the verify callback
+ * works from a private snapshot, not a live cache slot that another server
+ * context could evict or rewrite mid-verification. */
+static int _ImgMgrCopyKeyFromKeystore(whServerContext* server, whKeyId keyId,
+                                      uint8_t* dst, size_t dstMax,
+                                      size_t* outLen)
+{
+    int      ret;
+    uint32_t keySz = (uint32_t)dstMax;
+
+    ret = WH_SERVER_NVM_LOCK(server);
+    if (ret != WH_ERROR_OK) {
+        return ret;
+    }
+    ret = wh_Server_KeystoreReadKey(server, keyId, NULL, dst, &keySz);
+    (void)WH_SERVER_NVM_UNLOCK(server);
+
+    if (ret == WH_ERROR_OK) {
+        *outLen = keySz;
+    }
+    return ret;
+}
+
 int wh_Server_ImgMgrVerifyImg(whServerImgMgrContext*      context,
                               const whServerImgMgrImg*    img,
                               whServerImgMgrVerifyResult* result)
 {
-    int              ret     = WH_ERROR_OK;
-    whServerContext* server  = NULL;
-    uint8_t*         keyBuf  = NULL;
-    whNvmMetadata*   keyMeta = NULL;
-    size_t           keySz   = 0;
+    int              ret    = WH_ERROR_OK;
+    whServerContext* server = NULL;
+    uint8_t          keyBuf[WOLFHSM_CFG_SERVER_IMG_MGR_MAX_KEY_SIZE];
+    const uint8_t*   keyPtr = NULL; /* stays NULL for paths with no key */
+    size_t           keySz  = 0;
     uint8_t sigBuf[WOLFHSM_CFG_SERVER_IMG_MGR_MAX_SIG_SIZE]; /* Buffer for
                                                                 signature */
     whNvmMetadata sigMeta       = {0};
@@ -127,12 +151,12 @@ int wh_Server_ImgMgrVerifyImg(whServerImgMgrContext*      context,
     switch (img->imgType) {
         case WH_IMG_MGR_IMG_TYPE_WOLFBOOT:
             /* Load key from keystore, skip sig loading (sig is in header) */
-            ret = wh_Server_KeystoreFreshenKey(server, img->keyId, &keyBuf,
-                                               &keyMeta);
+            ret = _ImgMgrCopyKeyFromKeystore(server, img->keyId, keyBuf,
+                                             sizeof(keyBuf), &keySz);
             if (ret != WH_ERROR_OK) {
                 return ret;
             }
-            keySz = keyMeta->len;
+            keyPtr = keyBuf;
             /* sig/sigSz passed as NULL/0 to callback */
             break;
 
@@ -142,15 +166,8 @@ int wh_Server_ImgMgrVerifyImg(whServerImgMgrContext*      context,
             break;
 
         case WH_IMG_MGR_IMG_TYPE_RAW:
-            /* Existing behavior: load key from keystore + sig from NVM */
-            ret = wh_Server_KeystoreFreshenKey(server, img->keyId, &keyBuf,
-                                               &keyMeta);
-            if (ret != WH_ERROR_OK) {
-                return ret;
-            }
-            keySz = keyMeta->len;
-
-            /* Load the signature from NVM */
+            /* Load the signature from NVM first so the key snapshot is the
+             * last thing taken before verification */
             ret = wh_Nvm_GetMetadata(server->nvm, img->sigNvmId, &sigMeta);
             if (ret != WH_ERROR_OK) {
                 return ret;
@@ -168,6 +185,14 @@ int wh_Server_ImgMgrVerifyImg(whServerImgMgrContext*      context,
             }
             actualSigSize = sigMeta.len;
             sigPtr        = sigBuf;
+
+            /* Load key from keystore */
+            ret = _ImgMgrCopyKeyFromKeystore(server, img->keyId, keyBuf,
+                                             sizeof(keyBuf), &keySz);
+            if (ret != WH_ERROR_OK) {
+                return ret;
+            }
+            keyPtr = keyBuf;
             break;
 
         default:
@@ -177,11 +202,13 @@ int wh_Server_ImgMgrVerifyImg(whServerImgMgrContext*      context,
     /* Invoke verify method callback */
     if (img->verifyMethod != NULL) {
         result->verifyMethodResult = img->verifyMethod(
-            context, img, keyBuf, keySz, sigPtr, actualSigSize);
+            context, img, keyPtr, keySz, sigPtr, actualSigSize);
     }
     else {
         result->verifyMethodResult = WH_ERROR_NOHANDLER;
     }
+    /* The key snapshot may hold a symmetric key (AES-CMAC verify) */
+    wh_Utils_ForceZero(keyBuf, sizeof(keyBuf));
 
     /* Invoke verifyAction callback */
     if (img->verifyAction != NULL) {

--- a/test/wh_test_cert.c
+++ b/test/wh_test_cert.c
@@ -28,6 +28,8 @@
 #if defined(WOLFHSM_CFG_CERTIFICATE_MANAGER) && !defined(WOLFHSM_CFG_NO_CRYPTO)
 
 #include "wolfhsm/wh_error.h"
+#include "wolfhsm/wh_message.h"
+#include "wolfhsm/wh_message_cert.h"
 
 #ifdef WOLFHSM_CFG_ENABLE_SERVER
 #include "wolfhsm/wh_server.h"
@@ -1845,6 +1847,32 @@ int whTest_CertClientAcertDma_ClientServerTestInternal(whClientContext* client)
     WH_TEST_RETURN_ON_FAIL(wh_Client_CertVerifyAcertDma(
         client, attrCert_der, attrCert_der_len, rootCertB_id, &out_rc));
     WH_TEST_ASSERT_RETURN(out_rc == WH_ERROR_CERT_VERIFY);
+
+    /* Regression test for finding 4235. A malformed (undersized) ACERT_DMA
+     * request must report an error on the wire, not a false success. Send a
+     * raw 1 byte request with the low level API and confirm resp.rc is not OK.
+     */
+    WH_TEST_PRINT("Sending malformed ACERT_DMA request...\n");
+    {
+        uint8_t                      badReq = 0;
+        uint16_t                     rgroup, raction, rsize;
+        whMessageCert_SimpleResponse badResp = {0};
+
+        do {
+            rc = wh_Client_SendRequest(
+                client, WH_MESSAGE_GROUP_CERT,
+                WH_MESSAGE_CERT_ACTION_VERIFY_ACERT_DMA, sizeof(badReq),
+                &badReq);
+        } while (rc == WH_ERROR_NOTREADY);
+        WH_TEST_ASSERT_RETURN(rc == WH_ERROR_OK);
+
+        do {
+            rc = wh_Client_RecvResponse(client, &rgroup, &raction, &rsize,
+                                        sizeof(badResp), &badResp);
+        } while (rc == WH_ERROR_NOTREADY);
+        WH_TEST_ASSERT_RETURN(rc == WH_ERROR_OK);
+        WH_TEST_ASSERT_RETURN(badResp.rc != WH_ERROR_OK);
+    }
 
     /* Clean up - delete the trusted certificates */
     WH_TEST_PRINT("Deleting trusted certificates...\n");

--- a/test/wh_test_clientserver.c
+++ b/test/wh_test_clientserver.c
@@ -689,6 +689,25 @@ static int _testClientCounter(whClientContext* client)
             wh_Client_CounterRead(client, (whNvmId)i, &counter));
     }
 
+    /* Invalid counter action: the default case reports a zero length
+     * response, not the stale request sized buffer. */
+    {
+        uint8_t  reqbuf[8]   = {0};
+        uint8_t  respbuf[64] = {0};
+        uint16_t respGroup   = 0;
+        uint16_t respAction  = 0;
+        uint16_t respSz      = 0xFFFF;
+
+        WH_TEST_RETURN_ON_FAIL(wh_Client_SendRequest(
+            client, WH_MESSAGE_GROUP_COUNTER, 0x7F, sizeof(reqbuf), reqbuf));
+        do {
+            rc = wh_Client_RecvResponse(client, &respGroup, &respAction,
+                                        &respSz, sizeof(respbuf), respbuf);
+        } while (rc == WH_ERROR_NOTREADY);
+        WH_TEST_ASSERT_RETURN(rc == WH_ERROR_OK);
+        WH_TEST_ASSERT_RETURN(respSz == 0);
+    }
+
     /* Ensure NVM is back to the pre-test baseline */
     WH_TEST_RETURN_ON_FAIL(rc = wh_Client_NvmGetAvailable(
                                client, &server_rc, &avail_size, &avail_objects,

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -17218,6 +17218,73 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
 #endif /* HAVE_ECC_DHE */
 #endif /* HAVE_ECC */
 
+#ifdef HAVE_CURVE25519
+    /* X25519 (Curve25519) shared secret without DERIVE flag */
+    WH_TEST_PRINT("  Testing X25519 shared secret without DERIVE flag...\n");
+    {
+        curve25519_key privKey[1];
+        curve25519_key pubKey[1];
+        uint8_t        x25519Secret[CURVE25519_KEYSIZE] = {0};
+        word32         x25519SecretLen                  = sizeof(x25519Secret);
+        whKeyId        privId                           = WH_KEYID_ERASED;
+        whKeyId        pubId                            = WH_KEYID_ERASED;
+
+        /* Generate a private key on the server WITHOUT the derive flag */
+        ret = wh_Client_Curve25519MakeCacheKey(
+            client, CURVE25519_KEYSIZE, &privId, WH_NVM_FLAGS_USAGE_SIGN,
+            (uint8_t*)"x25519-no-derive", strlen("x25519-no-derive"));
+        if (ret == 0) {
+            /* Valid peer public key (DERIVE allowed) */
+            ret = wh_Client_Curve25519MakeCacheKey(
+                client, CURVE25519_KEYSIZE, &pubId, WH_NVM_FLAGS_USAGE_DERIVE,
+                (uint8_t*)"x25519-peer", strlen("x25519-peer"));
+        }
+        if (ret == 0) {
+            ret = wc_curve25519_init_ex(privKey, NULL, WH_CLIENT_DEVID(client));
+            if (ret == 0) {
+                ret = wc_curve25519_init_ex(pubKey, NULL,
+                                            WH_CLIENT_DEVID(client));
+                if (ret == 0) {
+                    /* Associate the cached keyIds with the local key objects */
+                    ret = wh_Client_Curve25519SetKeyId(privKey, privId);
+                    if (ret == 0) {
+                        ret = wh_Client_Curve25519SetKeyId(pubKey, pubId);
+                    }
+
+                    /* Must fail: private key lacks DERIVE */
+                    if (ret == 0) {
+                        ret = wc_curve25519_shared_secret(
+                            privKey, pubKey, x25519Secret, &x25519SecretLen);
+                        if (ret == WH_ERROR_USAGE) {
+                            WH_TEST_PRINT(
+                                "    PASS: Correctly denied key derivation\n");
+                            ret = 0; /* Test passed */
+                        }
+                        else {
+                            WH_ERROR_PRINT(
+                                "    FAIL: Expected WH_ERROR_USAGE, got %d\n",
+                                ret);
+                            ret = WH_ERROR_ABORTED;
+                        }
+                    }
+                    wc_curve25519_free(pubKey);
+                }
+                wc_curve25519_free(privKey);
+            }
+        }
+        /* Clean up cached keys */
+        if (!WH_KEYID_ISERASED(privId)) {
+            wh_Client_KeyEvict(client, privId);
+        }
+        if (!WH_KEYID_ISERASED(pubId)) {
+            wh_Client_KeyEvict(client, pubId);
+        }
+    }
+    if (ret != 0) {
+        return ret;
+    }
+#endif /* HAVE_CURVE25519 */
+
 #ifdef HAVE_HKDF
     /* HKDF without DERIVE flag */
     WH_TEST_PRINT("  Testing HKDF without DERIVE flag...\n");

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -17285,6 +17285,156 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
     }
 #endif /* HAVE_CURVE25519 */
 
+#ifndef NO_RSA
+    /* RSA usage policy plus the sign/verify fallback (PUBLIC_DECRYPT falls back
+     * to VERIFY, PRIVATE_ENCRYPT to SIGN). */
+    WH_TEST_PRINT("  Testing RSA usage policy and sign/verify fallback...\n");
+    {
+        RsaKey  rsaKey[1];
+        whKeyId rsaId = WH_KEYID_ERASED;
+        byte    rsaIn[32];
+        byte    rsaSig[RSA_KEY_BYTES];
+        byte    rsaRec[RSA_KEY_BYTES];
+        int     opRc;
+        int     sigLen;
+
+        memset(rsaIn, 0xA5, sizeof(rsaIn));
+
+        /* SIGN only key: PublicEncrypt needs ENCRYPT, so deny. */
+        ret =
+            wh_Client_RsaMakeCacheKey(client, RSA_KEY_BITS, RSA_EXPONENT,
+                                      &rsaId, WH_NVM_FLAGS_USAGE_SIGN, 0, NULL);
+        if (ret == 0) {
+            ret = wc_InitRsaKey_ex(rsaKey, NULL, WH_CLIENT_DEVID(client));
+            if (ret == 0) {
+                ret = wh_Client_RsaSetKeyId(rsaKey, rsaId);
+                if (ret == 0) {
+                    opRc = wc_RsaPublicEncrypt(rsaIn, sizeof(rsaIn), rsaSig,
+                                               sizeof(rsaSig), rsaKey, rng);
+                    if (opRc == WH_ERROR_USAGE) {
+                        WH_TEST_PRINT("    PASS: encrypt denied without "
+                                      "ENCRYPT\n");
+                    }
+                    else {
+                        WH_ERROR_PRINT(
+                            "    FAIL: expected WH_ERROR_USAGE, got %d\n",
+                            opRc);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_FreeRsaKey(rsaKey);
+            }
+            wh_Client_KeyEvict(client, rsaId);
+        }
+        if (ret != 0) {
+            return ret;
+        }
+
+        /* ENCRYPT only key: Verify needs DECRYPT or VERIFY, so deny. */
+        rsaId = WH_KEYID_ERASED;
+        ret   = wh_Client_RsaMakeCacheKey(client, RSA_KEY_BITS, RSA_EXPONENT,
+                                          &rsaId, WH_NVM_FLAGS_USAGE_ENCRYPT, 0,
+                                          NULL);
+        if (ret == 0) {
+            ret = wc_InitRsaKey_ex(rsaKey, NULL, WH_CLIENT_DEVID(client));
+            if (ret == 0) {
+                ret = wh_Client_RsaSetKeyId(rsaKey, rsaId);
+                if (ret == 0) {
+                    memset(rsaSig, 0, sizeof(rsaSig));
+                    opRc = wc_RsaSSL_Verify(rsaSig, sizeof(rsaSig), rsaRec,
+                                            sizeof(rsaRec), rsaKey);
+                    if (opRc == WH_ERROR_USAGE) {
+                        WH_TEST_PRINT("    PASS: verify denied without "
+                                      "VERIFY\n");
+                    }
+                    else {
+                        WH_ERROR_PRINT(
+                            "    FAIL: expected WH_ERROR_USAGE, got %d\n",
+                            opRc);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_FreeRsaKey(rsaKey);
+            }
+            wh_Client_KeyEvict(client, rsaId);
+        }
+        if (ret != 0) {
+            return ret;
+        }
+
+        /* VERIFY only key: Sign needs ENCRYPT or SIGN, so deny. */
+        rsaId = WH_KEYID_ERASED;
+        ret   = wh_Client_RsaMakeCacheKey(client, RSA_KEY_BITS, RSA_EXPONENT,
+                                          &rsaId, WH_NVM_FLAGS_USAGE_VERIFY, 0,
+                                          NULL);
+        if (ret == 0) {
+            ret = wc_InitRsaKey_ex(rsaKey, NULL, WH_CLIENT_DEVID(client));
+            if (ret == 0) {
+                ret = wh_Client_RsaSetKeyId(rsaKey, rsaId);
+                if (ret == 0) {
+                    opRc = wc_RsaSSL_Sign(rsaIn, sizeof(rsaIn), rsaSig,
+                                          sizeof(rsaSig), rsaKey, rng);
+                    if (opRc == WH_ERROR_USAGE) {
+                        WH_TEST_PRINT("    PASS: sign denied without SIGN\n");
+                    }
+                    else {
+                        WH_ERROR_PRINT(
+                            "    FAIL: expected WH_ERROR_USAGE, got %d\n",
+                            opRc);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                wc_FreeRsaKey(rsaKey);
+            }
+            wh_Client_KeyEvict(client, rsaId);
+        }
+        if (ret != 0) {
+            return ret;
+        }
+
+        /* 4) SIGN|VERIFY key: sign then verify must succeed via the fallback
+         *    paths, proving the fallback is live rather than dead code. */
+        rsaId = WH_KEYID_ERASED;
+        ret   = wh_Client_RsaMakeCacheKey(
+            client, RSA_KEY_BITS, RSA_EXPONENT, &rsaId,
+            WH_NVM_FLAGS_USAGE_SIGN | WH_NVM_FLAGS_USAGE_VERIFY, 0, NULL);
+        if (ret == 0) {
+            ret = wc_InitRsaKey_ex(rsaKey, NULL, WH_CLIENT_DEVID(client));
+            if (ret == 0) {
+                ret = wh_Client_RsaSetKeyId(rsaKey, rsaId);
+                if (ret == 0) {
+                    sigLen = wc_RsaSSL_Sign(rsaIn, sizeof(rsaIn), rsaSig,
+                                            sizeof(rsaSig), rsaKey, rng);
+                    if (sigLen < 0) {
+                        WH_ERROR_PRINT("    FAIL: sign via fallback %d\n",
+                                       sigLen);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                }
+                if (ret == 0) {
+                    opRc = wc_RsaSSL_Verify(rsaSig, sigLen, rsaRec,
+                                            sizeof(rsaRec), rsaKey);
+                    if (opRc != (int)sizeof(rsaIn) ||
+                        memcmp(rsaRec, rsaIn, sizeof(rsaIn)) != 0) {
+                        WH_ERROR_PRINT("    FAIL: verify via fallback %d\n",
+                                       opRc);
+                        ret = WH_ERROR_ABORTED;
+                    }
+                    else {
+                        WH_TEST_PRINT(
+                            "    PASS: sign/verify fallback round trip\n");
+                    }
+                }
+                wc_FreeRsaKey(rsaKey);
+            }
+            wh_Client_KeyEvict(client, rsaId);
+        }
+        if (ret != 0) {
+            return ret;
+        }
+    }
+#endif /* NO_RSA */
+
 #ifdef HAVE_HKDF
     /* HKDF without DERIVE flag */
     WH_TEST_PRINT("  Testing HKDF without DERIVE flag...\n");

--- a/test/wh_test_crypto.c
+++ b/test/wh_test_crypto.c
@@ -17145,6 +17145,60 @@ int whTest_CryptoKeyUsagePolicies(whClientContext* client, WC_RNG* rng)
     }
 #endif /* HAVE_ECC_SIGN */
 
+#ifdef HAVE_ECC_VERIFY
+    /* ECDSA verify without VERIFY flag */
+    WH_TEST_PRINT("  Testing ECDSA verify without VERIFY flag...\n");
+    {
+        ecc_key eccKey[1];
+        uint8_t sig[ECC_MAX_SIG_SIZE]       = {0};
+        word32  sigLen                      = sizeof(sig);
+        uint8_t hash[WC_SHA256_DIGEST_SIZE] = {0};
+        int     verifyResult                = 0;
+
+        /* Cache a SIGN only key so verification is denied by usage policy
+         * before the signature is checked. */
+        keyId = WH_KEYID_ERASED;
+        ret   = wh_Client_EccMakeCacheKey(
+              client, 32, ECC_SECP256R1, &keyId, WH_NVM_FLAGS_USAGE_SIGN,
+              strlen("ecc-no-verify"), (uint8_t*)"ecc-no-verify");
+        if (ret == 0) {
+            ret = wc_ecc_init_ex(eccKey, NULL, WH_CLIENT_DEVID(client));
+            if (ret == 0) {
+                ret = wc_ecc_set_curve(eccKey, 32, ECC_SECP256R1);
+                if (ret == 0) {
+                    ret = wh_Client_EccSetKeyId(eccKey, keyId);
+                    if (ret == 0) {
+                        ret = wc_RNG_GenerateBlock(rng, hash, sizeof(hash));
+                        if (ret == 0) {
+                            /* Usage enforcement runs before verify, so a
+                             * dummy signature is enough to kill the check. */
+                            ret = wc_ecc_verify_hash(sig, sigLen, hash,
+                                                     sizeof(hash),
+                                                     &verifyResult, eccKey);
+                            if (ret == WH_ERROR_USAGE) {
+                                WH_TEST_PRINT(
+                                    "    PASS: Correctly denied verification\n");
+                                ret = 0; /* Test passed */
+                            }
+                            else {
+                                WH_ERROR_PRINT("    FAIL: Expected "
+                                               "WH_ERROR_USAGE, got %d\n",
+                                               ret);
+                                ret = WH_ERROR_ABORTED;
+                            }
+                        }
+                    }
+                }
+                wc_ecc_free(eccKey);
+            }
+            wh_Client_KeyEvict(client, keyId);
+        }
+    }
+    if (ret != 0) {
+        return ret;
+    }
+#endif /* HAVE_ECC_VERIFY */
+
 #ifdef HAVE_ECC_DHE
     /* ECDH without DERIVE flag */
     WH_TEST_PRINT("  Testing ECDH without DERIVE flag...\n");

--- a/test/wh_test_server_img_mgr.c
+++ b/test/wh_test_server_img_mgr.c
@@ -1577,6 +1577,155 @@ whTest_ServerImgMgrServerCfgWolfBootCertChainRsa4096(whServerConfig* serverCfg)
 #endif /* WOLFHSM_CFG_CERTIFICATE_MANAGER */
 #endif /* !NO_RSA */
 
+/* Key used to prove the verify callback gets a private copy */
+static const uint8_t testSnapshotKey[16] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55,
+                                            0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB,
+                                            0xCC, 0xDD, 0xEE, 0xFF};
+
+/* Verify method that evicts and re-caches the same keyId the way a concurrent
+ * request would. The key passed in must be a private snapshot, so it stays
+ * intact for the rest of the callback. */
+static int _ImgMgrSnapshotVerifyMethod(whServerImgMgrContext*   context,
+                                       const whServerImgMgrImg* img,
+                                       const uint8_t* key, size_t keySz,
+                                       const uint8_t* sig, size_t sigSz)
+{
+    int           ret;
+    whNvmMetadata meta = {0};
+    uint8_t       attackerKey[sizeof(testSnapshotKey)];
+
+    (void)sig;
+    (void)sigSz;
+
+    if (context == NULL || context->server == NULL || img == NULL ||
+        key == NULL || keySz != sizeof(testSnapshotKey)) {
+        return WH_ERROR_BADARGS;
+    }
+
+    memset(attackerKey, 0xAA, sizeof(attackerKey));
+
+    ret = wh_Server_KeystoreEvictKey(context->server, img->keyId);
+    if (ret != WH_ERROR_OK) {
+        WH_ERROR_PRINT("Failed to evict key during verify: %d\n", ret);
+        return ret;
+    }
+
+    meta.id     = img->keyId;
+    meta.access = WH_NVM_ACCESS_ANY;
+    meta.flags  = WH_NVM_FLAGS_NONE;
+    meta.len    = sizeof(attackerKey);
+    ret = wh_Server_KeystoreCacheKey(context->server, &meta, attackerKey);
+    if (ret != WH_ERROR_OK) {
+        WH_ERROR_PRINT("Failed to cache substitute key during verify: %d\n",
+                       ret);
+        return ret;
+    }
+
+    if (memcmp(key, testSnapshotKey, keySz) != 0) {
+        WH_ERROR_PRINT("Verify key was substituted mid verification\n");
+        return WH_ERROR_ABORTED;
+    }
+
+    return WH_ERROR_OK;
+}
+
+static int whTest_ServerImgMgrKeySnapshot(whServerConfig* serverCfg)
+{
+    int                        ret          = 0;
+    whServerContext            server[1]    = {0};
+    whServerImgMgrConfig       imgMgrConfig = {0};
+    whServerImgMgrContext      imgMgr       = {0};
+    whServerImgMgrImg          testImage    = {0};
+    whServerImgMgrVerifyResult result       = {0};
+    whNvmMetadata              keyMeta      = {0};
+    whNvmMetadata              sigMeta      = {0};
+    const whNvmId              testKeyId    = 1;
+    const whNvmId              testSigNvmId = 2;
+    const uint8_t              dummySig[4]  = {0};
+
+    /* The callback ignores the signature, but the RAW path requires one */
+    sigMeta.id     = testSigNvmId;
+    sigMeta.access = WH_NVM_ACCESS_ANY;
+    sigMeta.flags  = WH_NVM_FLAGS_NONE;
+    sigMeta.len    = sizeof(dummySig);
+    snprintf((char*)sigMeta.label, WH_NVM_LABEL_LEN, "TestSnapshotSig");
+
+    ret =
+        wh_Nvm_AddObject(serverCfg->nvm, &sigMeta, sizeof(dummySig), dummySig);
+    if (ret != WH_ERROR_OK) {
+        WH_ERROR_PRINT("Failed to add snapshot signature to NVM: %d\n", ret);
+        return ret;
+    }
+
+    testImage.imgType      = WH_IMG_MGR_IMG_TYPE_RAW;
+    testImage.addr         = (uintptr_t)testData;
+    testImage.size         = sizeof(testData);
+    testImage.keyId        = testKeyId;
+    testImage.sigNvmId     = testSigNvmId;
+    testImage.verifyMethod = _ImgMgrSnapshotVerifyMethod;
+    testImage.verifyAction = wh_Server_ImgMgrVerifyActionDefault;
+
+    imgMgrConfig.images     = &testImage;
+    imgMgrConfig.imageCount = 1;
+    imgMgrConfig.server     = server;
+
+    ret = wh_Server_Init(server, serverCfg);
+    if (ret != WH_ERROR_OK) {
+        WH_ERROR_PRINT("Failed to initialize server: %d\n", ret);
+        return ret;
+    }
+
+    ret = wh_Server_ImgMgrInit(&imgMgr, &imgMgrConfig);
+    if (ret != WH_ERROR_OK) {
+        WH_ERROR_PRINT("Failed to initialize image manager: %d\n", ret);
+        wh_Server_Cleanup(server);
+        return ret;
+    }
+
+    keyMeta.id     = testKeyId;
+    keyMeta.access = WH_NVM_ACCESS_ANY;
+    keyMeta.flags  = WH_NVM_FLAGS_NONE;
+    keyMeta.len    = sizeof(testSnapshotKey);
+    snprintf((char*)keyMeta.label, WH_NVM_LABEL_LEN, "TestSnapshotKey");
+
+    ret =
+        wh_Server_KeystoreCacheKey(server, &keyMeta, (uint8_t*)testSnapshotKey);
+    if (ret != WH_ERROR_OK) {
+        WH_ERROR_PRINT("Failed to cache snapshot key: %d\n", ret);
+        wh_Server_Cleanup(server);
+        return ret;
+    }
+
+    ret = wh_Server_ImgMgrVerifyImg(&imgMgr, &testImage, &result);
+    if (ret != WH_ERROR_OK) {
+        WH_ERROR_PRINT("Snapshot image verification failed: %d\n", ret);
+        wh_Server_Cleanup(server);
+        return ret;
+    }
+
+    if (result.verifyMethodResult != WH_ERROR_OK) {
+        WH_ERROR_PRINT("Snapshot verify method failed: %d\n",
+                       result.verifyMethodResult);
+        wh_Server_Cleanup(server);
+        return result.verifyMethodResult;
+    }
+
+    /* Drop the substitute key the callback left behind */
+    (void)wh_Server_KeystoreEvictKey(server, testKeyId);
+
+    ret = wh_Nvm_DestroyObjects(serverCfg->nvm, 1, &sigMeta.id);
+    if (ret != WH_ERROR_OK) {
+        WH_ERROR_PRINT("Failed to delete snapshot signature object: %d\n", ret);
+        wh_Server_Cleanup(server);
+        return ret;
+    }
+
+    wh_Server_Cleanup(server);
+
+    WH_TEST_PRINT("IMG_MGR key snapshot Test completed successfully!\n");
+    return 0;
+}
+
 int whTest_ServerImgMgr(whTestNvmBackendType nvmType)
 {
     int            rc          = 0;
@@ -1640,6 +1789,14 @@ int whTest_ServerImgMgr(whTestNvmBackendType nvmType)
     rc = whTest_ServerImgMgrServerCfgReturnSemantics(s_conf);
     if (rc != 0) {
         WH_ERROR_PRINT("Image manager return semantics tests failed: %d\n", rc);
+        wh_Nvm_Cleanup(nvm);
+        return rc;
+    }
+
+    /* Verify key material is snapshotted before the verify callback runs */
+    rc = whTest_ServerImgMgrKeySnapshot(s_conf);
+    if (rc != 0) {
+        WH_ERROR_PRINT("Image manager key snapshot test failed: %d\n", rc);
         wh_Nvm_Cleanup(nvm);
         return rc;
     }

--- a/test/wh_test_she.c
+++ b/test/wh_test_she.c
@@ -656,6 +656,44 @@ int whTest_SheClientConfig(whClientConfig* config)
         WH_TEST_PRINT("SHE LOAD KEY authorization matrix SUCCESS\n");
     }
 
+    /* Corrupted M3 with valid M1/M2 must be rejected; reloading with the
+     * restored M3 at the same counter then succeeds. Counter 3 follows the
+     * authorization matrix test, which left the slot at counter 2. */
+    {
+        uint8_t savedM3;
+
+        if ((ret = wh_She_GenerateLoadableKey(
+                 SHE_TEST_VECTOR_KEY_ID, WH_SHE_MASTER_ECU_KEY_ID, 3, 0, sheUid,
+                 vectorRawKey, vectorMasterEcuKey, messageOne, messageTwo,
+                 messageThree, messageFour, messageFive)) != 0) {
+            WH_ERROR_PRINT("Failed to generate M3-test M1/M2/M3 %d\n", ret);
+            goto exit;
+        }
+
+        savedM3 = messageThree[0];
+        messageThree[0] ^= 0xFF;
+        ret = wh_Client_SheLoadKey(client, messageOne, messageTwo, messageThree,
+                                   outMessageFour, outMessageFive);
+        if (ret != WH_SHE_ERC_KEY_UPDATE_ERROR) {
+            WH_ERROR_PRINT("SHE LOAD KEY corrupt M3: expected "
+                           "KEY_UPDATE_ERROR, got %d\n",
+                           ret);
+            ret = WH_ERROR_ABORTED;
+            goto exit;
+        }
+
+        messageThree[0] = savedM3;
+        if ((ret = wh_Client_SheLoadKey(client, messageOne, messageTwo,
+                                        messageThree, outMessageFour,
+                                        outMessageFive)) != 0) {
+            WH_ERROR_PRINT("SHE LOAD KEY restored M3: expected success, "
+                           "got %d\n",
+                           ret);
+            goto exit;
+        }
+        WH_TEST_PRINT("SHE LOAD KEY M3 CMAC auth SUCCESS\n");
+    }
+
     if ((ret = wh_Client_SheInitRnd(client)) != 0) {
         WH_ERROR_PRINT("Failed to wh_Client_SheInitRnd %d\n", ret);
         goto exit;

--- a/wolfhsm/wh_settings.h
+++ b/wolfhsm/wh_settings.h
@@ -131,6 +131,9 @@
  *  WOLFHSM_CFG_SERVER_IMG_MGR_MAX_SIG_SIZE - Maximum signature size for image
  * verification Default: 512 bytes (RSA4096)
  *
+ *  WOLFHSM_CFG_SERVER_IMG_MGR_MAX_KEY_SIZE - Maximum verification key size for
+ * image verification Default: 1200 bytes (ASN.1 RSA4096 public key)
+ *
  *  WOLFHSM_CFG_DMA_CUSTOM_CLIENT_COPY - if defined, allows to setup a custom
  * callback to handle client to server and/or server to client memory copy
  * operation in DMA requests.
@@ -353,6 +356,12 @@
 /* Image manager maximum signature size (RSA4096 = 512 bytes) */
 #ifndef WOLFHSM_CFG_SERVER_IMG_MGR_MAX_SIG_SIZE
 #define WOLFHSM_CFG_SERVER_IMG_MGR_MAX_SIG_SIZE 512
+#endif
+
+/* Image manager maximum verification key size. Sized to hold an ASN.1 RSA4096
+ * public key. Raise it for larger keys such as ML-DSA. */
+#ifndef WOLFHSM_CFG_SERVER_IMG_MGR_MAX_KEY_SIZE
+#define WOLFHSM_CFG_SERVER_IMG_MGR_MAX_KEY_SIZE 1200
 #endif
 
 /*  WOLFHSM_CFG_CUSTOMCB_LEN - Maximum size of a customcb message.


### PR DESCRIPTION
This pull request introduces several important security and robustness improvements to the image manager, cryptography, and transport layers, as well as updates to documentation and regression tests. The changes focus on better key material handling, explicit memory zeroization, and improved error handling in edge cases.

**Security and Key Handling Improvements:**

* The image manager now copies verification keys from the keystore into a private buffer before verification, ensuring that verification operates on a stable snapshot and not a live cache slot. The buffer size is bounded by the new `WOLFHSM_CFG_SERVER_IMG_MGR_MAX_KEY_SIZE` configuration, and the buffer is explicitly zeroed after use to prevent key leakage. (`src/wh_server_img_mgr.c` [[1]](diffhunk://#diff-6797d685bcc5bc5491cffa8f150316913be270d29ea605df312684378b181409R99-R129) [[2]](diffhunk://#diff-6797d685bcc5bc5491cffa8f150316913be270d29ea605df312684378b181409L130-R159) [[3]](diffhunk://#diff-6797d685bcc5bc5491cffa8f150316913be270d29ea605df312684378b181409L145-R170) [[4]](diffhunk://#diff-6797d685bcc5bc5491cffa8f150316913be270d29ea605df312684378b181409R188-R195) [[5]](diffhunk://#diff-6797d685bcc5bc5491cffa8f150316913be270d29ea605df312684378b181409L180-R211); `docs/src/5-Features.md` [[6]](diffhunk://#diff-6b629408db8afec40161b5abbc8b9d186b89d9bc46cfb4efae5ca999b9ba7a1cL875-R875); `docs/src/9-Configuration.md` [[7]](diffhunk://#diff-410d28f8d719a734a85ad48206ac530970cc5573d6a830c5a148e92968e35e8cR120)

* Added explicit zeroization of sensitive key material and cryptographic contexts after use in both CMAC operations and DMA transport callbacks, reducing the risk of sensitive data lingering in memory. (`src/wh_server_crypto.c` [[1]](diffhunk://#diff-446b88572bf243d9336b5ea249b53061536fe2c9d006f36fde4e1b7abdb1c015R4616-R4619) [[2]](diffhunk://#diff-446b88572bf243d9336b5ea249b53061536fe2c9d006f36fde4e1b7abdb1c015R9133-R9136); `port/posix/posix_transport_shm.c` [[3]](diffhunk://#diff-12eba5ccee4a72b6e4498c8d834660e48963d02d0730cf1a658ff9d91d832de3R664-R666) [[4]](diffhunk://#diff-12eba5ccee4a72b6e4498c8d834660e48963d02d0730cf1a658ff9d91d832de3R675-R677)

**Robustness and Error Handling:**

* Improved error handling in the counter server: invalid counter actions now return a zero-length response, preventing stale or misleading data from being returned to the client. (`src/wh_server_counter.c` [src/wh_server_counter.cR228](diffhunk://#diff-370c49cb051e6d39e898dc2864331ce509b66878968665c9762d393236510025R228))

**Testing and Regression Coverage:**

* Added regression tests to ensure malformed ACERT_DMA requests and invalid counter actions are correctly handled and do not result in false successes or stale data. (`test/wh_test_cert.c` [[1]](diffhunk://#diff-1b00966397081e530e928e2e78745d6617e07aa95fc3ed1083f8a80fc76f2ae6R1851-R1876); `test/wh_test_clientserver.c` [[2]](diffhunk://#diff-48bf822280139ba1c8bdec996baf5a9cd0479b1c2cc200ea42905b38a27d5f81R692-R710)

* Added a test to verify that ECDSA verification is properly denied when the key does not have the VERIFY usage flag, ensuring correct enforcement of key usage policies. (`test/wh_test_crypto.c` [test/wh_test_crypto.cR17148-R17201](diffhunk://#diff-083f295431989edf8ac05c5c0b2025a661438a94a9de153472289cd913bd5b3fR17148-R17201))

**Documentation Updates:**

* Updated documentation to describe the new key buffer handling and configuration option for maximum key size in the image manager. (`docs/src/5-Features.md` [[1]](diffhunk://#diff-6b629408db8afec40161b5abbc8b9d186b89d9bc46cfb4efae5ca999b9ba7a1cL875-R875); `docs/src/9-Configuration.md` [[2]](diffhunk://#diff-410d28f8d719a734a85ad48206ac530970cc5573d6a830c5a148e92968e35e8cR120)

---

**Key Handling and Security:**
- The image manager now copies verification keys from the keystore into a private buffer before verification, bounded by `WOLFHSM_CFG_SERVER_IMG_MGR_MAX_KEY_SIZE`, and zeroes the buffer after use. This prevents race conditions and key leakage. [[1]](diffhunk://#diff-6797d685bcc5bc5491cffa8f150316913be270d29ea605df312684378b181409R99-R129) [[2]](diffhunk://#diff-6797d685bcc5bc5491cffa8f150316913be270d29ea605df312684378b181409L130-R159) [[3]](diffhunk://#diff-6797d685bcc5bc5491cffa8f150316913be270d29ea605df312684378b181409L145-R170) [[4]](diffhunk://#diff-6797d685bcc5bc5491cffa8f150316913be270d29ea605df312684378b181409R188-R195) [[5]](diffhunk://#diff-6797d685bcc5bc5491cffa8f150316913be270d29ea605df312684378b181409L180-R211) [[6]](diffhunk://#diff-6b629408db8afec40161b5abbc8b9d186b89d9bc46cfb4efae5ca999b9ba7a1cL875-R875) [[7]](diffhunk://#diff-410d28f8d719a734a85ad48206ac530970cc5573d6a830c5a148e92968e35e8cR120)
- Explicitly zero sensitive key material and cryptographic contexts after use in CMAC and DMA transport code. [[1]](diffhunk://#diff-446b88572bf243d9336b5ea249b53061536fe2c9d006f36fde4e1b7abdb1c015R4616-R4619) [[2]](diffhunk://#diff-446b88572bf243d9336b5ea249b53061536fe2c9d006f36fde4e1b7abdb1c015R9133-R9136) [[3]](diffhunk://#diff-12eba5ccee4a72b6e4498c8d834660e48963d02d0730cf1a658ff9d91d832de3R664-R666) [[4]](diffhunk://#diff-12eba5ccee4a72b6e4498c8d834660e48963d02d0730cf1a658ff9d91d832de3R675-R677)

**Robustness and Error Handling:**
- The counter server now returns a zero-length response for invalid actions, preventing stale data exposure.

**Testing and Regression:**
- Added regression tests for malformed ACERT_DMA requests and invalid counter actions to ensure correct error reporting and response handling. [[1]](diffhunk://#diff-1b00966397081e530e928e2e78745d6617e07aa95fc3ed1083f8a80fc76f2ae6R1851-R1876) [[2]](diffhunk://#diff-48bf822280139ba1c8bdec996baf5a9cd0479b1c2cc200ea42905b38a27d5f81R692-R710)
- Added a test to verify ECDSA verification is denied when the VERIFY flag is missing from the key, enforcing key usage policies.

**Documentation:**
- Updated documentation to describe new key buffer handling and configuration options. [[1]](diffhunk://#diff-6b629408db8afec40161b5abbc8b9d186b89d9bc46cfb4efae5ca999b9ba7a1cL875-R875) [[2]](diffhunk://#diff-410d28f8d719a734a85ad48206ac530970cc5573d6a830c5a148e92968e35e8cR120)